### PR TITLE
Link NGINX to its website

### DIFF
--- a/content/docs/1.13/deployment.md
+++ b/content/docs/1.13/deployment.md
@@ -349,7 +349,7 @@ docker run \
 ## Query Service & UI
 
 **jaeger-query** serves the API endpoints and a React/Javascript UI.
-The service is stateless and is typically run behind a load balancer, such as **nginx**.
+The service is stateless and is typically run behind a load balancer, such as [**NGINX**](https://www.nginx.com/).
 
 At default settings the query service exposes the following port(s):
 

--- a/content/docs/next-release/deployment.md
+++ b/content/docs/next-release/deployment.md
@@ -349,7 +349,7 @@ docker run \
 ## Query Service & UI
 
 **jaeger-query** serves the API endpoints and a React/Javascript UI.
-The service is stateless and is typically run behind a load balancer, such as **nginx**.
+The service is stateless and is typically run behind a load balancer, such as [**NGINX**](https://www.nginx.com/).
 
 At default settings the query service exposes the following port(s):
 


### PR DESCRIPTION
I got an email from "Got.Media", asking to add a link to NGINX' website from the `Deployment` page, where we mention them. I think it's a fair request.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
