### PR TITLE
Use gprc reporter by default

### DIFF
--- a/content/docs/next-release/deployment.md
+++ b/content/docs/next-release/deployment.md
@@ -85,20 +85,17 @@ docker run \
   -p6832:6832/udp \
   -p5778:5778/tcp \
   jaegertracing/jaeger-agent:{{< currentVersion >}} \
-  --reporter.tchannel.host-port=jaeger-collector.jaeger-infra.svc:14267
+  --reporter.grpc.host-port=jaeger-collector.jaeger-infra.svc:14250
 ```
 
-Or add `--reporter.type=grpc` and `--reporter.grpc.host-port=jaeger-collector.jaeger-infra.svc:14250` to use gRPC
-communication with the collector. Then the `tchannel` option can be removed.
+Or use `--reporter.tchannel.host-port=jaeger-collector.jaeger-infra.svc:14267` to use
+legacy tchannel reporter.
 
 When using gRPC, you have several options for load balancing and name resolution:
 
 * Single connection and no load balancing. This is the default if you specify a single `host:port`. (example: `--reporter.grpc.host-port=jaeger-collector.jaeger-infra.svc:14250`)
 * Static list of hostnames and round-robin load balancing. This is what you get with a comma-separated list of addresses. (example: `reporter.grpc.host-port=jaeger-collector1:14250,jaeger-collector2:14250,jaeger-collector3:14250`)
 * Dynamic DNS resolution and round-robin load balancing. To get this behaviour, prefix the address with `dns:///` and gRPC will attempt to resolve the hostname using SRV records (for [external load balancing](https://github.com/grpc/grpc/blob/master/doc/load-balancing.md)), TXT records (for [service configs](https://github.com/grpc/grpc/blob/master/doc/service_config.md)), and A records. Refer to the [gRPC Name Resolution docs](https://github.com/grpc/grpc/blob/master/doc/naming.md) and the [dns_resolver.go implementation](https://github.com/grpc/grpc-go/blob/master/resolver/dns/dns_resolver.go) for more info. (example: `--reporter.grpc.host-port=dns:///jaeger-collector.jaeger-infra.svc:14250`)
-
-In the future we will support different service discovery systems to dynamically load balance
-across several collectors ([issue 213](https://github.com/jaegertracing/jaeger/issues/213)).
 
 
 ## Collectors


### PR DESCRIPTION
Preparing for 1.11

Signed-off-by: Pavol Loffay <ploffay@redhat.com>
