### PR TITLE
WIP Use tabs for different storage types in CLI docs

### DIFF
--- a/content/docs/1.13/cli.md
+++ b/content/docs/1.13/cli.md
@@ -10,4 +10,20 @@ This is auto-generated documentation for CLI flags supported by Jaeger binaries.
   * Some binaries support _commands_ (mostly informational), such as `env`, `docs`, and `version`. These commands are not included here.
   * All parameters can be also provided via environment variables, by changing all letters to upper-case and replacing all punctuation characters with underscore `_`. For example, the value for the flag `--cassandra.connections-per-host` can be  provided via `CASSANDRA_CONNECTIONS_PER_HOST` environment variable.
 
+{{< tabset cookie-name="cli-blah" >}}
+
+{{< tab name="default" cookie-value="default" >}}
+
+CLI flags for some binaries change depending on the `SPAN_STORAGE_TYPE` environment variable. Relevant variations are included below.
+
+{{< /tab >}}
+
+{{< tab name="demo" cookie-value="demo" >}}
+
+Some binaries support _commands_ (mostly informational), such as `env`, `docs`, and `version`. These commands are not included here.
+
+{{< /tab >}}
+
+{{< /tabset >}}
+
 {{< cli/tools-list >}}

--- a/themes/jaeger-docs/assets/js/tabset.js
+++ b/themes/jaeger-docs/assets/js/tabset.js
@@ -17,6 +17,7 @@
 //  - converted to JavaScript using http://www.typescriptlang.org/play
 //  - minor fix-ups to avoid using functions from Istio's src/ts/utils.ts
 //  - disable cookies functionality
+//  - remove keyboard navigation
 
 "use strict";
 

--- a/themes/jaeger-docs/assets/js/tabset.js
+++ b/themes/jaeger-docs/assets/js/tabset.js
@@ -1,0 +1,112 @@
+// Copyright 2019 The Jaeger Authors
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Adopted from https://github.com/istio/istio.io/blob/master/src/ts/tabset.ts
+//  - converted to JavaScript using http://www.typescriptlang.org/play
+//  - minor fix-ups to avoid using functions from Istio's src/ts/utils.ts
+//  - disable cookies functionality
+
+"use strict";
+
+const ariaSelected = "aria-selected";
+const ariaControls = "aria-controls";
+const tabIndex = "tabindex";
+
+function selectTabsets(cookieName, cookieValue) {
+    document.querySelectorAll(".tabset").forEach(tabset => {
+        tabset.querySelectorAll(".tab-strip").forEach(o => {
+            const strip = o;
+            if (strip.dataset.cookieName === cookieName) {
+                strip.querySelectorAll("[role=tab]").forEach(tab => {
+                    const attr = tab.getAttribute(ariaControls);
+                    if (!attr) {
+                        return;
+                    }
+                    const panel = document.getElementById(attr);
+                    if (!panel) {
+                        return;
+                    }
+                    if (tab.dataset.cookieValue === cookieValue) {
+                        tab.setAttribute(ariaSelected, "true");
+                        tab.removeAttribute(tabIndex);
+                        panel.removeAttribute("hidden");
+                    }
+                    else {
+                        tab.removeAttribute(ariaSelected);
+                        tab.setAttribute(tabIndex, "-1");
+                        panel.setAttribute("hidden", "");
+                    }
+                });
+            }
+        });
+    });
+}
+function handleTabs() {
+    document.querySelectorAll(".tabset").forEach(tabset => {
+        const strip = tabset.querySelector(".tab-strip");
+        if (!strip) {
+            return;
+        }
+        const cookieName = strip.dataset.cookieName;
+        const panels = tabset.querySelectorAll("[role=tabpanel]");
+        const tabs = [];
+        strip.querySelectorAll("[role=tab]").forEach(tab => {
+            tabs.push(tab);
+        });
+        function activateTab(tab) {
+            deactivateAllTabs();
+            tab.removeAttribute(tabIndex);
+            tab.setAttribute(ariaSelected, "true");
+            const ac = tab.getAttribute(ariaControls);
+            if (ac) {
+                const other = document.getElementById(ac);
+                if (other) {
+                    other.removeAttribute("hidden");
+                }
+            }
+        }
+        function deactivateAllTabs() {
+            tabs.forEach(tab => {
+                tab.setAttribute(tabIndex, "-1");
+                tab.setAttribute(ariaSelected, "false");
+            });
+            panels.forEach(panel => {
+                panel.setAttribute("hidden", "");
+            });
+        }
+        // attach the event handlers to support tab sets
+        strip.querySelectorAll("button").forEach(tab => {
+            tab.addEventListener("focus", () => {
+                activateTab(tab);
+                if (cookieName) {
+                    const cookieValue = tab.dataset.cookieValue;
+                    if (cookieValue) {
+                        selectTabsets(cookieName, cookieValue);
+                    }
+                }
+            });
+            tab.addEventListener("click", () => {
+                activateTab(tab);
+                if (cookieName) {
+                    const cookieValue = tab.dataset.cookieValue;
+                    if (cookieValue) {
+                        selectTabsets(cookieName, cookieValue);
+                    }
+                }
+            });
+        });
+    });
+}
+handleTabs();

