### PR TITLE
Add tables for supported clients and client features

### DIFF
--- a/content/docs/client-libraries.md
+++ b/content/docs/client-libraries.md
@@ -26,7 +26,7 @@ Libraries in other languages are currently under development, please see [issue 
 
 ## Features
 
-The table below provides a feature matrix for the existing client libraries:
+The table below provides a feature matrix for the existing client libraries. Cells marked with `?` indicate that it's not known if the given client supports the given feature and additional research & documentation update is required.
 
 {{< featuresTable >}}
 

--- a/content/docs/client-libraries.md
+++ b/content/docs/client-libraries.md
@@ -3,12 +3,6 @@ title: Client libraries
 rank: 4
 ---
 
-{{< featuresTable >}}
-
-{{< clientsTable >}}
-
-## Introduction
-
 All Jaeger client libraries support the [OpenTracing standard](http://opentracing.io). The following resources provide more information about instrumenting your application with the OpenTracing APIs:
 
 * [OpenTracing tutorials](https://github.com/yurishkuro/opentracing-tutorial) for Java, Go, Python, and Node.js
@@ -22,15 +16,15 @@ The rest of this page contains information about configuring and instantiating a
 
 We use the term *client library*, *instrumentation library*, and *tracer* interchangeably in this document.
 
+## Client library features
+
+The table below lists possible features supported by client libraries:
+
+{{< featuresTable >}}
+
 ## Official libraries
 
-| Language | Library                                                      |
-| ---------|--------------------------------------------------------------|
-| go       | [jaeger-client-go](https://github.com/uber/jaeger-client-go)        |
-| java     | [jaeger-client-java](https://github.com/uber/jaeger-client-java)    |
-| node     | [jaeger-client-node](https://github.com/uber/jaeger-client-node)    |
-| python   | [jaeger-client-python](https://github.com/uber/jaeger-client-python)|
-| C++      | [cpp-client](https://github.com/jaegertracing/cpp-client)           |
+{{< clientsTable >}}
 
 Libraries in other languages are currently under development, please see [issue #366](https://github.com/jaegertracing/jaeger/issues/366).
 

--- a/content/docs/client-libraries.md
+++ b/content/docs/client-libraries.md
@@ -14,11 +14,11 @@ The rest of this page contains information about configuring and instantiating a
 
 ## Terminology
 
-We use the term *client library*, *instrumentation library*, and *tracer* interchangeably in this document.
+We use the terms *client library*, *instrumentation library*, and *tracer* interchangeably in this document.
 
 ## Client library features
 
-The table below lists possible features supported by client libraries:
+The table below provides a feature matrix for the existing client libraries:
 
 {{< featuresTable >}}
 

--- a/content/docs/client-libraries.md
+++ b/content/docs/client-libraries.md
@@ -3,6 +3,10 @@ title: Client libraries
 rank: 4
 ---
 
+{{< featuresTable >}}
+
+{{< clientsTable >}}
+
 ## Introduction
 
 All Jaeger client libraries support the [OpenTracing standard](http://opentracing.io). The following resources provide more information about instrumenting your application with the OpenTracing APIs:

--- a/content/docs/client-libraries.md
+++ b/content/docs/client-libraries.md
@@ -3,12 +3,12 @@ title: Client libraries
 rank: 4
 ---
 
-All Jaeger client libraries support the [OpenTracing standard](http://opentracing.io). The following resources provide more information about instrumenting your application with the OpenTracing APIs:
+All Jaeger client libraries support the [OpenTracing APIs](http://opentracing.io). The following resources provide more information about instrumenting your application with OpenTracing:
 
 * [OpenTracing tutorials](https://github.com/yurishkuro/opentracing-tutorial) for Java, Go, Python, and Node.js
 * A deep dive blog post [Tracing HTTP request latency in Go][http-latency-medium]
 * The official OpenTracing documentation and other materials at [opentracing.io](http://opentracing.io)
-* The `opentracing-contrib` [org on GitHub](https://github.com/opentracing-contrib) contains many repositories with off-the-shelf instrumentation for many popular frameworks, including JAXRS & Dropwizard (Java), Flask & Django (Python), Go std library, etc.
+* The [`opentracing-contrib` org on GitHub](https://github.com/opentracing-contrib) contains many repositories with off-the-shelf instrumentation for many popular frameworks, including JAXRS & Dropwizard (Java), Flask & Django (Python), Go std library, etc.
 
 The rest of this page contains information about configuring and instantiating a Jaeger tracer in an application that is already instrumented with OpenTracing API.
 
@@ -16,17 +16,19 @@ The rest of this page contains information about configuring and instantiating a
 
 We use the terms *client library*, *instrumentation library*, and *tracer* interchangeably in this document.
 
-## Client library features
+## Supported libraries
 
-The table below provides a feature matrix for the existing client libraries:
-
-{{< featuresTable >}}
-
-## Official libraries
+The following client libraries are officially supported:
 
 {{< clientsTable >}}
 
 Libraries in other languages are currently under development, please see [issue #366](https://github.com/jaegertracing/jaeger/issues/366).
+
+## Features
+
+The table below provides a feature matrix for the existing client libraries:
+
+{{< featuresTable >}}
 
 ## Initializing Jaeger Tracer
 

--- a/data/clients.yaml
+++ b/data/clients.yaml
@@ -11,11 +11,15 @@ featureGroups:
   - description: Inter-process propagation wire format (headers)
     features:
     - name: propagation_uber
-      description: Uber's [original headers](#propagation-format)
+      description: "[Uber's original headers](#propagation-format)"
     - name: propagation_b3
       description: Zipkin's [B3 headers](https://github.com/openzipkin/b3-propagation)
     - name: propagation_w3c
-      description: W3C [Trace Context headers](https://github.com/w3c/distributed-tracing)
+      description: "[W3C Trace Context headers](https://github.com/w3c/distributed-tracing)"
+    - name: jaeger_debug_id
+      description: Support inbound `jaeger-debug-id` header
+    - name: jaeger_baggage
+      description: Accept baggage from `jaeger-baggage` headers
 
   - description: Metrics
     features:
@@ -92,6 +96,8 @@ clients:
       propagation_uber: yes
       propagation_b3: yes
       propagation_w3c: coming
+      jaeger_debug_id: when there is no trace
+      jaeger_baggage: when there is no trace
       standard_tracer_metrics: yes
       standard_rpc_metrics: yes
       prometheus_metrics: yes
@@ -130,6 +136,8 @@ clients:
       propagation_uber: yes
       propagation_b3: yes
       propagation_w3c: coming
+      jaeger_debug_id:
+      jaeger_baggage:
       standard_tracer_metrics: yes
       standard_rpc_metrics: no
       prometheus_metrics: yes
@@ -168,6 +176,8 @@ clients:
       propagation_uber: yes
       propagation_b3: yes
       propagation_w3c: coming
+      jaeger_debug_id:
+      jaeger_baggage:
       standard_tracer_metrics: yes
       standard_rpc_metrics: no
       prometheus_metrics: no
@@ -206,6 +216,8 @@ clients:
       propagation_uber: yes
       propagation_b3: yes
       propagation_w3c: coming
+      jaeger_debug_id:
+      jaeger_baggage:
       standard_tracer_metrics: yes
       standard_rpc_metrics: no
       prometheus_metrics: yes
@@ -244,6 +256,8 @@ clients:
       propagation_uber: yes
       propagation_b3: no
       propagation_w3c: coming
+      jaeger_debug_id:
+      jaeger_baggage:
       standard_tracer_metrics:
       standard_rpc_metrics: no
       prometheus_metrics:
@@ -282,6 +296,8 @@ clients:
       propagation_uber: yes
       propagation_b3: no
       propagation_w3c: coming
+      jaeger_debug_id:
+      jaeger_baggage:
       standard_tracer_metrics:
       standard_rpc_metrics: no
       prometheus_metrics:

--- a/data/clients.yaml
+++ b/data/clients.yaml
@@ -1,17 +1,23 @@
 features:
   - name: udp_jaeger_thrift
-    description: Report spans in `jaeger.thrift` format over UDP
+    description: Report spans in [`jaeger.thrift`](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift) format over UDP
   - name: propagation_b3
-    description: Support Zipkin's B3 headers as wire format for span context
+    description: Support Zipkin's [B3 headers](https://zipkin.io/pages/instrumenting) as the wire format for span context
 
 clients:
   - language: Go
     repo: jaegertracing/jaeger-client-go
     features:
-      udp_jaeger_thrift: true
+      udp_jaeger_thrift: yes
       propagation_b3: partial
   - language: Java
     repo: jaegertracing/jaeger-client-java
     features:
-      udp_jaeger_thrift: true
-      propagation_b3: false
+      udp_jaeger_thrift: yes
+      propagation_b3: no
+  #- language: Node.js
+  #  repo: jaegertracing/jaeger-client-node
+  #- language: Python
+  #  repo: jaegertracing/jaeger-client-python
+  #- language: C++
+  #  repo: jaegertracing/cpp-client

--- a/data/clients.yaml
+++ b/data/clients.yaml
@@ -1,0 +1,17 @@
+features:
+  - name: udp_jaeger_thrift
+    description: Report spans in `jaeger.thrift` format over UDP
+  - name: propagation_b3
+    description: Support Zipkin's B3 headers as wire format for span context
+
+clients:
+  - language: Go
+    repo: jaegertracing/jaeger-client-go
+    features:
+      udp_jaeger_thrift: true
+      propagation_b3: partial
+  - language: Java
+    repo: jaegertracing/jaeger-client-java
+    features:
+      udp_jaeger_thrift: true
+      propagation_b3: false

--- a/data/clients.yaml
+++ b/data/clients.yaml
@@ -1,34 +1,86 @@
-features:
-  - name: report_jaeger_thrift_udp
-    description: Report [`jaeger.thrift`](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift) over UDP
-  - name: report_jaeger_thrift_http
-    description: Report [`jaeger.thrift`](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift) over HTTP
-  - name: report_zipkin_thrift_http
-    description: Report Zipkin Thrift over HTTP
-  - name: propagation_uber
-    description: Span context wire format - [Uber's original headers](#propagation-format)
-  - name: propagation_b3
-    description: Span context wire format -  Zipkin's [B3 headers](https://github.com/openzipkin/b3-propagation)
-  - name: propagation_w3c
-    description: Span context wire format - [W3C Trace Context headers](https://github.com/w3c/distributed-tracing)
-  - name: standard_tracer_metrics
-    description: Support standard tracer metrics
-  - name: standard_rpc_metrics
-    description: Support standard RPC metrics
-  - name: prometheus_metrics
-    description: Metrics in [Prometheus](http://prometheus.io/) format
-  - name: configuration
-    description: Support declarative tracer configuration
-  - name: config_tracer_tags
-    description: Allow configuring tracer tags, aka process tags
-  - name: remote_sampler
-    description: Allow remote configuration of samplers
-  - name: adaptive_sampler
-    description: Remotely configurable [adaptive sampler](../sampling)
-  - name: baggage_restriction
-    description: Remotely configurable baggage restrictions
-  - name: env_tracer_tags
-    description: Env var `JAEGER_TAGS` - tracer/process tags
+featureGroups:
+  - description: Data format and transport for reporting spans to Jaeger backend
+    features:
+    - name: report_jaeger_thrift_udp
+      description: Report [`jaeger.thrift`](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift) over UDP
+    - name: report_jaeger_thrift_http
+      description: Report [`jaeger.thrift`](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift) over HTTP
+    - name: report_zipkin_thrift_http
+      description: Report Zipkin Thrift over HTTP
+
+  - description: Inter-process propagation wire format (headers)
+    features:
+    - name: propagation_uber
+      description: Uber's [original headers](#propagation-format)
+    - name: propagation_b3
+      description: Zipkin's [B3 headers](https://github.com/openzipkin/b3-propagation)
+    - name: propagation_w3c
+      description: W3C [Trace Context headers](https://github.com/w3c/distributed-tracing)
+
+  - description: Metrics
+    features:
+    - name: standard_tracer_metrics
+      description: Support standard tracer metrics (number of spans started, finished, reported, etc.)
+    - name: standard_rpc_metrics
+      description: Support standard RPC metrics
+    - name: prometheus_metrics
+      description: Metrics in [Prometheus](http://prometheus.io/) format
+
+  - description: Tracer configuration
+    features:
+    - name: configuration
+      description: Support declarative tracer configuration
+    - name: config_tracer_tags
+      description: Allow configuring tracer tags, aka process tags
+    - name: remote_sampler
+      description: Allow remote configuration of samplers
+    - name: adaptive_sampler
+      description: Remotely configurable [adaptive sampler](../sampling)
+    - name: baggage_restriction
+      description: Remotely configurable baggage restrictions
+
+  - description: Tracer configurarion via environment variables
+    features:
+    - name: env_JAEGER_SERVICE_NAME
+      description: "`JAEGER_SERVICE_NAME`"
+    - name: env_JAEGER_AGENT_HOST
+      description: "`JAEGER_AGENT_HOST`"
+    - name: env_JAEGER_AGENT_PORT
+      description: "`JAEGER_AGENT_PORT`"
+    - name: env_JAEGER_REPORTER_LOG_SPANS
+      description: "`JAEGER_REPORTER_LOG_SPANS` - log finished span IDs"
+    - name: env_JAEGER_REPORTER_MAX_QUEUE_SIZE
+      description: "`JAEGER_REPORTER_MAX_QUEUE_SIZE`"
+    - name: env_JAEGER_REPORTER_FLUSH_INTERVAL
+      description: "`JAEGER_REPORTER_FLUSH_INTERVAL`"
+    - name: env_JAEGER_SAMPLER_TYPE
+      description: "`JAEGER_SAMPLER_TYPE` - default type of sampler, e.g. `probabilistic`"
+    - name: env_JAEGER_SAMPLER_PARAM
+      description: "`JAEGER_SAMPLER_PARAM` - default sampler config, e.g. probability 0.001"
+    - name: env_JAEGER_SAMPLER_MANAGER_HOST_PORT
+      description: "`JAEGER_SAMPLER_MANAGER_HOST_PORT`"
+    - name: env_TRACER_TAGS
+      description: "`JAEGER_TAGS` - tracer/process tags"
+    - name: env_JAEGER_DISABLED
+      description: "`JAEGER_DISABLED`"
+    - name: env_JAEGER_RPC_METRICS
+      description: "`JAEGER_RPC_METRICS`"
+    - name: env_JAEGER_SAMPLER_MAX_OPERATIONS
+      description: "`JAEGER_SAMPLER_MAX_OPERATIONS`"
+    - name: env_JAEGER_SAMPLER_REFRESH_INTERVAL
+      description: "`JAEGER_SAMPLER_REFRESH_INTERVAL`"
+    - name: env_JAEGER_ENDPOINT
+      description: "`JAEGER_ENDPOINT`"
+    - name: env_JAEGER_AUTH_TOKEN
+      description: "`JAEGER_AUTH_TOKEN`"
+    - name: env_JAEGER_USER
+      description: "`JAEGER_USER`"
+    - name: env_JAEGER_PASSWORD
+      description: "`JAEGER_PASSWORD`"
+    - name: env_JAEGER_PROPAGATION
+      description: "`JAEGER_PROPAGATION`"
+    - name: env_JAEGER_DISABLE_GLOBAL_TRACER
+      description: "`JAEGER_DISABLE_GLOBAL_TRACER`"
 
 clients:
   - language: Go
@@ -48,7 +100,26 @@ clients:
       remote_sampler: yes
       adaptive_sampler: yes
       baggage_restriction: yes
-      env_tracer_tags: yes
+      env_JAEGER_SERVICE_NAME: yes
+      env_JAEGER_AGENT_HOST: yes
+      env_JAEGER_AGENT_PORT: yes
+      env_JAEGER_REPORTER_LOG_SPANS: yes
+      env_JAEGER_REPORTER_MAX_QUEUE_SIZE: yes
+      env_JAEGER_REPORTER_FLUSH_INTERVAL: yes
+      env_JAEGER_SAMPLER_TYPE: yes
+      env_JAEGER_SAMPLER_PARAM: yes
+      env_JAEGER_SAMPLER_MANAGER_HOST_PORT: yes
+      env_TRACER_TAGS: yes
+      env_JAEGER_DISABLED: yes
+      env_JAEGER_RPC_METRICS: yes
+      env_JAEGER_SAMPLER_MAX_OPERATIONS: yes
+      env_JAEGER_SAMPLER_REFRESH_INTERVAL: yes
+      env_JAEGER_ENDPOINT: no
+      env_JAEGER_AUTH_TOKEN: no
+      env_JAEGER_USER: no
+      env_JAEGER_PASSWORD: no
+      env_JAEGER_PROPAGATION: no
+      env_JAEGER_DISABLE_GLOBAL_TRACER: no
 
   - language: Java
     repo: jaegertracing/jaeger-client-java
@@ -67,7 +138,26 @@ clients:
       remote_sampler: yes
       adaptive_sampler: yes
       baggage_restriction: coming
-      env_tracer_tags: yes
+      env_JAEGER_SERVICE_NAME: yes
+      env_JAEGER_AGENT_HOST: yes
+      env_JAEGER_AGENT_PORT: yes
+      env_JAEGER_REPORTER_LOG_SPANS: yes
+      env_JAEGER_REPORTER_MAX_QUEUE_SIZE: yes
+      env_JAEGER_REPORTER_FLUSH_INTERVAL: yes
+      env_JAEGER_SAMPLER_TYPE: yes
+      env_JAEGER_SAMPLER_PARAM: yes
+      env_JAEGER_SAMPLER_MANAGER_HOST_PORT: yes
+      env_TRACER_TAGS: yes
+      env_JAEGER_DISABLED: no
+      env_JAEGER_RPC_METRICS: no
+      env_JAEGER_SAMPLER_MAX_OPERATIONS: no
+      env_JAEGER_SAMPLER_REFRESH_INTERVAL: no
+      env_JAEGER_ENDPOINT: yes
+      env_JAEGER_AUTH_TOKEN: yes
+      env_JAEGER_USER: yes
+      env_JAEGER_PASSWORD: yes
+      env_JAEGER_PROPAGATION: yes
+      env_JAEGER_DISABLE_GLOBAL_TRACER: yes
 
   - language: Node.js
     repo: jaegertracing/jaeger-client-node
@@ -86,7 +176,26 @@ clients:
       remote_sampler: yes
       adaptive_sampler: yes
       baggage_restriction: coming
-      env_tracer_tags: no
+      env_JAEGER_SERVICE_NAME: no
+      env_JAEGER_AGENT_HOST: no
+      env_JAEGER_AGENT_PORT: no
+      env_JAEGER_REPORTER_LOG_SPANS: no
+      env_JAEGER_REPORTER_MAX_QUEUE_SIZE: no
+      env_JAEGER_REPORTER_FLUSH_INTERVAL: no
+      env_JAEGER_SAMPLER_TYPE: no
+      env_JAEGER_SAMPLER_PARAM: no
+      env_JAEGER_SAMPLER_MANAGER_HOST_PORT: no
+      env_TRACER_TAGS: no
+      env_JAEGER_DISABLED: no
+      env_JAEGER_RPC_METRICS: no
+      env_JAEGER_SAMPLER_MAX_OPERATIONS: no
+      env_JAEGER_SAMPLER_REFRESH_INTERVAL: no
+      env_JAEGER_ENDPOINT: no
+      env_JAEGER_AUTH_TOKEN: no
+      env_JAEGER_USER: no
+      env_JAEGER_PASSWORD: no
+      env_JAEGER_PROPAGATION: no
+      env_JAEGER_DISABLE_GLOBAL_TRACER: no
 
   - language: Python
     repo: jaegertracing/jaeger-client-python
@@ -105,42 +214,99 @@ clients:
       remote_sampler: yes
       adaptive_sampler: yes
       baggage_restriction: coming
-      env_tracer_tags: no
+      env_JAEGER_SERVICE_NAME: no
+      env_JAEGER_AGENT_HOST: no
+      env_JAEGER_AGENT_PORT: no
+      env_JAEGER_REPORTER_LOG_SPANS: no
+      env_JAEGER_REPORTER_MAX_QUEUE_SIZE: no
+      env_JAEGER_REPORTER_FLUSH_INTERVAL: no
+      env_JAEGER_SAMPLER_TYPE: no
+      env_JAEGER_SAMPLER_PARAM: no
+      env_JAEGER_SAMPLER_MANAGER_HOST_PORT: no
+      env_TRACER_TAGS: no
+      env_JAEGER_DISABLED: no
+      env_JAEGER_RPC_METRICS: no
+      env_JAEGER_SAMPLER_MAX_OPERATIONS: no
+      env_JAEGER_SAMPLER_REFRESH_INTERVAL: no
+      env_JAEGER_ENDPOINT: no
+      env_JAEGER_AUTH_TOKEN: no
+      env_JAEGER_USER: no
+      env_JAEGER_PASSWORD: no
+      env_JAEGER_PROPAGATION: no
+      env_JAEGER_DISABLE_GLOBAL_TRACER: no
 
   - language: C++
     repo: jaegertracing/cpp-client
     features:
       report_jaeger_thrift_udp: yes
-      report_jaeger_thrift_http: "?"
+      report_jaeger_thrift_http:
       report_zipkin_thrift_http: no
       propagation_uber: yes
       propagation_b3: no
       propagation_w3c: coming
-      standard_tracer_metrics: yes
-      standard_rpc_metrics:
+      standard_tracer_metrics:
+      standard_rpc_metrics: no
       prometheus_metrics:
       configuration:
       config_tracer_tags:
       remote_sampler: yes
       adaptive_sampler: yes
       baggage_restriction: no
-      env_tracer_tags:
+      env_JAEGER_SERVICE_NAME: no
+      env_JAEGER_AGENT_HOST: no
+      env_JAEGER_AGENT_PORT: no
+      env_JAEGER_REPORTER_LOG_SPANS: no
+      env_JAEGER_REPORTER_MAX_QUEUE_SIZE: no
+      env_JAEGER_REPORTER_FLUSH_INTERVAL: no
+      env_JAEGER_SAMPLER_TYPE: no
+      env_JAEGER_SAMPLER_PARAM: no
+      env_JAEGER_SAMPLER_MANAGER_HOST_PORT: no
+      env_TRACER_TAGS: no
+      env_JAEGER_DISABLED: no
+      env_JAEGER_RPC_METRICS: no
+      env_JAEGER_SAMPLER_MAX_OPERATIONS: no
+      env_JAEGER_SAMPLER_REFRESH_INTERVAL: no
+      env_JAEGER_ENDPOINT: no
+      env_JAEGER_AUTH_TOKEN: no
+      env_JAEGER_USER: no
+      env_JAEGER_PASSWORD: no
+      env_JAEGER_PROPAGATION: no
+      env_JAEGER_DISABLE_GLOBAL_TRACER: no
 
   - language: C#
     repo: jaegertracing/jaeger-client-csharp
     features:
       report_jaeger_thrift_udp: yes
-      report_jaeger_thrift_http: "?"
+      report_jaeger_thrift_http:
       report_zipkin_thrift_http: no
       propagation_uber: yes
       propagation_b3: no
       propagation_w3c: coming
-      standard_tracer_metrics: yes
-      standard_rpc_metrics:
+      standard_tracer_metrics:
+      standard_rpc_metrics: no
       prometheus_metrics:
       configuration:
       config_tracer_tags:
       remote_sampler:
       adaptive_sampler:
       baggage_restriction:
-      env_tracer_tags:
+      env_JAEGER_SERVICE_NAME: no
+      env_JAEGER_AGENT_HOST: no
+      env_JAEGER_AGENT_PORT: no
+      env_JAEGER_REPORTER_LOG_SPANS: no
+      env_JAEGER_REPORTER_MAX_QUEUE_SIZE: no
+      env_JAEGER_REPORTER_FLUSH_INTERVAL: no
+      env_JAEGER_SAMPLER_TYPE: no
+      env_JAEGER_SAMPLER_PARAM: no
+      env_JAEGER_SAMPLER_MANAGER_HOST_PORT: no
+      env_TRACER_TAGS: no
+      env_JAEGER_DISABLED: no
+      env_JAEGER_RPC_METRICS: no
+      env_JAEGER_SAMPLER_MAX_OPERATIONS: no
+      env_JAEGER_SAMPLER_REFRESH_INTERVAL: no
+      env_JAEGER_ENDPOINT: no
+      env_JAEGER_AUTH_TOKEN: no
+      env_JAEGER_USER: no
+      env_JAEGER_PASSWORD: no
+      env_JAEGER_PROPAGATION: no
+      env_JAEGER_DISABLE_GLOBAL_TRACER: no

--- a/data/clients.yaml
+++ b/data/clients.yaml
@@ -1,23 +1,146 @@
 features:
-  - name: udp_jaeger_thrift
-    description: Report spans in [`jaeger.thrift`](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift) format over UDP
+  - name: report_jaeger_thrift_udp
+    description: Report [`jaeger.thrift`](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift) over UDP
+  - name: report_jaeger_thrift_http
+    description: Report [`jaeger.thrift`](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift) over HTTP
+  - name: report_zipkin_thrift_http
+    description: Report Zipkin Thrift over HTTP
+  - name: propagation_uber
+    description: Span context wire format - [Uber's original headers](#propagation-format)
   - name: propagation_b3
-    description: Support Zipkin's [B3 headers](https://zipkin.io/pages/instrumenting) as the wire format for span context
+    description: Span context wire format -  Zipkin's [B3 headers](https://github.com/openzipkin/b3-propagation)
+  - name: propagation_w3c
+    description: Span context wire format - [W3C Trace Context headers](https://github.com/w3c/distributed-tracing)
+  - name: standard_tracer_metrics
+    description: Support standard tracer metrics
+  - name: standard_rpc_metrics
+    description: Support standard RPC metrics
+  - name: prometheus_metrics
+    description: Metrics in [Prometheus](http://prometheus.io/) format
+  - name: configuration
+    description: Support declarative tracer configuration
+  - name: config_tracer_tags
+    description: Allow configuring tracer tags, aka process tags
+  - name: remote_sampler
+    description: Allow remote configuration of samplers
+  - name: adaptive_sampler
+    description: Remotely configurable [adaptive sampler](../sampling)
+  - name: baggage_restriction
+    description: Remotely configurable baggage restrictions
+  - name: env_tracer_tags
+    description: Env var `JAEGER_TAGS` - tracer/process tags
 
 clients:
   - language: Go
     repo: jaegertracing/jaeger-client-go
     features:
-      udp_jaeger_thrift: yes
-      propagation_b3: partial
+      report_jaeger_thrift_udp: yes
+      report_jaeger_thrift_http: no
+      report_zipkin_thrift_http: yes
+      propagation_uber: yes
+      propagation_b3: yes
+      propagation_w3c: coming
+      standard_tracer_metrics: yes
+      standard_rpc_metrics: yes
+      prometheus_metrics: yes
+      configuration: yes
+      config_tracer_tags: yes
+      remote_sampler: yes
+      adaptive_sampler: yes
+      baggage_restriction: yes
+      env_tracer_tags: yes
+
   - language: Java
     repo: jaegertracing/jaeger-client-java
     features:
-      udp_jaeger_thrift: yes
+      report_jaeger_thrift_udp: yes
+      report_jaeger_thrift_http: yes
+      report_zipkin_thrift_http: no
+      propagation_uber: yes
+      propagation_b3: yes
+      propagation_w3c: coming
+      standard_tracer_metrics: yes
+      standard_rpc_metrics: no
+      prometheus_metrics: yes
+      configuration: yes
+      config_tracer_tags: yes
+      remote_sampler: yes
+      adaptive_sampler: yes
+      baggage_restriction: coming
+      env_tracer_tags: yes
+
+  - language: Node.js
+    repo: jaegertracing/jaeger-client-node
+    features:
+      report_jaeger_thrift_udp: yes
+      report_jaeger_thrift_http: no
+      report_zipkin_thrift_http: no
+      propagation_uber: yes
+      propagation_b3: yes
+      propagation_w3c: coming
+      standard_tracer_metrics: yes
+      standard_rpc_metrics: no
+      prometheus_metrics: no
+      configuration: yes
+      config_tracer_tags: yes
+      remote_sampler: yes
+      adaptive_sampler: yes
+      baggage_restriction: coming
+      env_tracer_tags: no
+
+  - language: Python
+    repo: jaegertracing/jaeger-client-python
+    features:
+      report_jaeger_thrift_udp: yes
+      report_jaeger_thrift_http: no
+      report_zipkin_thrift_http: no
+      propagation_uber: yes
+      propagation_b3: yes
+      propagation_w3c: coming
+      standard_tracer_metrics: yes
+      standard_rpc_metrics: no
+      prometheus_metrics: yes
+      configuration: yes
+      config_tracer_tags: yes
+      remote_sampler: yes
+      adaptive_sampler: yes
+      baggage_restriction: coming
+      env_tracer_tags: no
+
+  - language: C++
+    repo: jaegertracing/cpp-client
+    features:
+      report_jaeger_thrift_udp: yes
+      report_jaeger_thrift_http: "?"
+      report_zipkin_thrift_http: no
+      propagation_uber: yes
       propagation_b3: no
-  #- language: Node.js
-  #  repo: jaegertracing/jaeger-client-node
-  #- language: Python
-  #  repo: jaegertracing/jaeger-client-python
-  #- language: C++
-  #  repo: jaegertracing/cpp-client
+      propagation_w3c: coming
+      standard_tracer_metrics: yes
+      standard_rpc_metrics:
+      prometheus_metrics:
+      configuration:
+      config_tracer_tags:
+      remote_sampler: yes
+      adaptive_sampler: yes
+      baggage_restriction: no
+      env_tracer_tags:
+
+  - language: C#
+    repo: jaegertracing/jaeger-client-csharp
+    features:
+      report_jaeger_thrift_udp: yes
+      report_jaeger_thrift_http: "?"
+      report_zipkin_thrift_http: no
+      propagation_uber: yes
+      propagation_b3: no
+      propagation_w3c: coming
+      standard_tracer_metrics: yes
+      standard_rpc_metrics:
+      prometheus_metrics:
+      configuration:
+      config_tracer_tags:
+      remote_sampler:
+      adaptive_sampler:
+      baggage_restriction:
+      env_tracer_tags:

--- a/themes/jaeger-docs/layouts/shortcodes/clientsTable.html
+++ b/themes/jaeger-docs/layouts/shortcodes/clientsTable.html
@@ -6,29 +6,16 @@
     <tr>
       <th>Language</th>
       <th>GitHub Repo</th>
-      {{- range $features }}
-      <th><a href="#{{ .name | urlize }}">{{ .name }}</a></th>
-      {{- end }}
+
     </tr>
   </thead>
   <tbody>
     {{- range $clients }}
-    {{- $client := . }}
     <tr>
       <td>{{ .language }}</td>
       <td>
         <a href="https://github.com/{{ .repo }}">{{ .repo }}</a>
       </td>
-      {{- range $features }}
-      {{- $supported := index $client.features .name }}
-      {{- if eq $supported true }}
-      <td>{{ emojify ":white_check_mark:" }}</td>
-      {{- else if eq $supported false }}
-      <td>{{ emojify ":x:" }}</td>
-      {{- else }}
-      <td>{{ $supported }}</td>
-      {{- end }}
-      {{- end }}
     </tr>
     {{- end }}
   </tbody>

--- a/themes/jaeger-docs/layouts/shortcodes/clientsTable.html
+++ b/themes/jaeger-docs/layouts/shortcodes/clientsTable.html
@@ -21,7 +21,13 @@
       </td>
       {{- range $features }}
       {{- $supported := index $client.features .name }}
+      {{- if eq $supported true }}
+      <td>{{ emojify ":white_check_mark:" }}</td>
+      {{- else if eq $supported false }}
+      <td>{{ emojify ":x:" }}</td>
+      {{- else }}
       <td>{{ $supported }}</td>
+      {{- end }}
       {{- end }}
     </tr>
     {{- end }}

--- a/themes/jaeger-docs/layouts/shortcodes/clientsTable.html
+++ b/themes/jaeger-docs/layouts/shortcodes/clientsTable.html
@@ -1,4 +1,3 @@
-
 {{- $clients := .Site.Data.clients.clients }}
 {{- $features := .Site.Data.clients.features }}
 <table>

--- a/themes/jaeger-docs/layouts/shortcodes/clientsTable.html
+++ b/themes/jaeger-docs/layouts/shortcodes/clientsTable.html
@@ -1,0 +1,29 @@
+
+{{- $clients := .Site.Data.clients.clients }}
+{{- $features := .Site.Data.clients.features }}
+<table>
+  <thead>
+    <tr>
+      <th>Language</th>
+      <th>GitHub Repo</th>
+      {{- range $features }}
+      <th><a href="#{{ .name | urlize }}">{{ .name }}</a></th>
+      {{- end }}
+    </tr>
+  </thead>
+  <tbody>
+    {{- range $clients }}
+    {{- $client := . }}
+    <tr>
+      <td>{{ .language }}</td>
+      <td>
+        <a href="https://github.com/{{ .repo }}">{{ .repo }}</a>
+      </td>
+      {{- range $features }}
+      {{- $supported := index $client.features .name }}
+      <td>{{ $supported }}</td>
+      {{- end }}
+    </tr>
+    {{- end }}
+  </tbody>
+</table>

--- a/themes/jaeger-docs/layouts/shortcodes/featuresTable.html
+++ b/themes/jaeger-docs/layouts/shortcodes/featuresTable.html
@@ -1,0 +1,16 @@
+<table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{- range .Site.Data.clients.features }}
+      <tr>
+        <td id="{{ .name | urlize }}">{{ .name }}</td>
+        <td>{{ .description | markdownify }}</td>
+      </tr>
+      {{- end }}
+    </tbody>
+  </table>

--- a/themes/jaeger-docs/layouts/shortcodes/featuresTable.html
+++ b/themes/jaeger-docs/layouts/shortcodes/featuresTable.html
@@ -21,7 +21,8 @@
         {{- else if eq $supported false }}
         <td>{{ emojify ":x:" }}</td>
         {{- else }}
-        <td>{{ default "" $supported }}</td>
+        {{- $supported := default "?" $supported }}
+        <td>{{ $supported | markdownify }}</td>
         {{- end }}
         {{- end }}
       </tr>

--- a/themes/jaeger-docs/layouts/shortcodes/featuresTable.html
+++ b/themes/jaeger-docs/layouts/shortcodes/featuresTable.html
@@ -26,7 +26,7 @@
         {{- else if eq $supported false }}
         <td>{{ emojify ":x:" }}</td>
         {{- else }}
-        {{- $supported := default "?" $supported }}
+        {{- $supported := default "`?`" $supported }}
         <td>{{ $supported | markdownify }}</td>
         {{- end }}
         {{- end }}

--- a/themes/jaeger-docs/layouts/shortcodes/featuresTable.html
+++ b/themes/jaeger-docs/layouts/shortcodes/featuresTable.html
@@ -1,19 +1,24 @@
 {{- $clients := .Site.Data.clients.clients }}
-{{- $features := .Site.Data.clients.features }}
+{{- $featureGroups := .Site.Data.clients.featureGroups }}
 <table>
     <thead>
+    </thead>
+    <tbody>
+      {{- range $featureGroups}}
+      <tr>
+        <th colspan="7">{{ .description | markdownify }}</th>
+      </tr>
       <tr>
         <th>Feature</th>
         {{- range $clients }}
         <th>{{ .language }}</th>
         {{- end }}
       </tr>
-    </thead>
-    <tbody>
-      {{- range $features }}
+      {{- range .features }}
       {{- $featureName := .name }}
       <tr>
-        <td>{{ .description | markdownify }}</td>
+        {{- $description := default .name .description }}
+        <td>{{ $description | markdownify }}</td>
         {{- range $clients }}
         {{- $supported := index .features $featureName }}
         {{- if eq $supported true }}
@@ -26,6 +31,7 @@
         {{- end }}
         {{- end }}
       </tr>
+      {{- end }}
       {{- end }}
     </tbody>
   </table>

--- a/themes/jaeger-docs/layouts/shortcodes/featuresTable.html
+++ b/themes/jaeger-docs/layouts/shortcodes/featuresTable.html
@@ -1,15 +1,29 @@
+{{- $clients := .Site.Data.clients.clients }}
+{{- $features := .Site.Data.clients.features }}
 <table>
     <thead>
       <tr>
-        <th>Name</th>
-        <th>Description</th>
+        <th>Feature</th>
+        {{- range $clients }}
+        <th>{{ .language }}</th>
+        {{- end }}
       </tr>
     </thead>
     <tbody>
-      {{- range .Site.Data.clients.features }}
+      {{- range $features }}
+      {{- $featureName := .name }}
       <tr>
-        <td id="{{ .name | urlize }}">{{ .name }}</td>
         <td>{{ .description | markdownify }}</td>
+        {{- range $clients }}
+        {{- $supported := index .features $featureName }}
+        {{- if eq $supported true }}
+        <td>{{ emojify ":white_check_mark:" }}</td>
+        {{- else if eq $supported false }}
+        <td>{{ emojify ":x:" }}</td>
+        {{- else }}
+        <td>{{ default "" $supported }}</td>
+        {{- end }}
+        {{- end }}
       </tr>
       {{- end }}
     </tbody>


### PR DESCRIPTION
Fixes #38 

@yurishkuro The YAML file defining the clients is currently incomplete but otherwise I think this is more or less what you were asking for.

* [Features table](https://deploy-preview-39--jaegertracing.netlify.com/docs/client-libraries/#client-library-features)
* [Libraries table](https://deploy-preview-39--jaegertracing.netlify.com/docs/client-libraries/#official-libraries)