### PR TITLE
Add link patterns info to docs

### DIFF
--- a/content/docs/1.13/frontend-ui.md
+++ b/content/docs/1.13/frontend-ui.md
@@ -41,19 +41,33 @@ An example configuration file:
         }
       ]
     }
-  ]
+  ],
+  "linkPatterns": [{
+    "type": "process",
+    "key": "jaeger.version",
+    "url": "https://github.com/jaegertracing/jaeger-client-java/releases/tag/#{jaeger.version}",
+    "text": "Information about Jaeger release #{jaeger.version}"
+  }]
 }
 ```
+
+### Dependencies
 
 `dependencies.dagMaxNumServices` defines the maximum number of services allowed before the DAG dependency view is disabled. Default: `200`.
 
 `dependencies.menuEnabled` enables (`true`) or disables (`false`) the dependencies menu button. Default: `true`.
 
+### Archive Support
+
 `archiveEnabled` enables (`true`) or disables (`false`) the archive traces button. Default: `false`. It requires a configuration of an archive storage in Query service. Archived traces are only accessible directly by ID, they are not searchable.
+
+### Google Analytics Tracking
 
 `tracking.gaID` defines the Google Analytics tracking ID. This is required for Google Analytics tracking, and setting it to a non-`null` value enables Google Analytics tracking. Default: `null`.
 
 `tracking.trackErrors` enables (`true`) or disables (`false`) error tracking via Google Analytics. Errors can only be tracked if a valid Google Analytics ID is provided. For additional details on error tracking via Google Analytics see the [tracking README](https://github.com/jaegertracing/jaeger-ui/blob/c622330546afc1be59a42f874bcc1c2fadf7e69a/src/utils/tracking/README.md) in the UI repo. Default: `true`.
+
+### Custom Menu Items
 
 `menu` allows additional links to be added to the global nav. The additional links are right-aligned.
 
@@ -76,6 +90,19 @@ Links can either be members of the `menu` Array, directly, or they can be groupe
 ```
 
 The `items` Array should contain one or more link configurations.
+
+### Link Patterns
+
+The `linkPatterns` node can be used to create links from tag values displayed in the Jaeger UI.
+
+Field | Description
+------|------------
+type  | The metadata section in which your link will be added: process, tags, logs
+key   | The name of tag/process/log attribute which value will be displayed as a link
+url   | The URL where the link should point to, it can be an external site or relative path in Jaeger UI
+text  | The text displayed in the tooltip for the link
+
+Both `url` and `text` can be defined as templates where Jaeger UI will dynamically substitute values based on tags/logs data.
 
 ## Embedded Mode
 

--- a/content/docs/1.13/frontend-ui.md
+++ b/content/docs/1.13/frontend-ui.md
@@ -93,7 +93,7 @@ The `items` Array should contain one or more link configurations.
 
 ### Link Patterns
 
-The `linkPatterns` node can be used to create links from tag values displayed in the Jaeger UI.
+The `linkPatterns` node can be used to create links from fields displayed in the Jaeger UI.
 
 Field | Description
 ------|------------

--- a/content/docs/1.13/frontend-ui.md
+++ b/content/docs/1.13/frontend-ui.md
@@ -102,7 +102,7 @@ key   | The name of tag/process/log attribute which value will be displayed as a
 url   | The URL where the link should point to, it can be an external site or relative path in Jaeger UI
 text  | The text displayed in the tooltip for the link
 
-Both `url` and `text` can be defined as templates where Jaeger UI will dynamically substitute values based on tags/logs data.
+Both `url` and `text` can be defined as templates (i.e. using `#{field-name}`) where Jaeger UI will dynamically substitute values based on tags/logs data.
 
 ## Embedded Mode
 

--- a/content/docs/1.13/operator.md
+++ b/content/docs/1.13/operator.md
@@ -478,7 +478,7 @@ To apply UI configuration changes within the Custom Resource, the same informati
       options:
         dependencies:
           menuEnabled: false
-        tracking: 
+        tracking:
           gaID: UA-000000-2
         menu:
         - label: "About Jaeger"

