### PR TITLE
Update 128bit_trace_id from client feature matrix

### DIFF
--- a/data/clients.yaml
+++ b/data/clients.yaml
@@ -252,7 +252,7 @@ clients:
       env_JAEGER_USER: yes
       env_JAEGER_PASSWORD: yes
       env_JAEGER_PROPAGATION: no
-      128bit_trace_id: no
+      128bit_trace_id: yes
       JAEGER_TRACEID_128BIT: no
 
   - language: Python
@@ -293,8 +293,8 @@ clients:
       env_JAEGER_USER: no
       env_JAEGER_PASSWORD: no
       env_JAEGER_PROPAGATION: no
-      128bit_trace_id: no
-      JAEGER_TRACEID_128BIT: no
+      128bit_trace_id: yes
+      JAEGER_TRACEID_128BIT: yes
 
   - language: C++
     repo: jaegertracing/jaeger-client-cpp


### PR DESCRIPTION
## Which problem is this PR solving?
- https://github.com/jaegertracing/jaeger/issues/858

## Short description of the changes
- Update the matrix as Python and Node clients now have support for 128bit traceid
- https://github.com/jaegertracing/jaeger-client-python/releases/tag/v4.0.0
- https://github.com/jaegertracing/jaeger-client-node/releases/tag/v3.16.0
