### PR TITLE
Update ports

### DIFF
--- a/content/docs/1.12/deployment.md
+++ b/content/docs/1.12/deployment.md
@@ -49,12 +49,13 @@ Command line option                | Environment variable
 Jaeger client libraries expect **jaeger-agent** process to run locally on each host.
 The agent exposes the following ports:
 
-Port | Protocol | Function
----- | -------  | ---
-6831 | UDP      | accept [jaeger.thrift][jaeger-thrift] in `compact` Thrift protocol used by most current Jaeger clients
-6832 | UDP      | accept [jaeger.thrift][jaeger-thrift] in `binary` Thrift protocol used by Node.js Jaeger client (because [thriftrw][thriftrw] npm package does not support `compact` protocol)
-5778 | HTTP     | serve configs, sampling strategies
-5775 | UDP      | accept [zipkin.thrift][zipkin-thrift] in `compact` Thrift protocol (deprecated; only used by very old Jaeger clients, circa 2016)
+Port  | Protocol | Function
+----- | -------  | ---
+6831  | UDP      | accept [jaeger.thrift][jaeger-thrift] in `compact` Thrift protocol used by most current Jaeger clients
+6832  | UDP      | accept [jaeger.thrift][jaeger-thrift] in `binary` Thrift protocol used by Node.js Jaeger client (because [thriftrw][thriftrw] npm package does not support `compact` protocol)
+5778  | HTTP     | serve configs, sampling strategies
+5775  | UDP      | accept [zipkin.thrift][zipkin-thrift] in `compact` Thrift protocol (deprecated; only used by very old Jaeger clients, circa 2016)
+14271 | HTTP     | Healthcheck at `/` and metrics at `/metrics`
 
 It can be executed directly on the host or via Docker, as follows:
 
@@ -127,7 +128,7 @@ Port  | Protocol | Function
 14250 | gRPC     | used by **jaeger-agent** to send spans in model.proto format
 14268 | HTTP     | can accept spans directly from clients in jaeger.thrift format over binary thrift protocol
 9411  | HTTP     | can accept Zipkin spans in JSON or Thrift (disabled by default)
-14269 | HTTP     | Health check at **/**
+14269 | HTTP     | Healthcheck at `/` and metrics at `/metrics`
 
 
 ## Storage Backends
@@ -334,8 +335,7 @@ docker run \
 
 Port  | Protocol | Function
 ----- | -------  | ---
-14270 | HTTP     | Health check at **/**
-14271 | HTTP     | Metrics endpoint
+14270 | HTTP     | Healthcheck at `/` and metrics at `/metrics`
 
 To view all exposed configuration options run the following command:
 ```sh
@@ -354,8 +354,8 @@ At default settings the query service exposes the following port(s):
 
 Port  | Protocol | Function
 ----- | -------  | ---
-16686 | HTTP     | **/api/*** endpoints and Jaeger UI at **/**
-16687 | HTTP     | Health check at **/**
+16686 | HTTP     | `/api/*` endpoints and Jaeger UI at `/`
+16687 | HTTP     | Healthcheck at `/` and metrics at `/metrics`
 
 ### Minimal deployment example (Elasticsearch backend):
 ```sh

--- a/content/docs/1.13/deployment.md
+++ b/content/docs/1.13/deployment.md
@@ -54,12 +54,13 @@ Command line option                | Environment variable
 Jaeger client libraries expect **jaeger-agent** process to run locally on each host.
 The agent exposes the following ports:
 
-Port | Protocol | Function
----- | -------  | ---
-6831 | UDP      | accept [jaeger.thrift][jaeger-thrift] in `compact` Thrift protocol used by most current Jaeger clients
-6832 | UDP      | accept [jaeger.thrift][jaeger-thrift] in `binary` Thrift protocol used by Node.js Jaeger client (because [thriftrw][thriftrw] npm package does not support `compact` protocol)
-5778 | HTTP     | serve configs, sampling strategies
-5775 | UDP      | accept [zipkin.thrift][zipkin-thrift] in `compact` Thrift protocol (deprecated; only used by very old Jaeger clients, circa 2016)
+Port  | Protocol | Function
+----- | -------  | ---
+6831  | UDP      | accept [jaeger.thrift][jaeger-thrift] in `compact` Thrift protocol used by most current Jaeger clients
+6832  | UDP      | accept [jaeger.thrift][jaeger-thrift] in `binary` Thrift protocol used by Node.js Jaeger client (because [thriftrw][thriftrw] npm package does not support `compact` protocol)
+5778  | HTTP     | serve configs, sampling strategies
+5775  | UDP      | accept [zipkin.thrift][zipkin-thrift] in `compact` Thrift protocol (deprecated; only used by very old Jaeger clients, circa 2016)
+14271 | HTTP     | Healthcheck at `/` and metrics at `/metrics`
 
 It can be executed directly on the host or via Docker, as follows:
 
@@ -132,7 +133,7 @@ Port  | Protocol | Function
 14250 | gRPC     | used by **jaeger-agent** to send spans in model.proto format
 14268 | HTTP     | can accept spans directly from clients in jaeger.thrift format over binary thrift protocol
 9411  | HTTP     | can accept Zipkin spans in JSON or Thrift (disabled by default)
-14269 | HTTP     | Health check at **/**
+14269 | HTTP     | Healthcheck at `/` and metrics at `/metrics`
 
 
 ## Storage Backends
