### PR TITLE
Provide link to branding site

### DIFF
--- a/themes/jaeger-docs/layouts/partials/navbar.html
+++ b/themes/jaeger-docs/layouts/partials/navbar.html
@@ -88,6 +88,10 @@
               Roadmap
             </a>
 
+            <a class="navbar-item" href="https://branding.cncf.io/projects/jaeger">
+              Branding
+            </a>
+
             <a class="navbar-item" href="/report-security-issue">
               Report security issue
             </a>


### PR DESCRIPTION
This PR provides a link to the new [branding page](https://branding.cncf.io/projects/jaeger) for Jaeger.