### PR TITLE
Remove redundant canonical tag

### DIFF
--- a/themes/jaeger-docs/layouts/partials/meta.html
+++ b/themes/jaeger-docs/layouts/partials/meta.html
@@ -7,15 +7,14 @@
 {{- $imageUrl := printf "%s/%s" site.BaseURL site.Params.openGraphImage }}
 <meta charset="utf-8" />
 <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
-{{- with $description }}<meta nam="description" content="{{ . }}" />{{- end }}
-<link rel="canonical" content="{{ .Permalink }}" />
+{{- with $description }}<meta name="description" content="{{ . }}" />{{- end }}
 {{ hugo.Generator }}
 
 <!-- OpenGraph metadata -->
 <meta property="og:title" content="{{ $title }}" />
 {{- if $isDoc }}
 {{- $version := index (split .File.Path "/") 1 }}
-{{- $latest := .Site.Params.latest }}
+{{- $latest := site.Params.latest }}
 {{- $url := replace .Permalink $version "latest" }}
 <meta property="og:type" content="documentation" />
 <meta property="og:url" content="{{ $url }}" />


### PR DESCRIPTION
I think this was inadvertently added during a merge.

cc @yurishkuro