### PR TITLE
add support to config SuccessfulJobsHistoryLimit

### DIFF
--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -389,6 +389,7 @@ storage:
     numberOfDays: 7                               // number of days to wait before deleting a record
     schedule: "55 23 * * *"                       // cron expression for it to run
     image: jaegertracing/jaeger-es-index-cleaner  // image of the job
+    successfulJobsHistoryLimit: 0                 // number of successful job will will be kept in history, support for esRollover, esIndexCleaner, dependencies.
 ```
 
 ## Auto-injecting Jaeger Agent Sidecars


### PR DESCRIPTION
## Which problem is this PR solving?
- please refer to the jaegertracing/jaeger-operator#621 for more details.

## Short description of the changes
- I add new config about setting the number of successful job will will be kept in history, which supports for esRollover, esIndexCleaner, dependencies.
