### PR TITLE
Fixed page title for single pages

### DIFF
--- a/themes/jaeger-docs/layouts/_default/single.html
+++ b/themes/jaeger-docs/layouts/_default/single.html
@@ -1,5 +1,5 @@
 {{- define "title" }}
-Jaeger &ndash; Download
+Jaeger &ndash; {{ .Title }}
 {{- end }}
 
 {{ define "main" }}


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Which problem is this PR solving?

The HTML title tag is wrong for single-pages. It's always "Jaeger - Downloads", when it should use the page's "Title" property:

![image](https://user-images.githubusercontent.com/13387/55867224-616e3780-5b82-11e9-8cca-8785493d547c.png)

