### PR TITLE
Add 128bit trace ID support as a feature on Client Features

### DIFF
--- a/content/docs/deployment.md
+++ b/content/docs/deployment.md
@@ -31,7 +31,7 @@ To see the complete list of options, run the binary with `help` command. Options
 $ docker run --rm \
     -e SPAN_STORAGE_TYPE=cassandra \
     jaegertracing/jaeger-collector \
-    /go/bin/collector-linux help
+    help
 ```
 
 In order to provide configuration parameters via environment variables, find the respective command line option and convert its name to UPPER_SNAKE_CASE, for example:
@@ -82,7 +82,7 @@ docker run \
   -p6832:6832/udp \
   -p5778:5778/tcp \
   jaegertracing/jaeger-agent \
-  /go/bin/agent-linux --collector.host-port=jaeger-collector.jaeger-infra.svc:14267
+  --collector.host-port=jaeger-collector.jaeger-infra.svc:14267
 ```
 
 In the future we will support different service discovery systems to dynamically load balance
@@ -102,7 +102,7 @@ go run ./cmd/collector/main.go -h
 or, if you don't have the source code
 
 ```
-docker run -it --rm jaegertracing/jaeger-collector /go/bin/collector-linux -h
+docker run -it --rm jaegertracing/jaeger-collector -h
 ```
 
 At default settings the collector exposes the following ports:

--- a/data/clients.yaml
+++ b/data/clients.yaml
@@ -20,6 +20,8 @@ featureGroups:
       description: Support inbound `jaeger-debug-id` header
     - name: jaeger_baggage
       description: Accept baggage from `jaeger-baggage` headers
+    - name: 128bit_trace_id
+      description: 128bit Trace ID
 
   - description: Metrics
     features:
@@ -83,6 +85,8 @@ featureGroups:
       description: "`JAEGER_PASSWORD`"
     - name: env_JAEGER_PROPAGATION
       description: "`JAEGER_PROPAGATION`"
+    - name: JAEGER_TRACEID_128BIT
+      description: "`JAEGER_TRACEID_128BIT`"
 
 clients:
   - language: Go
@@ -123,6 +127,8 @@ clients:
       env_JAEGER_USER: no
       env_JAEGER_PASSWORD: no
       env_JAEGER_PROPAGATION: no
+      128bit_trace_id: yes
+      JAEGER_TRACEID_128BIT: no
 
   - language: Java
     repo: jaegertracing/jaeger-client-java
@@ -162,6 +168,8 @@ clients:
       env_JAEGER_USER: yes
       env_JAEGER_PASSWORD: yes
       env_JAEGER_PROPAGATION: yes
+      128bit_trace_id: no
+      JAEGER_TRACEID_128BIT: no
 
   - language: Node.js
     repo: jaegertracing/jaeger-client-node
@@ -201,6 +209,8 @@ clients:
       env_JAEGER_USER: no
       env_JAEGER_PASSWORD: no
       env_JAEGER_PROPAGATION: no
+      128bit_trace_id: no
+      JAEGER_TRACEID_128BIT: no
 
   - language: Python
     repo: jaegertracing/jaeger-client-python
@@ -240,6 +250,8 @@ clients:
       env_JAEGER_USER: no
       env_JAEGER_PASSWORD: no
       env_JAEGER_PROPAGATION: no
+      128bit_trace_id: no
+      JAEGER_TRACEID_128BIT: no
 
   - language: C++
     repo: jaegertracing/jaeger-client-cpp
@@ -279,6 +291,8 @@ clients:
       env_JAEGER_USER: no
       env_JAEGER_PASSWORD: no
       env_JAEGER_PROPAGATION: no
+      128bit_trace_id: yes
+      JAEGER_TRACEID_128BIT: no
 
   - language: C#
     repo: jaegertracing/jaeger-client-csharp
@@ -317,4 +331,6 @@ clients:
       env_JAEGER_AUTH_TOKEN: yes
       env_JAEGER_USER: yes
       env_JAEGER_PASSWORD: yes
-      env_JAEGER_PROPAGATION: yes      
+      env_JAEGER_PROPAGATION: yes
+      128bit_trace_id: yes
+      JAEGER_TRACEID_128BIT: yes

--- a/data/clients.yaml
+++ b/data/clients.yaml
@@ -21,7 +21,7 @@ featureGroups:
     - name: jaeger_baggage
       description: Accept baggage from `jaeger-baggage` headers
     - name: 128bit_trace_id
-      description: 128bit Trace ID
+      description: Support for 128bit Trace ID
 
   - description: Metrics
     features:


### PR DESCRIPTION
Signed-off-by: Prakriti <prakritibansal98@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
-Resolves #105 

## Short description of the changes
-Add 128bit trace ID support as a feature on Client Features