@@ -340,8 +341,7 @@ docker run \
 
 Port  | Protocol | Function
 ----- | -------  | ---
-14270 | HTTP     | Health check at **/**
-14271 | HTTP     | Metrics endpoint
+14270 | HTTP     | Healthcheck at `/` and metrics at `/metrics`
 
 To view all exposed configuration options run the following command:
 ```sh
@@ -360,8 +360,8 @@ At default settings the query service exposes the following port(s):
 
 Port  | Protocol | Function
 ----- | -------  | ---
-16686 | HTTP     | **/api/*** endpoints and Jaeger UI at **/**
-16687 | HTTP     | Health check at **/**
+16686 | HTTP     | `/api/*` endpoints and Jaeger UI at `/`
+16687 | HTTP     | Healthcheck at `/` and metrics at `/metrics`
 
 ### Minimal deployment example (Elasticsearch backend):
 ```sh

--- a/content/docs/next-release/deployment.md
+++ b/content/docs/next-release/deployment.md
@@ -54,12 +54,13 @@ Command line option                | Environment variable
 Jaeger client libraries expect **jaeger-agent** process to run locally on each host.
 The agent exposes the following ports:
 
-Port | Protocol | Function
----- | -------  | ---
-6831 | UDP      | accept [jaeger.thrift][jaeger-thrift] in `compact` Thrift protocol used by most current Jaeger clients
-6832 | UDP      | accept [jaeger.thrift][jaeger-thrift] in `binary` Thrift protocol used by Node.js Jaeger client (because [thriftrw][thriftrw] npm package does not support `compact` protocol)
-5778 | HTTP     | serve configs, sampling strategies
-5775 | UDP      | accept [zipkin.thrift][zipkin-thrift] in `compact` Thrift protocol (deprecated; only used by very old Jaeger clients, circa 2016)
+Port  | Protocol | Function
+----- | -------  | ---
+6831  | UDP      | accept [jaeger.thrift][jaeger-thrift] in `compact` Thrift protocol used by most current Jaeger clients
+6832  | UDP      | accept [jaeger.thrift][jaeger-thrift] in `binary` Thrift protocol used by Node.js Jaeger client (because [thriftrw][thriftrw] npm package does not support `compact` protocol)
+5778  | HTTP     | serve configs, sampling strategies
+5775  | UDP      | accept [zipkin.thrift][zipkin-thrift] in `compact` Thrift protocol (deprecated; only used by very old Jaeger clients, circa 2016)
+14271 | HTTP     | Healthcheck at `/` and metrics at `/metrics`
 
 It can be executed directly on the host or via Docker, as follows:
 
@@ -132,7 +133,7 @@ Port  | Protocol | Function
 14250 | gRPC     | used by **jaeger-agent** to send spans in model.proto format
 14268 | HTTP     | can accept spans directly from clients in jaeger.thrift format over binary thrift protocol
 9411  | HTTP     | can accept Zipkin spans in JSON or Thrift (disabled by default)
-14269 | HTTP     | Health check at **/**
+14269 | HTTP     | Healthcheck at `/` and metrics at `/metrics`
 
 
 ## Storage Backends
@@ -340,8 +341,7 @@ docker run \
 
 Port  | Protocol | Function
 ----- | -------  | ---
-14270 | HTTP     | Health check at **/**
-14271 | HTTP     | Metrics endpoint
+14270 | HTTP     | Healthcheck at `/` and metrics at `/metrics`
 
 To view all exposed configuration options run the following command:
 ```sh
@@ -360,8 +360,8 @@ At default settings the query service exposes the following port(s):
 
 Port  | Protocol | Function
 ----- | -------  | ---
-16686 | HTTP     | **/api/*** endpoints and Jaeger UI at **/**
-16687 | HTTP     | Health check at **/**
+16686 | HTTP     | `/api/*` endpoints and Jaeger UI at `/`
+16687 | HTTP     | Healthcheck at `/` and metrics at `/metrics`
 
 ### Minimal deployment example (Elasticsearch backend):
 ```sh


### PR DESCRIPTION
Fixes #293 

Healthcheck and metrics endpoints were combined on admin ports in https://github.com/jaegertracing/jaeger/pull/1442