### PR TITLE
Adds protocol note to ports exposed by Collector

### DIFF
--- a/content/docs/deployment.md
+++ b/content/docs/deployment.md
@@ -110,7 +110,7 @@ At default settings the collector exposes the following ports:
 Port  | Protocol | Function
 ----- | -------  | ---
 14267 | TChannel | used by **jaeger-agent** to send spans in jaeger.thrift format
-14268 | HTTP     | can accept spans directly from clients in jaeger.thrift format
+14268 | HTTP     | can accept spans directly from clients in jaeger.thrift format over binary thrift protocol
 9411  | HTTP     | can accept Zipkin spans in JSON or Thrift (disabled by default)
 
 


### PR DESCRIPTION
## Which problem is this PR solving?

The ports exposed by the collector do not specify which Thrift protocol should be used when communicating with them. Based on reading the Java client codebase, it appears that HTTP over port 14268 expects [Binary Thrift](https://github.com/jaegertracing/jaeger-client-java/blob/dfb9d8b9dc849f2e6f880b44b26fb77dfc894a02/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/senders/HttpSender.java#L42)