--- a/themes/jaeger-docs/assets/sass/style.sass
+++ b/themes/jaeger-docs/assets/sass/style.sass
@@ -13,6 +13,7 @@
 @import "pages"
 @import "syntax"
 @import "toc"
+@import "tabset"
 
 @import "bulma-tooltip/dist/css/bulma-tooltip"
 @import "latest-articles"

--- a/themes/jaeger-docs/assets/sass/tabset.scss
+++ b/themes/jaeger-docs/assets/sass/tabset.scss
@@ -1,0 +1,64 @@
+.tabset {
+    padding: 0;
+
+    margin: 1em 0 1em 1em;
+    // @media (min-width: $bp-md) {
+    //     margin: 1em;
+    // }
+
+    .tab-strip {
+        button {
+            display: inline-block;
+            margin: 0 3px;
+            border: 1px solid $tabsetBorderColor;
+            border-bottom: 0;
+            border-top-left-radius: $border-radius;
+            border-top-right-radius: $border-radius;
+            padding: 0 1rem;
+            transform: skewX(-20deg);
+            transform-origin: left bottom;
+            cursor: pointer;
+            outline: 0;
+            font: inherit;
+            background-color: $tabsetUnselectedTabBackgroundColor;
+
+            span {
+                transform: skewX(6deg);
+                color: $tabsetUnselectedTabTextColor;
+                font-size: 80%;
+            }
+
+            &:hover, &:focus {
+                span {
+                    color: $link;
+                }
+            }
+
+            &[aria-selected=true] {
+                background-color: $tabsetSelectedTabBackgroundColor;
+                cursor: default;
+                box-shadow: none;
+                border-bottom: solid 2px $dark;
+
+                span {
+                    color: $tabsetSelectedTabTextColor;
+                }
+            }
+        }
+    }
+
+    .tab-content {
+        border: 1px solid $tabsetBorderColor;
+        border-radius: $border-radius;
+        padding: 1rem;
+        box-shadow: 3px 3px 8px $tabsetShadowColor;
+
+        p:first-of-type {
+            margin-top: 0;
+        }
+
+        p:last-of-type {
+            margin-bottom: 0;
+        }
+    }
+}

