### PR TITLE
Update docker examples for new run syntax

### DIFF
--- a/content/docs/deployment.md
+++ b/content/docs/deployment.md
@@ -58,7 +58,7 @@ docker run \
   -p6832:6832/udp \
   -p5778:5778/tcp \
   jaegertracing/jaeger-agent \
-  /go/bin/agent-linux --collector.host-port=jaeger-collector.jaeger-infra.svc:14267
+  --collector.host-port=jaeger-collector.jaeger-infra.svc:14267
 ```
 
 In the future we will support different service discovery systems to dynamically load balance
@@ -78,7 +78,7 @@ go run ./cmd/collector/main.go -h
 or, if you don't have the source code
 
 ```
-docker run -it --rm jaegertracing/jaeger-collector /go/bin/collector-linux -h
+docker run -it --rm jaegertracing/jaeger-collector -h
 ```
 
 At default settings the collector exposes the following ports:


### PR DESCRIPTION
- Dockerfiles were switched to reference the executables in ENTRYPOINT,
this enables users to call docker run without needing to specify it
again

Signed-off-by: Zachary DiCesare <zachary.v.dicesare@gmail.com>

https://github.com/jaegertracing/jaeger/pull/815