### PR TITLE
Auto-infer latest from directory structure

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -31,6 +31,3 @@ home = [ "HTML", "REDIRECTS" ]
     [[links]]
       title = "Docs"
       url = "/docs"
-
-[params.versions]
-latest = "1.6"

--- a/themes/jaeger-docs/layouts/404.html
+++ b/themes/jaeger-docs/layouts/404.html
@@ -1,4 +1,5 @@
-{{- $latest := .Site.Params.versions.latest }}
+{{- $versions := sort (readDir "content/docs") "Name" "desc" }}
+{{- $latest   := (index ($versions) 0).Name }}
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode }}">
   <head>

--- a/themes/jaeger-docs/layouts/index.redirects
+++ b/themes/jaeger-docs/layouts/index.redirects
@@ -1,4 +1,5 @@
-{{- $latest := .Site.Params.versions.latest }}
+{{- $versions     := sort (readDir "content/docs") "Name" "desc" }}
+{{- $latest       := (index ($versions) 0).Name }}
 {{- $originalDocs := readDir "content/docs/1.6" -}}
 {{- range $originalDocs }}
 {{- if ne .Name "_index.md" }}

--- a/themes/jaeger-docs/layouts/partials/docs/header.html
+++ b/themes/jaeger-docs/layouts/partials/docs/header.html
@@ -1,5 +1,6 @@
+{{- $versions  := sort (readDir "content/docs") "Name" "desc" }}
+{{- $latest    := (index ($versions) 0).Name }}
 {{- $version   := index (split .File.Path "/") 1 }}
-{{- $latest    := .Site.Params.versions.latest }}
 {{- $isLatest  := eq $version $latest }}
 {{- $latestUrl := .URL | replaceRE $version $latest }}
 <header>

--- a/themes/jaeger-docs/layouts/partials/home/hero.html
+++ b/themes/jaeger-docs/layouts/partials/home/hero.html
@@ -1,4 +1,5 @@
-{{- $latest := .Site.Params.versions.latest }}
+{{- $versions := sort (readDir "content/docs") "Name" "desc" }}
+{{- $latest   := (index ($versions) 0).Name }}
 <section class="hero hero--home is-info is-medium">
   <div class="hero-body">
     <div class="container">

--- a/themes/jaeger-docs/layouts/partials/navbar.html
+++ b/themes/jaeger-docs/layouts/partials/navbar.html
@@ -1,8 +1,8 @@
 {{- $menuPages     := .Site.Menus.docs }}
 {{- $githubRepo    := .Site.Params.githubRepo }}
 {{- $twitterHandle := .Site.Params.twitterHandle }}
-{{- $latest        := .Site.Params.versions.latest }}
 {{- $versions      := sort (readDir "content/docs") "Name" "desc" }}
+{{- $latest        := (index ($versions) 0).Name }}
 {{- $isDocsPage    := eq .Section "docs" }}
 <nav class="navbar is-fixed-top">
   <div class="container is-fluid">

--- a/themes/jaeger-docs/layouts/shortcodes/dockerImages.html
+++ b/themes/jaeger-docs/layouts/shortcodes/dockerImages.html
@@ -1,4 +1,6 @@
 {{- $dockerImages := .Site.Data.download.docker }}
+{{- $versions     := sort (readDir "content/docs") "Name" "desc" }}
+{{- $latest       := (index ($versions) 0).Name }}
 <table>
   <thead>
     <tr>
@@ -15,8 +17,8 @@
     {{- $link        := printf "https://hub.docker.com/r/$s/%s" $org $image }}
     {{- $description := .description | markdownify }}
     {{- $since       := .since }}
-    {{- $latest      := .latest | default $.Site.Params.versions.latest }}
-    {{- $pullCmd     := printf "<code><span class=\"is-dollar\">$</span> docker pull %s:%s</code>" $fullImage $latest | safeHTML }}
+    {{- $latestImg   := .latest | default $latest }}
+    {{- $pullCmd     := printf "<code><span class=\"is-dollar\">$</span> docker pull %s:%s</code>" $fullImage $latestImg | safeHTML }}
     <tr>
       <td>
         <a href="{{ $link }}">


### PR DESCRIPTION
This PR removes the need to specify the latest version in the Hugo config. Instead, the latest can be inferred from the directory structure, i.e. Hugo will automatically know that 2.5 is the latest among versions 2.3, 2.4, and 2.5.

Just a little trick that I figured out working on another project.