### PR TITLE
Fix references to latest version

### DIFF
--- a/themes/jaeger-docs/layouts/404.html
+++ b/themes/jaeger-docs/layouts/404.html
@@ -1,5 +1,4 @@
-{{- $versions := sort (readDir "content/docs") "Name" "desc" }}
-{{- $latest   := (index ($versions) 0).Name }}
+{{- $latest   := .Site.Params.latest }}
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode }}">
   <head>

--- a/themes/jaeger-docs/layouts/index.html
+++ b/themes/jaeger-docs/layouts/index.html
@@ -11,7 +11,7 @@
 {{- end }}
 {{- $newestNewsletter := index $newsletters 0 }}
 
-{{ partial "home/hero.html" (dict "newestNewsletter" $newestNewsletter "posts" $posts "title" .Site.Title "tagline" .Site.Params.tagline) }}
+{{ partial "home/hero.html" (dict "newestNewsletter" $newestNewsletter "posts" $posts "title" .Site.Title "tagline" .Site.Params.tagline "latestVersion" .Site.Params.latest) }}
 {{ partial "home/why.html" . }}
 {{ partial "home/features.html" . }}
 {{ partial "home/articles.html" (dict "posts" $posts) }}

--- a/themes/jaeger-docs/layouts/partials/home/hero.html
+++ b/themes/jaeger-docs/layouts/partials/home/hero.html
@@ -1,5 +1,3 @@
-{{- $versions        := sort (readDir "content/docs") "Name" "desc" }}
-{{- $latest          := (index ($versions) 0).Name }}
 {{- $newsletterLink  := .newestNewsletter.link }}
 {{- $newsletterTitle := .newestNewsletter.title }}
 <section class="hero hero--home is-info is-medium">
@@ -17,7 +15,7 @@
 
           <div class="container">
             <div class="buttons is-centered">
-              <a href="/docs/{{ $latest }}/getting-started" class="button is-medium is-primary is-uppercase is-outlined has-text-weight-bold">
+              <a href="/docs/{{ .latestVersion }}/getting-started" class="button is-medium is-primary is-uppercase is-outlined has-text-weight-bold">
                 <span class="icon">
                   <i class="fas fa-play-circle"></i>
                 </span>

--- a/themes/jaeger-docs/layouts/shortcodes/dockerImages.html
+++ b/themes/jaeger-docs/layouts/shortcodes/dockerImages.html
@@ -1,6 +1,5 @@
 {{- $dockerImages := .Site.Data.download.docker }}
-{{- $versions     := sort (readDir "content/docs") "Name" "desc" }}
-{{- $latest       := (index ($versions) 0).Name }}
+{{- $latest       := .Site.Params.latest }}
 <table>
   <thead>
     <tr>


### PR DESCRIPTION
Since release of 1.10 some of the pages were still pointing to 1.9 due to the use of readDir / sort.