### PR TITLE
Fixed incorrect docker run example

### DIFF
--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -16,8 +16,8 @@ This image, designed for quick local testing, launches the Jaeger UI, collector,
 The simplest way to start the all in one docker image is to use the pre-built image published to DockerHub (a single command line).
 
 ```bash
-$ docker run -d -e --name jaeger \
-  COLLECTOR_ZIPKIN_HTTP_PORT=9411 \
+$ docker run -d --name jaeger \
+  -e COLLECTOR_ZIPKIN_HTTP_PORT=9411 \
   -p 5775:5775/udp \
   -p 6831:6831/udp \
   -p 6832:6832/udp \


### PR DESCRIPTION
The '-e' parameter was not next to the environment variable, and caused the command to fail.