### PR TITLE
Fix README to install a hugo extended release

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The site is built and hosted by [Netlify](https://www.netlify.com/).
 
 ## Setup
 
-Install the extended hugo binary from [hugo/releases](https://github.com/gohugoio/hugo/releases) or
+Install the extended hugo extended binary from [hugo/releases](https://github.com/gohugoio/hugo/releases) or
 use package manager if it is available for your operating system.
 The currently used version of hugo is defined in [netifly.toml](./netifly.toml) configuration file.
 


### PR DESCRIPTION
## Which problem is this PR solving?

Installing hugo release version >= 0.50 throw the error

```bash
Building sites … ERROR 2018/11/28 13:21:21 error: failed to transform resource: TOCSS: failed to transform "sass/style.sass" (text/x-sass): this feature is not available in your current Hugo version
```

## Short description of the changes

Specify in the README that the version must be the extended one.
