### PR TITLE
Download page follow-up

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -34,3 +34,4 @@ home = [ "HTML", "REDIRECTS" ]
 
 [params.versions]
 latest = "1.6"
+dockerImageLatest = "1.6.0"

--- a/config.toml
+++ b/config.toml
@@ -34,4 +34,3 @@ home = [ "HTML", "REDIRECTS" ]
 
 [params.versions]
 latest = "1.6"
-dockerImageLatest = "1.6.0"

--- a/data/download.yaml
+++ b/data/download.yaml
@@ -42,5 +42,4 @@ docker:
 - name: jaeger-es-index-cleaner
   since: 1.3
 - name: jaeger-operator
-  latest: 1.6
 

--- a/data/download.yaml
+++ b/data/download.yaml
@@ -18,28 +18,28 @@ binaries:
   - "1.5.0"
   - "1.6.0"
 docker:
-- name: all-in-one
+- image: all-in-one
   description: This image is designed for quick local testing. It launches the Jaeger UI, collector, query, and agent, with an in-memory storage component.
   since: 0.8
-- name: jaeger-collector
+- image: jaeger-collector
   description: The Jaeger collector
   since: 0.8
-- name: jaeger-query
+- image: jaeger-query
   description: The Jaeger query image
   since: 0.8
-- name: jaeger-agent
+- image: jaeger-agent
   description: The Jaeger agent
   since: 0.8
-- name: example-hotrod
+- image: example-hotrod
   description: The example hot rod application
   since: 1.6