--- a/content/docs/1.13/operator.md
+++ b/content/docs/1.13/operator.md
@@ -467,6 +467,31 @@ The secrets are available as environment variables in the (Collector/Query/All-I
 
 The secret itself would be managed outside of the `jaeger-operator` custom resource.
 
+## Configuring the UI
+
+Information on various configuration options for the UI can be found [here](../frontend-ui/#configuration), defined in json format.
+
+To apply UI configuration changes within the Custom Resource, the same information can be included in yaml format as shown below:
+
+```yaml
+    ui:
+      options:
+        dependencies:
+          menuEnabled: false
+        tracking: 
+          gaID: UA-000000-2
+        menu:
+        - label: "About Jaeger"
+          items:
+            - label: "Documentation"
+              url: "https://www.jaegertracing.io/docs/latest"
+        linkPatterns:
+        - type: "logs"
+          key: "customer_id"
+          url: /search?limit=20&lookback=1h&service=frontend&tags=%7B%22customer_id%22%3A%22#{customer_id}%22%7D
+          text: "Search for other traces for customer_id=#{customer_id}"
+```
+
 ## Defining Sampling Strategies
 
 {{< info >}}

--- a/content/docs/next-release/frontend-ui.md
+++ b/content/docs/next-release/frontend-ui.md
@@ -41,19 +41,33 @@ An example configuration file:
         }
       ]
     }
-  ]
+  ],
+  "linkPatterns": [{
+    "type": "process",
+    "key": "jaeger.version",
+    "url": "https://github.com/jaegertracing/jaeger-client-java/releases/tag/#{jaeger.version}",
+    "text": "Information about Jaeger release #{jaeger.version}"
+  }]
 }
 ```
+
+### Dependencies
 
 `dependencies.dagMaxNumServices` defines the maximum number of services allowed before the DAG dependency view is disabled. Default: `200`.
 
 `dependencies.menuEnabled` enables (`true`) or disables (`false`) the dependencies menu button. Default: `true`.
 
+### Archive Support
+
 `archiveEnabled` enables (`true`) or disables (`false`) the archive traces button. Default: `false`. It requires a configuration of an archive storage in Query service. Archived traces are only accessible directly by ID, they are not searchable.
+
+### Google Analytics Tracking
 
 `tracking.gaID` defines the Google Analytics tracking ID. This is required for Google Analytics tracking, and setting it to a non-`null` value enables Google Analytics tracking. Default: `null`.
 
 `tracking.trackErrors` enables (`true`) or disables (`false`) error tracking via Google Analytics. Errors can only be tracked if a valid Google Analytics ID is provided. For additional details on error tracking via Google Analytics see the [tracking README](https://github.com/jaegertracing/jaeger-ui/blob/c622330546afc1be59a42f874bcc1c2fadf7e69a/src/utils/tracking/README.md) in the UI repo. Default: `true`.
+
+### Custom Menu Items
 
 `menu` allows additional links to be added to the global nav. The additional links are right-aligned.
 
@@ -76,6 +90,19 @@ Links can either be members of the `menu` Array, directly, or they can be groupe
 ```
 
 The `items` Array should contain one or more link configurations.
+
+### Link Patterns
+
+The `linkPatterns` node can be used to create links from fields displayed in the Jaeger UI.
+
+Field | Description
+------|------------
+type  | The metadata section in which your link will be added: process, tags, logs
+key   | The name of tag/process/log attribute which value will be displayed as a link
+url   | The URL where the link should point to, it can be an external site or relative path in Jaeger UI
+text  | The text displayed in the tooltip for the link
+
+Both `url` and `text` can be defined as templates (i.e. using `#{field-name}`) where Jaeger UI will dynamically substitute values based on tags/logs data.
 
 ## Embedded Mode
 

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -467,6 +467,31 @@ The secrets are available as environment variables in the (Collector/Query/All-I
 
 The secret itself would be managed outside of the `jaeger-operator` custom resource.
 
+## Configuring the UI
+
+Information on various configuration options for the UI can be found [here](../frontend-ui/#configuration), defined in json format.
+
+To apply UI configuration changes within the Custom Resource, the same information can be included in yaml format as shown below:
+
+```yaml
+    ui:
+      options:
+        dependencies:
+          menuEnabled: false
+        tracking:
+          gaID: UA-000000-2
+        menu:
+        - label: "About Jaeger"
+          items:
+            - label: "Documentation"
+              url: "https://www.jaegertracing.io/docs/latest"
+        linkPatterns:
+        - type: "logs"
+          key: "customer_id"
+          url: /search?limit=20&lookback=1h&service=frontend&tags=%7B%22customer_id%22%3A%22#{customer_id}%22%7D
+          text: "Search for other traces for customer_id=#{customer_id}"
+```
+
 ## Defining Sampling Strategies
 
 {{< info >}}


### PR DESCRIPTION
Signed-off-by: Gary Brown <gary@brownuk.com>

## Which problem is this PR solving?
Missing docs regarding the `linkPatterns` element in the UI configuration, as discussed in blog post: https://medium.com/@mwieczorek/custom-links-in-jaeger-ui-3479f72bb815

## Short description of the changes
Added section in frontend-ui doc and cross-referenced from the operator doc page.
