### PR TITLE
Document 128bit trace ID support on Java Client as available

### DIFF
--- a/data/clients.yaml
+++ b/data/clients.yaml
@@ -168,8 +168,8 @@ clients:
       env_JAEGER_USER: yes
       env_JAEGER_PASSWORD: yes
       env_JAEGER_PROPAGATION: yes
-      128bit_trace_id: no
-      JAEGER_TRACEID_128BIT: no
+      128bit_trace_id: yes
+      JAEGER_TRACEID_128BIT: yes
 
   - language: Node.js
     repo: jaegertracing/jaeger-client-node


### PR DESCRIPTION
## Which problem is this PR solving?
This PR documents 128bit trace id feature for the java client.

## Short description of the changes
128 bit trace id is now available on java client.