### PR TITLE
Generate search index JSON

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,8 +6,9 @@ pygmentsUseClasses = true
 disableKinds       = ["taxonomy", "taxonomyTerm"]
 canonifyURLs       = true
 
-# Output HTML and JSON (for the search index)
 [outputs]
+  page = ["HTML"]
+  # Output HTML and JSON (for the search index)
   home = ["HTML", "JSON"]
 
 # Disable content taxonomies for now (until there is significantly more content)

--- a/config.toml
+++ b/config.toml
@@ -6,17 +6,21 @@ pygmentsUseClasses = true
 disableKinds       = ["taxonomy", "taxonomyTerm"]
 canonifyURLs       = true
 
+# Output HTML and JSON (for the search index)
+[outputs]
+  home = ["HTML", "JSON"]
+
 # Disable content taxonomies for now (until there is significantly more content)
 #[taxonomies]
 #  tag = "tags"
 
 [params]
-  tagline = "Monitor and troubleshoot transactions in complex distributed systems"
-  githubRepo     = "jaegertracing/jaeger"
-  twitterHandle  = "JaegerTracing"
-  mediumHandle   = "jaegertracing"
-  gitterHandle   = "jaegertracing"
-  openGraphImage = "img/jaeger-icon-color.png"
+  tagline         = "Monitor and troubleshoot transactions in complex distributed systems"
+  githubRepo      = "jaegertracing/jaeger"
+  twitterHandle   = "JaegerTracing"
+  mediumHandle    = "jaegertracing"
+  gitterHandle    = "jaegertracing"
+  openGraphImage  = "img/jaeger-icon-color.png"
   newsletterTitle = "April 2018 project update"
   newsletterURL   = "https://medium.com/jaegertracing/april-2018-newsletter-bad00a68080e"
 

--- a/themes/jaeger-docs/layouts/index.json
+++ b/themes/jaeger-docs/layouts/index.json
@@ -1,0 +1,5 @@
+{{- $.Scratch.Add "index" slice -}}
+{{- range where .Site.Pages "Type" "not in"  (slice "page" "json") -}}
+{{- $.Scratch.Add "index" (dict "title" .Title "ref" .Permalink "tags" .Params.tags "content" .Plain) -}}
+{{- end -}}
+{{- $.Scratch.Get "index" | jsonify -}}


### PR DESCRIPTION
This PR adds JSON index generation to the Hugo build, as a first step toward full-text search capabilities that don't require an external indexing service. An example JSON index (for the current build) can be found here:

https://5aef49bfdd6a5410666764f1--jaegertracing.netlify.com/index.json

@yurishkuro In general, I'll do the best I can on this with my jQuery/CSS powers but I'd recommend seeking some outside help to provide a polished experience.