### PR TITLE
Display latest version only in binaries table

### DIFF
--- a/content/download/_index.md
+++ b/content/download/_index.md
@@ -13,6 +13,10 @@ Jaeger binaries are available for macOS, Linux, and Windows. The table below lis
 
 {{< binaries >}}
 
+You can find the binaries for previous versions on the GitHub releases page:
+
+{{< priorBinaries >}}
+
 ## Docker images
 
 The following Docker images are available for the Jaeger project via the [jaegertracing](https://hub.docker.com/r/jaegertracing/) organization on [Docker Hub](https://hub.docker.com):

--- a/data/download.yaml
+++ b/data/download.yaml
@@ -1,9 +1,10 @@
 binaries:
+  latest: 1.6.0
+  allVersions:
+  - 1.6.0
+  - 1.5.0
+  - 1.4.1
   platforms:
-  - darwin
-  - linux
-  - windows
-  platformInfo:
     darwin:
       name: macOS
       icon: fa-apple
@@ -13,10 +14,6 @@ binaries:
     windows:
       name: Windows
       icon: fa-windows
-  fullReleaseVersions:
-  - "1.4.1"
-  - "1.5.0"
-  - "1.6.0"
 docker:
 - image: all-in-one
   description: This image is designed for quick local testing. It launches the Jaeger UI, collector, query, and agent, with an in-memory storage component.

--- a/themes/jaeger-docs/layouts/shortcodes/binaries.html
+++ b/themes/jaeger-docs/layouts/shortcodes/binaries.html
@@ -1,13 +1,14 @@
-{{- $binaries := .Site.Data.download.binaries }}
-{{- $fullReleaseVersions    := $binaries.fullReleaseVersions }}
-{{- $partialReleaseVersions := $binaries.partialReleaseVersions }}
-{{- $platforms              := $binaries.platforms }}
-{{- $platformInfo           := $binaries.platformInfo }}
+{{- $binaries      := .Site.Data.download.binaries }}
+{{- $latest        := $binaries.latest }}
+{{- $releaseUrl    := printf "https://github.com/jaegertracing/jaeger/releases/tag/v%s" $latest }}
+{{- $zipUrl        := printf "https://github.com/jaegertracing/jaeger/archive/v%s.zip" $latest }}
+{{- $tarUrl        := printf "https://github.com/jaegertracing/jaeger/archive/v%s.tar.gz" $latest }}
+{{- $platforms     := $binaries.platforms }}
 <table class="table is-striped">
   <thead>
     <tr>
       <th>
-        Version
+        Latest version
       </th>
       <th>
         Assets
@@ -15,33 +16,26 @@
     </tr>
   </thead>
   <tbody>
-    {{- range sort $fullReleaseVersions "value" "desc" }}
-    {{- $version    := . }}
-    {{- $releaseUrl := printf "https://github.com/jaegertracing/jaeger/releases/tag/v%s" $version }}
-    {{- $zipUrl     := printf "https://github.com/jaegertracing/jaeger/archive/v%s.zip" $version }}
-    {{- $tarUrl     := printf "https://github.com/jaegertracing/jaeger/archive/v%s.tar.gz" $version }}
     <tr>
       <td>
         <strong>
-          <span class="is-size-4">
+          <span class="is-size-3">
             <a href="{{ $releaseUrl }}">
-              {{ $version }}
+              {{ $latest }}
             </a>
           </span>
         </strong>
       </td>
       <td>
         <p class="buttons">
-          {{- range $platforms }}
-          {{- $platform    := . }}
-          {{- $info        := index $platformInfo $platform }}
-          {{- $name        := $info.name }}
-          {{- $icon        := $info.icon }}
-          {{- $asset       := printf "jaeger-%s-%s-amd64.tar.gz" $version $platform }}
-          {{- $downloadUrl := printf "https://github.com/jaegertracing/jaeger/releases/download/v%s/%s" $version $asset }}
-          {{- $zipUrl      := printf "https://github.com/jaegertracing/jaeger/archive/v%s.zip" $version }}
-          {{- $tarUrl      := printf "https://github.com/jaegertracing/jaeger/archive/v%s.tar.gz" $version }}
-          <a class="button is-large is-{{ $platform }}" href="{{ $downloadUrl }}" download>
+          {{- range $key, $platform := $platforms }}
+          {{- $name        := $platform.name }}
+          {{- $icon        := $platform.icon }}
+          {{- $asset       := printf "jaeger-%s-%s-amd64.tar.gz" $latest $key }}
+          {{- $downloadUrl := printf "https://github.com/jaegertracing/jaeger/releases/download/v%s/%s" $latest $asset }}
+          {{- $zipUrl      := printf "https://github.com/jaegertracing/jaeger/archive/v%s.zip" $latest }}
+          {{- $tarUrl      := printf "https://github.com/jaegertracing/jaeger/archive/v%s.tar.gz" $latest }}
+          <a class="button is-medium is-{{ $key }}" href="{{ $downloadUrl }}" download>
             <span class="icon">
               <i class="fab {{ $icon }}"></i>
             </span>
@@ -50,7 +44,7 @@
             </span>
           </a>
           {{- end }}
-          <a class="button is-large is-zip" href="{{ $zipUrl }}" download>
+          <a class="button is-medium is-zip" href="{{ $zipUrl }}" download>
             <span class="icon">
               <i class="fas fa-file-archive"></i>
             </span>
@@ -58,7 +52,7 @@
               Source (.zip)
             </span>
           </a>
-          <a class="button is-large is-tar" href="{{ $tarUrl }}" download>
+          <a class="button is-medium is-tar" href="{{ $tarUrl }}" download>
             <span class="icon">
               <i class="fas fa-file-archive"></i>
             </span>
@@ -69,6 +63,5 @@
         </p>
       </td>
     </tr>
-    {{- end }}
   </tbody>
 </table>

--- a/themes/jaeger-docs/layouts/shortcodes/priorBinaries.html
+++ b/themes/jaeger-docs/layouts/shortcodes/priorBinaries.html
@@ -1,0 +1,16 @@
+{{- $binaries    := .Site.Data.download.binaries }}
+{{- $latest      := $binaries.latest }}
+{{- $allVersions := $binaries.allVersions }}
+<ul>
+  {{- range $allVersions }}
+  {{- $version := . }}
+  {{- if ne $version $latest }}
+  {{- $url := printf "https://github.com/jaegertracing/jaeger/releases/tag/v%s" $version }}
+  <li>
+    <a href="{{ $url }}">
+      {{ . }}
+    </a>
+  </li>
+  {{- end }}
+  {{- end }}
+</ul>


### PR DESCRIPTION
Addresses issue #151 by showing only the most recent version in the downloads table. Prior versions are listed in a separate list with links to the GitHub releases page.

Preview:

https://deploy-preview-152--jaegertracing.netlify.com/download/