-- name: spark-dependencies
+- image: spark-dependencies
   description: An [Apache Spark](http://spark.apache.org/) job that collects Jaeger spans from storage, analyzes links between services, and stores them for later presentation in the Jaeger UI
   latest: latest
   since: 1.3
-- name: jaeger-cassandra-schema
+- image: jaeger-cassandra-schema
   since: 0.8
-- name: jaeger-es-index-cleaner
+- image: jaeger-es-index-cleaner
   since: 1.3
-- name: jaeger-operator
+- image: jaeger-operator
 

--- a/data/download.yaml
+++ b/data/download.yaml
@@ -1,4 +1,3 @@
-
 binaries:
   platforms:
   - darwin
@@ -21,9 +20,27 @@ binaries:
 docker:
 - name: all-in-one
   description: This image is designed for quick local testing. It launches the Jaeger UI, collector, query, and agent, with an in-memory storage component.
+  since: 0.8
 - name: jaeger-collector
   description: The Jaeger collector
+  since: 0.8
 - name: jaeger-query
   description: The Jaeger query image
+  since: 0.8
 - name: jaeger-agent
   description: The Jaeger agent
+  since: 0.8
+- name: example-hotrod
+  description: The example hot rod application
+  since: 1.6
+- name: spark-dependencies
+  description: An [Apache Spark](http://spark.apache.org/) job that collects Jaeger spans from storage, analyzes links between services, and stores them for later presentation in the Jaeger UI
+  latest: latest
+  since: 1.3
+- name: jaeger-cassandra-schema
+  since: 0.8
+- name: jaeger-es-index-cleaner
+  since: 1.3
+- name: jaeger-operator
+  latest: 1.6
+

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "hugo"
 
 [build.environment]
-HUGO_VERSION = "0.46"
+HUGO_VERSION = "0.48"
 
 [context.deploy-preview]
 command = "hugo --buildDrafts --buildFuture --baseURL $DEPLOY_PRIME_URL"

--- a/themes/jaeger-docs/layouts/shortcodes/binaries.html
+++ b/themes/jaeger-docs/layouts/shortcodes/binaries.html
@@ -1,8 +1,8 @@
 {{- $binaries := .Site.Data.download.binaries }}
-{{- $fullReleaseVersions    := index $binaries "fullReleaseVersions" }}
-{{- $partialReleaseVersions := index $binaries "partialReleaseVersions" }}
-{{- $platforms              := index $binaries "platforms" }}
-{{- $platformInfo           := index $binaries "platformInfo" }}
+{{- $fullReleaseVersions    := $binaries.fullReleaseVersions }}
+{{- $partialReleaseVersions := $binaries.partialReleaseVersions }}
+{{- $platforms              := $binaries.platforms }}
+{{- $platformInfo           := $binaries.platformInfo }}
 <table class="table is-striped">
   <thead>
     <tr>
@@ -16,14 +16,17 @@
   </thead>
   <tbody>
     {{- range sort $fullReleaseVersions "value" "desc" }}
-    {{- $version := . }}
-    {{- $zipUrl := printf "https://github.com/jaegertracing/jaeger/archive/v%s.zip" $version }}
-    {{- $tarUrl := printf "https://github.com/jaegertracing/jaeger/archive/v%s.tar.gz" $version }}
+    {{- $version    := . }}
+    {{- $releaseUrl := printf "https://github.com/jaegertracing/jaeger/releases/tag/v%s" $version }}
+    {{- $zipUrl     := printf "https://github.com/jaegertracing/jaeger/archive/v%s.zip" $version }}
+    {{- $tarUrl     := printf "https://github.com/jaegertracing/jaeger/archive/v%s.tar.gz" $version }}
     <tr>
       <td>
         <strong>
           <span class="is-size-4">
-            {{ $version }}
+            <a href="{{ $releaseUrl }}">
+              {{ $version }}
+            </a>
           </span>
         </strong>
       </td>
@@ -32,8 +35,8 @@
           {{- range $platforms }}
           {{- $platform    := . }}
           {{- $info        := index $platformInfo $platform }}
-          {{- $name        := index $info "name" }}
-          {{- $icon        := index $info "icon" }}
+          {{- $name        := $info.name }}
+          {{- $icon        := $info.icon }}
           {{- $asset       := printf "jaeger-%s-%s-amd64.tar.gz" $version $platform }}
           {{- $downloadUrl := printf "https://github.com/jaegertracing/jaeger/releases/download/v%s/%s" $version $asset }}
           {{- $zipUrl      := printf "https://github.com/jaegertracing/jaeger/archive/v%s.zip" $version }}
@@ -52,7 +55,7 @@
               <i class="fas fa-file-archive"></i>
             </span>
             <span>
-              ZIP
+              Source (.zip)
             </span>
           </a>
           <a class="button is-large is-tar" href="{{ $tarUrl }}" download>
@@ -60,7 +63,7 @@
               <i class="fas fa-file-archive"></i>
             </span>
             <span>
-              TAR
+              Source (.tar.gz)
             </span>
           </a>
         </p>

--- a/themes/jaeger-docs/layouts/shortcodes/dockerImages.html
+++ b/themes/jaeger-docs/layouts/shortcodes/dockerImages.html
@@ -5,13 +5,16 @@
       <th>Image</th>
       <th>Description</th>
       <th>Pull command</th>
+      <th>Since version</th>
     </tr>
   </thead>
   <tbody>
     {{- range $dockerImages }}
-    {{- $image := printf "jaegertracing/%s" .name }}
-    {{- $link  := printf "https://hub.docker.com/r/%s" $image }}
+    {{- $image       := .name }}
+    {{- $link        := printf "https://hub.docker.com/r/jaegertracing/%s" $image }}
     {{- $description := .description | markdownify }}
+    {{- $since       := .since }}
+    {{- $latest      := .latest | default $.Site.Params.versions.dockerImageLatest }}
     <tr>
       <td>
         <a href="{{ $link }}">
@@ -22,9 +25,10 @@
         {{ $description }}
       </td>
       <td>
-        <code>
-          docker pull {{ $image }}
-        </code>
+        <code>docker pull {{ $image }}:{{ $latest }}</code>
+      </td>
+      <td>
+        {{ $since }}
       </td>
     </tr>
     {{- end }}

--- a/themes/jaeger-docs/layouts/shortcodes/dockerImages.html
+++ b/themes/jaeger-docs/layouts/shortcodes/dockerImages.html
@@ -14,7 +14,7 @@
     {{- $link        := printf "https://hub.docker.com/r/jaegertracing/%s" $image }}
     {{- $description := .description | markdownify }}
     {{- $since       := .since }}
-    {{- $latest      := .latest | default $.Site.Params.versions.dockerImageLatest }}
+    {{- $latest      := .latest | default $.Site.Params.versions.latest }}
     <tr>
       <td>
         <a href="{{ $link }}">

--- a/themes/jaeger-docs/layouts/shortcodes/dockerImages.html
+++ b/themes/jaeger-docs/layouts/shortcodes/dockerImages.html
@@ -10,8 +10,10 @@
   </thead>
   <tbody>
     {{- range $dockerImages }}
-    {{- $image       := .name }}
-    {{- $link        := printf "https://hub.docker.com/r/jaegertracing/%s" $image }}
+    {{- $org         := "jaegertracing" }}
+    {{- $image       := .image }}
+    {{- $fullImage   := printf "%s/%s" $org $image }}
+    {{- $link        := printf "https://hub.docker.com/r/$s/%s" $org $image }}
     {{- $description := .description | markdownify }}
     {{- $since       := .since }}
     {{- $latest      := .latest | default $.Site.Params.versions.latest }}
@@ -25,7 +27,7 @@
         {{ $description }}
       </td>
       <td>
-        <code>docker pull {{ $image }}:{{ $latest }}</code>
+        <code>docker pull {{ $fullImage }}:{{ $latest }}</code>
       </td>
       <td>
         {{ $since }}


### PR DESCRIPTION
cc @yurishkuro

Addresses issue #147. I haven't yet come up with a good way of doing a combined "Components" table but we can save that for a future PR. There are also some missing Docker image descriptions. Feel free to provide those here in the PR discussion or do a follow-up PR (or just push commits).

The new download page is here:

https://deploy-preview-148--jaegertracing.netlify.com/download/