### PR TITLE
Fix OpenGraph tags

### DIFF
--- a/themes/jaeger-docs/layouts/partials/meta.html
+++ b/themes/jaeger-docs/layouts/partials/meta.html
@@ -18,12 +18,12 @@
 <meta property="og:locale" content="en_US" />
 {{- if not $isHome }}<meta property="og:site_name" content="{{ .Site.Title }}" />{{- end }}
 {{- with $description }}<meta property="og:description" content="{{ . }}" />{{- end }}
-<meta property="og:type" content="{{ $type }}" />
-<meta property="og:image" content="{{ $imageUrl }}" />
-<meta property="og:image:alt" content="Jaeger tracing project logo" />
-<meta property="og:image:type" content="image/png" />
-<meta property="og:image:width" content="1801" />
-<meta property="og:image:height" content="587" />
+<meta name="og:type" content="{{ $type }}" />
+<meta name="og:image" content="{{ $imageUrl }}" />
+<meta name="og:image:alt" content="Jaeger tracing project logo" />
+<meta name="og:image:type" content="image/png" />
+<meta name="og:image:width" content="1801" />
+<meta name="og:image:height" content="587" />
 
 <!-- Twitter Card metadata -->
 <meta name="twitter:card" content="summary" />


### PR DESCRIPTION
I learned the other day that OpenGraph tags need to be `<meta name="..." content="...">` rather than `<meta property="..." content="...">`. This PR should improve the SEO picture a bit.