### PR TITLE
Fix spelling error(s) and typos.

### DIFF
--- a/docs/client_libraries.md
+++ b/docs/client_libraries.md
@@ -53,7 +53,7 @@ Jaeger tracers use **reporters** to process finished spans. Typically Jaeger lib
 * **NullReporter** does nothing with the span. It can be useful in unit tests.
 * **LoggingReporter** simply logs the fact that a span was finished, usually by printing the trace and span ID and the operation name.
 * **CompositeReporter** takes a list of other reporters and invokes them one by one.
-* **RemoteReporter** (default) buffers a certain number of finished spans in memory and uses a **sender** to submit a batch of spans out of process to Jaeger backend. The sender is responsible for serializing the span to the wire format (e.g. Thrift of JSON) and communicating with the backend components (e.e. over UDP or HTTP).
+* **RemoteReporter** (default) buffers a certain number of finished spans in memory and uses a **sender** to submit a batch of spans out of process to Jaeger backend. The sender is responsible for serializing the span to the wire format (e.g. Thrift or JSON) and communicating with the backend components (e.g. over UDP or HTTP).
 
 #### EMSGSIZE and UDP buffer limits
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -41,7 +41,7 @@ Github.
 
 This is a demo application that consists of several microservices and
 illustrates the use of the [OpenTracing API](http://opentracing.io).
-A tutorial / walkthough is available in the blog post:
+A tutorial / walkthrough is available in the blog post:
 [Take OpenTracing for a HotROD ride][hotrod-tutorial].
 
 It can be run standalone, but requires Jaeger backend to view the
@@ -103,7 +103,7 @@ go run ./cmd/agent/main.go
 
 Collector service exposes Zipkin compatible REST API `/api/v1/spans` and `/api/v2/spans` for both
 JSON and thrift encoding.
-By default it's disabled. It can be enabled with `--collector.zipkin.http-port=9411`. 
+By default it's disabled. It can be enabled with `--collector.zipkin.http-port=9411`.
 
 Zipkin Thrift IDL file can be found in [jaegertracing/jaeger-idl](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/zipkincore.thrift).
 It's compatible with [openzipkin/zipkin-api](https://github.com/openzipkin/zipkin-api/blob/master/thrift/zipkinCore.thrift)


### PR DESCRIPTION
Corrected 'walkthrough' spelling on `getting_started.md` page. 
Fixed typos found in 'client_libraries.md' page.

Signed-off-by: Pooja Gadige <poojagadige@gmail.com>