### PR TITLE
Modify Netlify setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,12 +30,20 @@ build-content:
 		--theme $(HUGO_THEME) \
 		--baseURL $(BASE_URL)
 
+build-content-preview:
+	hugo -v \
+		--theme $(HUGO_THEME)
+
 build-assets:
 	(cd $(THEME_DIR) && $(GULP) build)
 
 build: clean build-assets build-content
 
+build-preview: clean build-assets build-content-preview
+
 netlify-build: netlify-setup build
+
+netlify-build-preview: netlify-setup build-preview
 
 dev: check-node
 	$(CONCURRENTLY) "make develop-content" "make develop-assets"

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,8 +2,12 @@
 publish = "public"
 command = "make netlify-build"
 
+[context.deploy-preview]
+publish = "public"
+command = "make netlify-build-preview"
+
 [context.production.environment]
-HUGO_VERSION = "0.37.1"
+HUGO_VERSION = "0.38"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.37.1"
+HUGO_VERSION = "0.38"


### PR DESCRIPTION
At the moment, all Netlify deploys (including for pull-request-specific previews) use a base URL of https://jaegertracing.io. This is fine for the "production" site but makes the deploy previews go haywire. This PR adds special "preview" build steps for non-production deploys.