### PR TITLE
Fix Hugo build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,10 @@ clean:
 
 build-content:
 	hugo -v \
-		--theme $(HUGO_THEME) \
         --baseURL $(BASE_URL)
 
 build-content-preview:
-	hugo -v \
-		--theme $(HUGO_THEME)
+	hugo -v
 
 build-assets: check-node
 	(cd $(THEME_DIR) && $(GULP) build)
@@ -54,7 +52,6 @@ dev:
 
 develop-content: build-assets
 	hugo server \
-		--theme $(HUGO_THEME) \
         --buildDrafts \
         --buildFuture \
         --disableFastRender \

--- a/config.toml
+++ b/config.toml
@@ -5,6 +5,7 @@ pygmentsCodeFences = true
 pygmentsUseClasses = true
 disableKinds       = ["taxonomy", "taxonomyTerm"]
 canonifyURLs       = true
+theme              = "jaeger-docs"
 
 # Disable content taxonomies for now (until there is significantly more content)
 #[taxonomies]


### PR DESCRIPTION
Apparently a regression was introduced in a handful of Hugo versions that broke setting the theme via the `--theme` flag. These changes fix for now and will be rendered superfluous by #102 (but best to un-break things in the meantime).