### PR TITLE
Main docs page redirect

### DIFF
--- a/themes/jaeger-docs/layouts/index.redirects
+++ b/themes/jaeger-docs/layouts/index.redirects
@@ -8,6 +8,7 @@
 {{ $originalUrl }}     {{ $latestUrl }}
 {{- end }}
 {{- end }}
+/docs    /docs/{{ $latest }}
 /docs/latest     /docs/{{ $latest }}
 /docs/latest/*     /docs/{{ $latest }}/:splat
 /docs/download     /download


### PR DESCRIPTION
For reasons I don't quite understand, Hugo is generating a `/docs` page that isn't supposed to be there. So I've added a redirect that will send `/docs` to `/docs/LATEST_VERSION`.