### PR TITLE
Fix Nav UI's issue

### DIFF
--- a/themes/jaeger-docs/assets/sass/pages.sass
+++ b/themes/jaeger-docs/assets/sass/pages.sass
@@ -25,6 +25,7 @@
     /* Left-hand documentation nav */
     .nav
       position: fixed
+      width: inherit
       overflow-x: auto
       //padding-right: 3rem
 


### PR DESCRIPTION
This PR add an css attribute to `.page--docs .nav` to break the nave item into new line in case the text is long. It will make web page display more reasonable in 1366x768 screen resolution.

Resolves #115 