### PR TITLE
Add hoverable tooltips for definitions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 [*]
 end_of_line = lf
-insert_final_newline = true
+insert_final_newline = false
 charset = utf-8
 max_line_length = 80
 trim_trailing_whitespace = true

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ HUGO_VERSION = 0.38
 HTMLPROOFER  = bundle exec htmlproofer
 NODE_BIN     = node_modules/.bin
 HUGO_THEME   = jaeger-docs
-BASE_URL     = https://jaegertracing.netlify.com
+#BASE_URL     = https://jaegertracing.netlify.com
 THEME_DIR    := themes/$(HUGO_THEME)
 GULP         := $(NODE_BIN)/gulp
 CONCURRENTLY := $(NODE_BIN)/concurrently
@@ -27,8 +27,7 @@ clean:
 
 build-content:
 	hugo -v \
-		--theme $(HUGO_THEME) \
-		--baseURL $(BASE_URL)
+		--theme $(HUGO_THEME)
 
 build-assets:
 	(cd $(THEME_DIR) && $(GULP) build)

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -8,6 +8,7 @@ Welcome to Jaeger's documentation portal! Below, you'll find information for beg
 If you can't find what you are looking for, or have an issue not covered here, we'd love to hear from you either on [Github](https://github.com/jaegertracing/jaeger/issues), [Gitter chat](https://gitter.im/jaegertracing/Lobby), or on our [mailing list](https://groups.google.com/forum/#!forum/jaeger-tracing).
 
 ## About
+
 Jaeger, inspired by [Dapper][dapper] and [OpenZipkin](http://zipkin.io),
 is a distributed tracing system released as open source by [Uber Technologies][ubeross].
 It is used for monitoring and troubleshooting microservices-based distributed systems, including:

--- a/content/docs/architecture.md
+++ b/content/docs/architecture.md
@@ -8,38 +8,43 @@ Jaeger's clients adhere to the data model described in the OpenTracing standard.
 ## Terminology
 
 ### Span
-A **span** represents a logical unit of work in the system that has an operation name, the start time of the operation, and the duration. Spans may be nested and ordered to model causal relationships. An RPC call is an example of a span.
+
+{{< definition "span" >}}
 
 ![Traces And Spans](/img/spans-traces.png)
 
 ### Trace
 
-A **trace** is a data/execution path through the system, and can be thought of as a directed acyclic graph of [spans](#span).
+{{< definition "trace" >}}
 
 ## Components
+
 ![Architecture](/img/architecture.png)
 
 This section details the constituents of Jaeger and how they relate to each other. It is arranged by the order in which spans from your application interact with them.
 
 ### Jaeger client libraries
+
 Jaeger clients are language specific implementations of the [OpenTracing API](http://opentracing.io). They can be used to instrument applications for distributed tracing either manually or with a variety of existing open source frameworks, such as Flask, Dropwizard, gRPC, and many more, that are already integrated with OpenTracing.
 
-An instrumented service creates spans when receiving new requests and attaches context information (trace id, span id, and baggage) to outgoing requests. Only ids and baggage are propagated with requests; all other information that compose a span like operation name, logs, etc. is not propagated. Instead sampled spans are transmitted out of process asynchronously, in the background, to Jaeger Agents.
+An instrumented service creates {{< tip "spans" "span" >}} when receiving new requests and attaches context information ({{< tip "trace" >}} id, span id, and baggage) to outgoing requests. Only ids and baggage are propagated with requests; all other information that compose a span like operation name, logs, etc. is not propagated. Instead sampled spans are transmitted out of process asynchronously, in the background, to Jaeger Agents.
 
 The instrumentation has very little overhead, and is designed to be always enabled in production.
 
-Note that while all traces are generated, only few are sampled. Sampling a trace marks the trace for further processing and storage.
+Note that while all {{< tip "traces" "trace" >}} are generated, only a few are sampled. Sampling a trace marks the trace for further processing and storage.
 By default, Jaeger client samples 0.1% of traces (1 in 1000), and has the ability to retrieve sampling strategies from the agent.
 
 ![Context propagation explained](/img/context-prop.png)
 *Illustration of context propagation*
 
 ### Agent
-A network daemon that listens for spans sent over UDP, which it batches and sends to the collector. It is designed to be deployed to all hosts as an infrastructure component.  The agent abstracts the routing and discovery of the collectors away from the client.
+
+{{< definition "agent" >}}
 
 ### Collector
-The collector receives traces from Jaeger agents and runs them through a processing pipeline. Currently our pipeline validates traces, indexes them, performs any transformations, and finally stores them.
-Our storage is a pluggable component which currently supports Cassandra and ElasticSearch.
+
+{{< definition "collector" >}}
 
 ### Query
-Query is a service that retrieves traces from storage and hosts a UI to display them.
+
+{{< definition "query" >}}

--- a/content/docs/client-libraries.md
+++ b/content/docs/client-libraries.md
@@ -42,7 +42,7 @@ See [here](../sampling#client-sampling-configuration).
 
 ### Reporters
 
-Jaeger tracers use **reporters** to process finished spans. Typically Jaeger libraries ship with the following reporters:
+Jaeger tracers use **reporters** to process finished {{< tip "spans" "span" >}}. Typically Jaeger libraries ship with the following reporters:
 
 * **NullReporter** does nothing with the span. It can be useful in unit tests.
 * **LoggingReporter** simply logs the fact that a span was finished, usually by printing the trace and span ID and the operation name.
@@ -51,7 +51,7 @@ Jaeger tracers use **reporters** to process finished spans. Typically Jaeger lib
 
 #### EMSGSIZE and UDP buffer limits
 
-By default Jaeger libraries use a UDP sender to report finished spans to `jaeger-agent` daemon.
+By default Jaeger libraries use a UDP sender to report finished {{< tip "spans" "span" >}} to the `jaeger-agent` daemon.
 The default max packet size is 65,000 bytes, which can be transmitted without segmentation when
 connecting to the agent via loopback interface. However, some OSs (in particular, MacOS), limit
 the max buffer size for UDP packets, as raised in [this GitHub issue](https://github.com/uber/jaeger-client-node/issues/124).

--- a/content/docs/features.md
+++ b/content/docs/features.md
@@ -14,13 +14,13 @@ Jaeger is used for monitoring and troubleshooting microservices-based distribute
 ## High Scalability
 
 Jaeger backend is designed to have no single points of failure and to scale with the business needs.
-For example, any given Jaeger installation at Uber is typically processing several billions of spans per day.
+For example, any given Jaeger installation at Uber is typically processing several billion {{< tip "spans" "span" >}} per day.
 
 ## Native support for OpenTracing
 
 Jaeger backend, Web UI, and instrumentation libraries have been designed from ground up to support the OpenTracing standard.
 
-* Represent traces as directed acyclic graphs (not just trees) via [span references](https://github.com/opentracing/specification/blob/master/specification.md#references-between-spans)
+* Represent {{< tip "traces" "trace" >}} as {{< tip "directed acyclic graphs" "directed acyclic graph" >}} (not just trees) via [span references](https://github.com/opentracing/specification/blob/master/specification.md#references-between-spans)
 * Support strongly typed span _tags_ and _structured logs_
 * Support general distributed context propagation mechanism via _baggage_
 
@@ -34,7 +34,7 @@ with a simple in-memory storage for testing setups.
 
 Jaeger Web UI is implemented in Javascript using popular open source frameworks like React. Several performance
 improvements have been released in v1.0 to allow the UI to efficiently deal with large volumes of data, and to display
-traces with tens of thousands of spans (e.g. we tried a trace with 80,000 spans).
+{{< tip "traces" "trace" >}} with tens of thousands of {{< tip "spans" "span" >}} (e.g. we tried a trace with 80,000 spans).
 
 ## Cloud Native Deployment
 

--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -57,7 +57,7 @@ A tutorial / walkthrough is available in the blog post:
 [Take OpenTracing for a HotROD ride][hotrod-tutorial].
 
 It can be run standalone, but requires Jaeger backend to view the
-traces.
+{{< tip "traces" "trace" >}}.
 
 #### Running
 
@@ -92,7 +92,7 @@ Then navigate to `http://localhost:8080`.
 #### Prerequisites
 
 -   You need Go 1.9 or higher installed on your machine.
--   Requires a [running Jaeger backend](#all-in-one-docker-image) to view the traces.
+-   Requires a [running Jaeger backend](#all-in-one-docker-image) to view the {{< tip "traces" "trace" >}}.
 
 ## Client Libraries
 

--- a/content/docs/sampling.md
+++ b/content/docs/sampling.md
@@ -3,7 +3,7 @@ title: Sampling
 weight: 9
 ---
 
-Jaeger libraries implement consistent upfront (or head-based) sampling. For example, assume we have a simple call graph where service A calls service B, and B calls service C: `A -> B -> C`. When service A receives a request that contains no tracing information, Jaeger tracer will start a new trace, assign it a random trace ID, and make a sampling decision based on the currently installed sampling strategy. The sampling decision will be propagated with the requests to B and to C, so those services will not be making the sampling decision again but instead will respect the decision made by the top service A. This approach guarantees that if a trace is sampled, all its spans will be recorded in the backend. If each service was making its own sampling decision we would rarely get complete traces in the backend.
+Jaeger libraries implement consistent upfront (or head-based) sampling. For example, assume we have a simple call graph where service A calls service B, and B calls service C: `A -> B -> C`. When service A receives a request that contains no tracing information, Jaeger tracer will start a new {{< tip "trace" >}}, assign it a random trace ID, and make a sampling decision based on the currently installed sampling strategy. The sampling decision will be propagated with the requests to B and to C, so those services will not be making the sampling decision again but instead will respect the decision made by the top service A. This approach guarantees that if a trace is sampled, all its {{< tip "spans" "span" >}} will be recorded in the backend. If each service was making its own sampling decision we would rarely get complete traces in the backend.
 
 ## Client Sampling Configuration
 
@@ -18,8 +18,8 @@ When using configuration object to instantiate the tracer, the type of sampling 
 
 Adaptive sampler is a composite sampler that combines two functions:
 
-  * It makes sampling decisions on a per-operation basis, i.e. based on span operation name. This is especially useful in the API services whose endpoints may have very different traffic volumes and using a single probabilistic sampler for the whole service might starve (never sample) some of the low QPS endpoints.
-  * It supports a minimum guaranteed rate of sampling, such as always allowing up to N traces per seconds and then sampling anything above that with a certain probability (everything is per-operation, not per-service).
+  * It makes sampling decisions on a per-operation basis, i.e. based on {{< tip "span" >}} operation name. This is especially useful in the API services whose endpoints may have very different traffic volumes and using a single probabilistic sampler for the whole service might starve (never sample) some of the low QPS endpoints.
+  * It supports a minimum guaranteed rate of sampling, such as always allowing up to N {{< tip "traces" "trace" >}} per seconds and then sampling anything above that with a certain probability (everything is per-operation, not per-service).
 
 Per-operation parameters can be configured statically or pulled periodically from Jaeger backend with the help of Remote sampler. Adaptive sampler is designed to work with the upcoming [Adaptive Sampling](https://github.com/jaegertracing/jaeger/issues/365) feature of the Jaeger backend.
 

--- a/data/definitions.yaml
+++ b/data/definitions.yaml
@@ -1,0 +1,14 @@
+span: |
+  A **span** represents a logical unit of work in Jaeger that has an operation name, the start time of the operation, and the duration. Spans may be nested and ordered to model causal relationships.
+trace: |
+  A **trace** is a data/execution path through the system, and can be thought of as a directed acyclic graph of [spans](../architecture#span).
+agent: |
+  The Jaeger **agent** is a network daemon that listens for spans sent over UDP, which it batches and sends to the collector. It is designed to be deployed to all hosts as an infrastructure component. The agent abstracts the routing and discovery of the collectors away from the client.
+collector: |
+  The Jaeger **collector** receives traces from Jaeger [agents](../architecture#agent) and runs them through a processing pipeline. Currently our pipeline validates traces, indexes them, performs any transformations, and finally stores them.
+
+  Jaeger's storage is a pluggable component which currently supports [Cassandra](../deployment#cassandra) and [ElasticSearch](../deployment#elasticsearch).
+query: |
+  **Query** is a service that retrieves traces from storage and hosts a UI to display them.
+directed-acyclic-graph:
+  A **directed acyclic graph** (DAG) is a directed graph that contains no cycles

--- a/themes/jaeger-docs/layouts/partials/meta.html
+++ b/themes/jaeger-docs/layouts/partials/meta.html
@@ -27,5 +27,5 @@
 
 <!-- Twitter Card metadata -->
 <meta name="twitter:card" content="summary" />
-<meta name="twitter:site" content="{{ $twitterHandle }}" />
-<meta name="twitter:creator" content="{{ $twitterHandle }}" />
+<meta name="twitter:site" content="@{{ $twitterHandle }}" />
+<meta name="twitter:creator" content="@{{ $twitterHandle }}" />

--- a/themes/jaeger-docs/layouts/shortcodes/definition.html
+++ b/themes/jaeger-docs/layouts/shortcodes/definition.html
@@ -1,0 +1,3 @@
+{{- $term := .Get 0 }}
+{{- $definition := index .Site.Data.definitions $term }}
+<p>{{ $definition | markdownify }}</p>

--- a/themes/jaeger-docs/layouts/shortcodes/tip.html
+++ b/themes/jaeger-docs/layouts/shortcodes/tip.html
@@ -1,6 +1,10 @@
-{{- $hasTwoParams := gt (len .Params) 1 -}}
-{{- $word := .Get 0 -}}
-{{- $term := cond $hasTwoParams (.Get 1) $word -}}
-{{- $definition := index .Site.Data.definitions (urlize $term) | markdownify -}}
+{{- if eq (len .Params) 2 -}}
+{{- .Scratch.Set "word" (.Get 0) -}}
+{{- .Scratch.Set "term" (.Get 1) }}
+{{- else -}}
+{{- .Scratch.Set "word" (.Get 0) -}}
+{{- .Scratch.Set "term" (.Get 0) -}}
+{{- end -}}
+{{- $definition := index .Site.Data.definitions (urlize (.Scratch.Get "term")) | markdownify -}}
 {{- $longDefinition := gt (len $definition) 40 -}}
-<span class="tooltip{{ if $longDefinition }} is-tooltip-multiline{{ end }}" data-tooltip="{{ $definition }}">{{- $word -}}</span>
+<span class="tooltip{{ if $longDefinition }} is-tooltip-multiline{{ end }}" data-tooltip="{{ $definition }}">{{- .Scratch.Get "word" -}}</span>

--- a/themes/jaeger-docs/layouts/shortcodes/tip.html
+++ b/themes/jaeger-docs/layouts/shortcodes/tip.html
@@ -1,6 +1,6 @@
-{{- $hasTwoParams := eq (len .Params) 2 -}}
-{{- $wordToDisplay := .Get 0 -}}
-{{- $term := cond $hasTwoParams (.Get 1) $wordToDisplay -}}
+{{- $hasTwoParams := gt (len .Params) 1 -}}
+{{- $word := .Get 0 -}}
+{{- $term := cond $hasTwoParams (.Get 1) $word -}}
 {{- $definition := index .Site.Data.definitions (urlize $term) | markdownify -}}
-{{- $multiline := gt (len $definition) 40 -}}
-<span class="tooltip{{ if $multiline }} is-tooltip-multiline{{ end }}" data-tooltip="{{ $definition }}">{{- $wordToDisplay -}}</span>
+{{- $longDefinition := gt (len $definition) 40 -}}
+<span class="tooltip{{ if $longDefinition }} is-tooltip-multiline{{ end }}" data-tooltip="{{ $definition }}">{{- $word -}}</span>

--- a/themes/jaeger-docs/layouts/shortcodes/tip.html
+++ b/themes/jaeger-docs/layouts/shortcodes/tip.html
@@ -1,0 +1,6 @@
+{{- $hasTwoParams := eq (len .Params) 2 -}}
+{{- $wordToDisplay := .Get 0 -}}
+{{- $term := cond $hasTwoParams (.Get 1) $wordToDisplay -}}
+{{- $definition := index .Site.Data.definitions (urlize $term) | markdownify -}}
+{{- $multiline := gt (len $definition) 40 -}}
+<span class="tooltip{{ if $multiline }} is-tooltip-multiline{{ end }}" data-tooltip="{{ $definition }}">{{- $wordToDisplay -}}</span>

--- a/themes/jaeger-docs/package.json
+++ b/themes/jaeger-docs/package.json
@@ -5,6 +5,7 @@
   "devDependencies": {
     "anchor-js": "^4.1.0",
     "bulma": "^0.6.2",
+    "bulma-tooltip": "^1.0.4",
     "del": "^3.0.0",
     "gulp": "gulpjs/gulp#4.0",
     "gulp-autoprefixer": "^4.1.0",

--- a/themes/jaeger-docs/source/sass/elements.sass
+++ b/themes/jaeger-docs/source/sass/elements.sass
@@ -3,6 +3,8 @@
 .tooltip
   color: darken($jaeger-beige, 20%)
   font-weight: 600
+  &::before
+    font-size: $tooltip-font-size !important
 
 .feature-table-header
   font-size: 1.5rem

--- a/themes/jaeger-docs/source/sass/elements.sass
+++ b/themes/jaeger-docs/source/sass/elements.sass
@@ -1,5 +1,9 @@
 @import "variables"
 
+.tooltip
+  color: darken($jaeger-beige, 20%)
+  font-weight: 600
+
 .feature-table-header
   font-size: 1.5rem
   max-width: 100%

--- a/themes/jaeger-docs/source/sass/style.sass
+++ b/themes/jaeger-docs/source/sass/style.sass
@@ -7,3 +7,4 @@
 @import "pages"
 @import "syntax"
 @import "toc"
+@import ../../node_modules/bulma-tooltip/dist/bulma-tooltip

--- a/themes/jaeger-docs/source/sass/variables.sass
+++ b/themes/jaeger-docs/source/sass/variables.sass
@@ -9,6 +9,7 @@ $jaeger-black: rgb(35, 31, 32)
 
 /* Other Jaeger-specific variables */
 $link-font-weight: 600
+$tooltip-font-size: 1rem
 
 /* Bulma modifications */
 @import ../../node_modules/bulma/sass/utilities/initial-variables


### PR DESCRIPTION
This adds hoverable tooltips for definitions of key terms (span, trace, etc.). At the moment I've sprinkled just a few throughout. As the site grows, though, I think that giving readers easy access to terminological definitions will become increasingly important.

For an example hover over the words "span" and "trace" (in beige) in the first paragraph of [this doc](https://deploy-preview-50--jaegertracing.netlify.com/docs/sampling/).