### PR TITLE
Add version-specific Hugo installation script

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,9 +5,13 @@ charset = utf-8
 max_line_length = 80
 trim_trailing_whitespace = true
 
-[*.{html,js,json,sh,sass,md,mmark,toml,yaml}]
+[*.{html,js,json,sass,md,mmark,toml,yaml}]
 indent_style = space
 indent_size = 2
+
+[*.{sh}]
+indent_style = space
+indent_size = 4
 
 [Makefile]
 indent_style = tab

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CONCURRENTLY := $(NODE_BIN)/concurrently
 WRITE_GOOD   := $(NODE_BIN)/write-good
 
 macos-setup:
-	brew switch hugo $(HUGO_VERSION) && brew link --overwrite hugo
+	scripts/install-hugo.sh $(HUGO_VERSION) macOS
 	npm install
 	(cd $(THEME_DIR) && npm install)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-HUGO_VERSION = 0.37.1
+HUGO_VERSION = 0.38
 HTMLPROOFER  = bundle exec htmlproofer
 NODE_BIN     = node_modules/.bin
 HUGO_THEME   = jaeger-docs

--- a/scripts/install-hugo.sh
+++ b/scripts/install-hugo.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+HUGO_VERSION=$1
+OS=$2
+
+echo "Installing Hugo version ${HUGO_VERSION} for ${OS}"
+
+(
+  cd /usr/local/bin
+  sudo rm -f hugo
+  sudo wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_${OS}-64bit.tar.gz
+  sudo tar -xvzf hugo_${HUGO_VERSION}_${OS}-64bit.tar.gz \
+    --no-same-permissions
+)

--- a/scripts/install-hugo.sh
+++ b/scripts/install-hugo.sh
@@ -3,12 +3,31 @@
 HUGO_VERSION=$1
 OS=$2
 
-echo "Installing Hugo version ${HUGO_VERSION} for ${OS}"
+function install {
+    (
+        cd /usr/local/bin
+        sudo rm -f hugo
+        sudo wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_${OS}-64bit.tar.gz
+        sudo tar -xvzf hugo_${HUGO_VERSION}_${OS}-64bit.tar.gz \
+          --no-same-permissions
+    )
+}
 
-(
-  cd /usr/local/bin
-  sudo rm -f hugo
-  sudo wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_${OS}-64bit.tar.gz
-  sudo tar -xvzf hugo_${HUGO_VERSION}_${OS}-64bit.tar.gz \
-    --no-same-permissions
-)
+if command -v hugo &> /dev/null; then
+    echo "Hugo installed. Checking version..."
+    installed_hugo_version=$(hugo version | awk '{print $5}')
+
+    if [ "${installed_hugo_version}" != "v${HUGO_VERSION}" ]; then
+        echo "Your currently installed version of Hugo (${installed_hugo_version}) doesn't match the required version (${HUGO_VERSION})."
+        echo "To install the most appropriate version, see the instructions here: https://github.com/gohugoio/hugo/releases/tag/v${HUGO_VERSION}"
+        exit 1
+    else
+        echo "You have the appropriate version of Hugo installed (${HUGO_VERSION})"
+        exit 0
+    fi
+else
+    echo "Hugo not installed. Installing version ${HUGO_VERSION}..."
+    install
+fi
+
+exit 0

--- a/scripts/install-hugo.sh
+++ b/scripts/install-hugo.sh
@@ -11,6 +11,7 @@ function install {
         sudo tar -xvzf hugo_${HUGO_VERSION}_${OS}-64bit.tar.gz \
           --no-same-permissions
     )
+    exit 0
 }
 
 if command -v hugo &> /dev/null; then
@@ -29,5 +30,3 @@ else
     echo "Hugo not installed. Installing version ${HUGO_VERSION}..."
     install
 fi
-
-exit 0


### PR DESCRIPTION
Fixes #36 

Currently, the macOS setup involves using Homebrew to install Hugo. The drawback, however, is that you can't install specific versions directly via Homebrew, which leads to a variety of potential issues. This PR adds an installation script for specific versions of Hugo (as well as different platforms...I'll add Linux setup later).