### PR TITLE
Fix links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The site is built and hosted by [Netlify](https://www.netlify.com/).
 
 Install the extended hugo binary from [hugo/releases](https://github.com/gohugoio/hugo/releases) or
 use package manager if it is available for your operating system.
-The currently used version of hugo is defined in [netifly.toml](./netifly.toml) configuration file.
+The currently used version of hugo is defined in [netlify.toml](./netlify.toml) configuration file.
 
 ## Running the site locally
 
@@ -18,7 +18,7 @@ If you want to develop the site locally, you can run a single command (assuming 
 $ make develop
 ```
 
-This will start up a local server on localhost port 1313. When you make changes to either the content of the website (in [`content`](content)) *or* to the Sass and JavaScript assets of the page (in [`themes/jaeger-docs/source`](themes/jaeger-docs/source)), the browser will automatically update to reflect those changes (usually in under one second).
+This will start up a local server on localhost port 1313. When you make changes to either the content of the website (in [`content`](content)) *or* to the Sass and JavaScript assets of the page (in [`themes/jaeger-docs/assets`](themes/jaeger-docs/assets)), the browser will automatically update to reflect those changes (usually in under one second).
 
 ## Publishing the site
 


### PR DESCRIPTION
netifly.toml -> netlify.toml
themes/jaeger-docs/source -> themes/jaeger-docs/assets

Signed-off-by: Alex Yang <yangyang1@zte.com.cn>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- There are 2 wrong links in README.md

## Short description of the changes
- Fix 2 links in README.md
