### PR TITLE
Set container name as jaeger in Getting Started

### DIFF
--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -16,7 +16,7 @@ This image, designed for quick local testing, launches the Jaeger UI, collector,
 The simplest way to start the all in one docker image is to use the pre-built image published to DockerHub (a single command line).
 
 ```bash
-$ docker run -d -e \
+$ docker run --name jaeger -d -e \
   COLLECTOR_ZIPKIN_HTTP_PORT=9411 \
   -p 5775:5775/udp \
   -p 6831:6831/udp \

--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -16,7 +16,7 @@ This image, designed for quick local testing, launches the Jaeger UI, collector,
 The simplest way to start the all in one docker image is to use the pre-built image published to DockerHub (a single command line).
 
 ```bash
-$ docker run --name jaeger -d -e \
+$ docker run -d -e --name jaeger \
   COLLECTOR_ZIPKIN_HTTP_PORT=9411 \
   -p 5775:5775/udp \
   -p 6831:6831/udp \


### PR DESCRIPTION
Current command to run the backend in Getting Started does not specify the container name as jaeger. HotROD example is linked to container name jaeger so it fails to connect to the backend.

Signed-off-by: Oguz Pastirmaci <oguzp@microsoft.com>
