### PR TITLE
Reference jaeger operator in features/cloud native section

### DIFF
--- a/content/docs/1.11/features.md
+++ b/content/docs/1.11/features.md
@@ -39,8 +39,8 @@ improvements have been released in v1.0 to allow the UI to efficiently deal with
 ## Cloud Native Deployment
 
 Jaeger backend is distributed as a collection of Docker images. The binaries support various configuration methods,
-including command line options, environment variables, and configuration files in multiple formats (yaml, toml, etc.)
-Deployment to Kubernetes clusters is assisted by [Kubernetes templates](https://github.com/jaegertracing/jaeger-kubernetes)
+including command line options, environment variables, and configuration files in multiple formats (yaml, toml, etc.).
+Deployment to Kubernetes clusters is assisted by a [Kubernetes operator](https://github.com/jaegertracing/jaeger-operator), [Kubernetes templates](https://github.com/jaegertracing/jaeger-kubernetes)
 and a [Helm chart](https://github.com/kubernetes/charts/tree/master/incubator/jaeger).
 
 ## Observability

--- a/content/docs/next-release/features.md
+++ b/content/docs/next-release/features.md
@@ -39,8 +39,8 @@ improvements have been released in v1.0 to allow the UI to efficiently deal with
 ## Cloud Native Deployment
 
 Jaeger backend is distributed as a collection of Docker images. The binaries support various configuration methods,
-including command line options, environment variables, and configuration files in multiple formats (yaml, toml, etc.)
-Deployment to Kubernetes clusters is assisted by [Kubernetes templates](https://github.com/jaegertracing/jaeger-kubernetes)
+including command line options, environment variables, and configuration files in multiple formats (yaml, toml, etc.).
+Deployment to Kubernetes clusters is assisted by a [Kubernetes operator](https://github.com/jaegertracing/jaeger-operator), [Kubernetes templates](https://github.com/jaegertracing/jaeger-kubernetes)
 and a [Helm chart](https://github.com/kubernetes/charts/tree/master/incubator/jaeger).
 
 ## Observability


### PR DESCRIPTION
Signed-off-by: Gary Brown <gary@brownuk.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Referencing the jaeger operator in the features/cloud native deployment section - currently only mentions templates and helm chart.

## Short description of the changes
Added link to the jaeger-operator repo.
