### PR TITLE
Use explicit versioning scheme

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -28,6 +28,7 @@ home = [ "HTML", "REDIRECTS" ]
   newsletterURL   = "https://medium.com/jaegertracing/september-2018-newsletter-26ae7e8c3f00"
 
   latest         = "1.7"
+  binariesLatest = "1.7.0"
   versions       = ["1.6", "1.7"]
 
   [navbar]

--- a/config.toml
+++ b/config.toml
@@ -27,6 +27,9 @@ home = [ "HTML", "REDIRECTS" ]
   newsletterTitle = "September 2018 project update"
   newsletterURL   = "https://medium.com/jaegertracing/september-2018-newsletter-26ae7e8c3f00"
 
+  latest         = "1.7"
+  versions       = ["1.6", "1.7"]
+
   [navbar]
     [[links]]
       title = "Docs"

--- a/data/download.yaml
+++ b/data/download.yaml
@@ -1,5 +1,4 @@
 binaries:
-  latest: 1.7.0
   platforms:
     darwin:
       name: macOS

--- a/themes/jaeger-docs/layouts/index.redirects
+++ b/themes/jaeger-docs/layouts/index.redirects
@@ -1,14 +1,5 @@
 {{- $versions     := .Site.Params.versions }}
 {{- $latest       := .Site.Params.latest }}
-{{- $originalDocs := readDir "content/docs/1.6" -}}
-{{- range $originalDocs }}
-{{- if ne .Name "_index.md" }}
-{{- $endpoint := .Name | replaceRE ".md" "" }}
-{{- $originalUrl := printf "/docs/%s" $endpoint }}
-{{- $latestUrl   := printf "/docs/%s/%s" $latest $endpoint }}
-{{ $originalUrl }}     {{ $latestUrl }}
-{{- end }}
-{{- end }}
 /docs    /docs/{{ $latest }}
 /docs/latest     /docs/{{ $latest }}
 /docs/latest/*     /docs/{{ $latest }}/:splat
@@ -17,3 +8,12 @@
 /docs/roadmap     /roadmap
 /docs/news     /news
 /docs/report-security-issue     /report-security-issue
+/docs/architecture     /docs/{{ $latest  }}/architecture
+/docs/client-features     /docs/{{ $latest }}/client-features
+/docs/client-libraries     /docs/{{ $latest }}/client-libraries
+/docs/deployment     /docs/{{ $latest }}/deployment
+/docs/features     /docs/{{ $latest }}/features
+/docs/getting-started     /docs/{{ $latest }}/getting-started
+/docs/monitoring     /docs/{{ $latest }}/monitoring
+/docs/sampling     /docs/{{ $latest }}/sampling
+/docs/troubleshooting     /docs/{{ $latest }}/troubleshooting

--- a/themes/jaeger-docs/layouts/index.redirects
+++ b/themes/jaeger-docs/layouts/index.redirects
@@ -1,5 +1,5 @@
-{{- $versions     := sort (readDir "content/docs") "Name" "desc" }}
-{{- $latest       := (index ($versions) 0).Name }}
+{{- $versions     := .Site.Params.versions }}
+{{- $latest       := .Site.Params.latest }}
 {{- $originalDocs := readDir "content/docs/1.6" -}}
 {{- range $originalDocs }}
 {{- if ne .Name "_index.md" }}

--- a/themes/jaeger-docs/layouts/partials/docs/header.html
+++ b/themes/jaeger-docs/layouts/partials/docs/header.html
@@ -1,5 +1,5 @@
-{{- $versions  := sort (readDir "content/docs") "Name" "desc" }}
-{{- $latest    := (index ($versions) 0).Name }}
+{{- $versions  := .Site.Params.versions }}
+{{- $latest    := .Site.Params.latest }}
 {{- $version   := index (split .File.Path "/") 1 }}
 {{- $isLatest  := eq $version $latest }}
 {{- $latestUrl := .URL | replaceRE $version $latest }}

--- a/themes/jaeger-docs/layouts/partials/navbar.html
+++ b/themes/jaeger-docs/layouts/partials/navbar.html
@@ -1,8 +1,9 @@
 {{- $menuPages     := .Site.Menus.docs }}
 {{- $githubRepo    := .Site.Params.githubRepo }}
 {{- $twitterHandle := .Site.Params.twitterHandle }}
-{{- $versions      := sort (readDir "content/docs") "Name" "desc" }}
-{{- $latest        := (index ($versions) 0).Name }}
+{{- $versions      := .Site.Params.versions }}
+{{- $latest        := .Site.Params.latest }}
+{{- $docs          := where .Site.Pages "Section" "docs" }}
 {{- $isDocsPage    := eq .Section "docs" }}
 <nav class="navbar is-fixed-top">
   <div class="container is-fluid">
@@ -32,7 +33,7 @@
           </a>
           <div class="navbar-dropdown">
             {{- range $versions }}
-            {{- $version := .Name }}
+            {{- $version := . }}
             {{- $isLatest := eq $version $latest }}
             <a class="navbar-item" href="/docs/{{ $version }}">
               {{ $version }}{{ if $isLatest }}&nbsp;&nbsp;(<strong>latest</strong>){{ end }}
@@ -46,11 +47,10 @@
             Docs
           </a>
           <div class="navbar-dropdown">
-            {{- range .Site.Pages }}
+            {{- range $docs }}
             {{- $docVersion := index (split .File.Path "/") 1 }}
-            {{- $isLatest := eq $docVersion $latest }}
-            {{- if and $isLatest (not .Params.hasparent) }}
-            <a class="navbar-item" href="{{ .Permalink }}">
+            {{- if eq $docVersion $latest }}
+            <a class="navbar-item" href="{{ .URL }}">
               {{ .Title }}
             </a>
             {{- end }}

--- a/themes/jaeger-docs/layouts/shortcodes/binaries.html
+++ b/themes/jaeger-docs/layouts/shortcodes/binaries.html
@@ -1,5 +1,5 @@
+{{- $latest        := .Site.Params.binariesLatest }}
 {{- $binaries      := .Site.Data.download.binaries }}
-{{- $latest        := $binaries.latest }}
 {{- $releaseUrl    := printf "https://github.com/jaegertracing/jaeger/releases/tag/v%s" $latest }}
 {{- $zipUrl        := printf "https://github.com/jaegertracing/jaeger/archive/v%s.zip" $latest }}
 {{- $tarUrl        := printf "https://github.com/jaegertracing/jaeger/archive/v%s.tar.gz" $latest }}


### PR DESCRIPTION
This PR changes the versioning scheme behind the docs from an implicit scheme (that infers existing versions and "latest" from the subdirectories of `content/docs`) to an explicit scheme (in which all versions and "latest" are assigned in the site configuration).

@yurishkuro This should address the concerns you raised previously.