--- a/themes/jaeger-docs/assets/sass/tabset.scss
+++ b/themes/jaeger-docs/assets/sass/tabset.scss
@@ -1,10 +1,8 @@
+// Adopted from https://github.com/istio/istio.io
 .tabset {
     padding: 0;
 
     margin: 1em 0 1em 1em;
-    // @media (min-width: $bp-md) {
-    //     margin: 1em;
-    // }
 
     .tab-strip {
         button {

--- a/themes/jaeger-docs/assets/sass/variables.sass
+++ b/themes/jaeger-docs/assets/sass/variables.sass
@@ -30,3 +30,12 @@ $dropdown-content-padding-bottom: 0
 
 /* Syntax highlighting theme colors */
 $syntax-magenta: #f92672
+
+/* Tab Set colors */
+$border-radius: 4px;
+$tabsetBorderColor: #f2f2f2;
+$tabsetShadowColor: #a7a7a7;
+$tabsetUnselectedTabTextColor: black;
+$tabsetUnselectedTabBackgroundColor: #ffffff;
+$tabsetSelectedTabTextColor: $jaeger-teal;
+$tabsetSelectedTabBackgroundColor: #eeeeff;

--- a/themes/jaeger-docs/layouts/partials/javascript.html
+++ b/themes/jaeger-docs/layouts/partials/javascript.html
@@ -1,6 +1,6 @@
 <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
 <script defer src="https://use.fontawesome.com/releases/v5.0.7/js/all.js"></script>
-{{- $jsFiles := (slice "jquery-ui-1.9.1.custom.min.js" "anchor.min.js" "tocbot.min.js" "app.js" "lunr-2.3.6.min.js") }}
+{{- $jsFiles := (slice "jquery-ui-1.9.1.custom.min.js" "anchor.min.js" "tocbot.min.js" "app.js" "tabset.js" "lunr-2.3.6.min.js") }}
 {{- range $jsFiles }}
 {{- $js := resources.Get (printf "js/%s" .) | minify | fingerprint }}
 <script src="{{ $js.Permalink }}" integrity="{{ $js.Data.Integrity }}"></script>

--- a/themes/jaeger-docs/layouts/shortcodes/tab.html
+++ b/themes/jaeger-docs/layouts/shortcodes/tab.html
@@ -1,3 +1,4 @@
+{{- /* Adopted from https://github.com/istio/istio.io */ -}}
 {{- if .Parent -}}
     {{- $name := trim (.Get "name") " " -}}
     {{- $cookie_value := trim (.Get "cookie-value") " " -}}

--- a/themes/jaeger-docs/layouts/shortcodes/tab.html
+++ b/themes/jaeger-docs/layouts/shortcodes/tab.html
@@ -1,0 +1,10 @@
+{{- if .Parent -}}
+    {{- $name := trim (.Get "name") " " -}}
+    {{- $cookie_value := trim (.Get "cookie-value") " " -}}
+    {{- if not (.Parent.Scratch.Get "tabs") -}}
+        {{- .Parent.Scratch.Set "tabs" slice -}}
+    {{- end -}}
+    {{- $.Parent.Scratch.Add "tabs" (dict "name" $name "cookie_value" $cookie_value "content" .Inner) -}}
+{{- else -}}
+    {{- errorf "Missing surrounding tabset for tab (%s)" .Position -}}
+{{- end -}}

--- a/themes/jaeger-docs/layouts/shortcodes/tabset.html
+++ b/themes/jaeger-docs/layouts/shortcodes/tabset.html
@@ -1,3 +1,4 @@
+{{- /* Adopted from https://github.com/istio/istio.io */ -}}
 {{- .Page.Scratch.Add "tabset-counter" 1 -}}
 {{- $tab_set_id := default (printf "tabset-%s-%d" (.Page.RelPermalink) (.Page.Scratch.Get "tabset-counter") ) | anchorize -}}
 {{- $tabs := .Scratch.Get "tabs" -}}

--- a/themes/jaeger-docs/layouts/shortcodes/tabset.html
+++ b/themes/jaeger-docs/layouts/shortcodes/tabset.html
@@ -1,0 +1,28 @@
+{{- .Page.Scratch.Add "tabset-counter" 1 -}}
+{{- $tab_set_id := default (printf "tabset-%s-%d" (.Page.RelPermalink) (.Page.Scratch.Get "tabset-counter") ) | anchorize -}}
+{{- $tabs := .Scratch.Get "tabs" -}}
+{{- $cookie_name := trim (.Get "cookie-name") " " -}}
+
+{{- if .Inner -}}
+    {{- /* We don't use the inner content, but Hugo needs this reference as a trigger
+           to indicate this shortcode has a content area. */ -}}
+{{- end -}}
+
+<div id="{{ $tab_set_id }}" role="tablist" class="tabset">
+    <div class="tab-strip" data-cookie-name="{{ $cookie_name }}">
+        {{- range $i, $e := $tabs -}}
+            {{- $id := printf "%s-%d" $tab_set_id $i -}}
+            <button {{ if eq $i 0 }}aria-selected="true"{{ else }}tabindex="-1"{{ end }} data-cookie-value="{{ .cookie_value }}"
+                aria-controls="{{ $id }}-panel" id="{{ $id }}-tab" role="tab"><span>{{ trim .name " " }}</span>
+            </button>
+        {{- end -}}
+    </div>
+    <div class="tab-content">
+        {{- range $i, $e := $tabs -}}
+            {{- $id := printf "%s-%d" $tab_set_id $i -}}
+            <div{{ if ne $i 0 }} hidden{{ end }} id="{{ $id }}-panel" role="tabpanel" tabindex="0" aria-labelledby="{{ $id }}-tab">
+                {{- .content | markdownify -}}
+            </div>
+        {{- end -}}
+    </div>
+</div>


### PR DESCRIPTION
Resolves #267 

Adopted tabs shortcodes from Istio docs and added a sample to CLI page.

Open question: CLI pages is rendered with shortcodes, and tabs are also shortcodes, which cannot be nested this way. Need to find a better way to integrate them.

cc @lucperkins 