### PR TITLE
Fix terminology - change from "snake-case" to "kebab-case"

### DIFF
--- a/content/docs/1.10/client-libraries.md
+++ b/content/docs/1.10/client-libraries.md
@@ -113,7 +113,7 @@ When `SpanContext` is encoded on the wire as part of the request to another serv
 
 * Key: `uberctx-{baggage-key}`
 * Value: url-encoded string
-* Limitation: since HTTP headers don’t preserve the case, Jaeger recommends baggage keys to be lowercase-snake-case,
+* Limitation: since HTTP headers don’t preserve the case, Jaeger recommends baggage keys to be lowercase-kebab-case,
 e.g. `my-baggage-key-1`.
 
 

--- a/content/docs/1.11/client-libraries.md
+++ b/content/docs/1.11/client-libraries.md
@@ -113,7 +113,7 @@ When `SpanContext` is encoded on the wire as part of the request to another serv
 
 * Key: `uberctx-{baggage-key}`
 * Value: url-encoded string
-* Limitation: since HTTP headers don’t preserve the case, Jaeger recommends baggage keys to be lowercase-snake-case,
+* Limitation: since HTTP headers don’t preserve the case, Jaeger recommends baggage keys to be lowercase-kebab-case,
 e.g. `my-baggage-key-1`.
 
 

--- a/content/docs/1.12/client-libraries.md
+++ b/content/docs/1.12/client-libraries.md
@@ -113,7 +113,7 @@ When `SpanContext` is encoded on the wire as part of the request to another serv
 
 * Key: `uberctx-{baggage-key}`
 * Value: url-encoded string
-* Limitation: since HTTP headers don’t preserve the case, Jaeger recommends baggage keys to be lowercase-snake-case,
+* Limitation: since HTTP headers don’t preserve the case, Jaeger recommends baggage keys to be lowercase-kebab-case,
 e.g. `my-baggage-key-1`.
 
 

--- a/content/docs/1.6/client-libraries.md
+++ b/content/docs/1.6/client-libraries.md
@@ -113,7 +113,7 @@ When `SpanContext` is encoded on the wire as part of the request to another serv
 
 * Key: `uberctx-{baggage-key}`
 * Value: url-encoded string
-* Limitation: since HTTP headers don’t preserve the case, Jaeger recommends baggage keys to be lowercase-snake-case,
+* Limitation: since HTTP headers don’t preserve the case, Jaeger recommends baggage keys to be lowercase-kebab-case,
 e.g. `my-baggage-key-1`.
 
 

--- a/content/docs/1.7/client-libraries.md
+++ b/content/docs/1.7/client-libraries.md
@@ -113,7 +113,7 @@ When `SpanContext` is encoded on the wire as part of the request to another serv
 
 * Key: `uberctx-{baggage-key}`
 * Value: url-encoded string
-* Limitation: since HTTP headers don’t preserve the case, Jaeger recommends baggage keys to be lowercase-snake-case,
+* Limitation: since HTTP headers don’t preserve the case, Jaeger recommends baggage keys to be lowercase-kebab-case,
 e.g. `my-baggage-key-1`.
 
 

--- a/content/docs/1.8/client-libraries.md
+++ b/content/docs/1.8/client-libraries.md
@@ -113,7 +113,7 @@ When `SpanContext` is encoded on the wire as part of the request to another serv
 
 * Key: `uberctx-{baggage-key}`
 * Value: url-encoded string
-* Limitation: since HTTP headers don’t preserve the case, Jaeger recommends baggage keys to be lowercase-snake-case,
+* Limitation: since HTTP headers don’t preserve the case, Jaeger recommends baggage keys to be lowercase-kebab-case,
 e.g. `my-baggage-key-1`.
 
 

--- a/content/docs/1.9/client-libraries.md
+++ b/content/docs/1.9/client-libraries.md
@@ -113,7 +113,7 @@ When `SpanContext` is encoded on the wire as part of the request to another serv
 
 * Key: `uberctx-{baggage-key}`
 * Value: url-encoded string
-* Limitation: since HTTP headers don’t preserve the case, Jaeger recommends baggage keys to be lowercase-snake-case,
+* Limitation: since HTTP headers don’t preserve the case, Jaeger recommends baggage keys to be lowercase-kebab-case,
 e.g. `my-baggage-key-1`.
 
 

--- a/content/docs/next-release/client-libraries.md
+++ b/content/docs/next-release/client-libraries.md
@@ -113,7 +113,7 @@ When `SpanContext` is encoded on the wire as part of the request to another serv
 
 * Key: `uberctx-{baggage-key}`
 * Value: url-encoded string
-* Limitation: since HTTP headers don’t preserve the case, Jaeger recommends baggage keys to be lowercase-snake-case,
+* Limitation: since HTTP headers don’t preserve the case, Jaeger recommends baggage keys to be lowercase-kebab-case,
 e.g. `my-baggage-key-1`.
 
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Using wrong terminology for case styles

## Short description of the changes
- Change "snake-case" to "kebab-case"

The difference is:
  kebab-case vs. snake_case

See: https://en.wikipedia.org/wiki/Letter_case#Special_case_styles