### PR TITLE
Fix port numbers for monitoring endpoints

### DIFF
--- a/content/docs/1.12/monitoring.md
+++ b/content/docs/1.12/monitoring.md
@@ -17,10 +17,10 @@ Each Jaeger component exposes the metrics scraping endpoint on one of the HTTP p
 
 Component             | Port
 --------------------- | ---
-**jaeger-agent**      | 5778
-**jaeger-collector**  | 14268
-**jaeger-query**      | 16686
-**jaeger-ingester**   | 14271
+**jaeger-agent**      | 14271
+**jaeger-collector**  | 14269
+**jaeger-query**      | 16687
+**jaeger-ingester**   | 14270
 
 ## Logging
 

--- a/content/docs/next-release/monitoring.md
+++ b/content/docs/next-release/monitoring.md
@@ -17,10 +17,10 @@ Each Jaeger component exposes the metrics scraping endpoint on one of the HTTP p
 
 Component             | Port
 --------------------- | ---
-**jaeger-agent**      | 5778
-**jaeger-collector**  | 14268
-**jaeger-query**      | 16686
-**jaeger-ingester**   | 14271
+**jaeger-agent**      | 14271
+**jaeger-collector**  | 14269
+**jaeger-query**      | 16687
+**jaeger-ingester**   | 14270
 
 ## Logging
 


### PR DESCRIPTION
Signed-off-by: mwieczorek <wieczorek-michal@wp.pl>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
`/metrics` are exposed on different ports than in docs.

## Short description of the changes
Changed port numbers 
