### PR TITLE
Document secretName support for Ingress TLS

### DIFF
--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -547,6 +547,34 @@ This example defines a default sampling strategy that is probabilistic, with a 5
 
 Refer to the Jaeger documentation on [Collector Sampling Configuration](https://www.jaegertracing.io/docs/latest/sampling/#collector-sampling-configuration) to see how service and endpoint sampling can be configured. The JSON representation described in that documentation can be used in the operator by converting to YAML.
 
+## Configuring the Ingress
+
+By default, the operator creates an [Ingress Resource](https://kubernetes.io/docs/concepts/services-networking/ingress/) to expose the Jaeger UI. This can be disabled by setting `spec.ingress.enabled` to `false`.
+
+```yaml
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: disable-ingress
+spec:
+  ingress:
+    enabled: false
+```
+
+To enable TLS in the Ingress, pass a `secretName` with the name to a [Secret](https://kubernetes.io/docs/concepts/configuration/secret/) containing the TLS certificate:
+
+```yaml
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: ingress-with-tls
+spec:
+  ingress:
+    secretName: my-tls-secret
+```
+
+Further details on how to configure the Ingress / Route on OpenShift are documented in the [OpenShift section](#openshift).
+
 ## Finer grained configuration
 
 The custom resource can be used to define finer grained Kubernetes configuration applied to all Jaeger components or at the individual component level.

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -547,34 +547,6 @@ This example defines a default sampling strategy that is probabilistic, with a 5
 
 Refer to the Jaeger documentation on [Collector Sampling Configuration](https://www.jaegertracing.io/docs/latest/sampling/#collector-sampling-configuration) to see how service and endpoint sampling can be configured. The JSON representation described in that documentation can be used in the operator by converting to YAML.
 
-## Configuring the Ingress
-
-By default, the operator creates an [Ingress Resource](https://kubernetes.io/docs/concepts/services-networking/ingress/) to expose the Jaeger UI. This can be disabled by setting `spec.ingress.enabled` to `false`.
-
-```yaml
-apiVersion: jaegertracing.io/v1
-kind: Jaeger
-metadata:
-  name: disable-ingress
-spec:
-  ingress:
-    enabled: false
-```
-
-To enable TLS in the Ingress, pass a `secretName` with the name to a [Secret](https://kubernetes.io/docs/concepts/configuration/secret/) containing the TLS certificate:
-
-```yaml
-apiVersion: jaegertracing.io/v1
-kind: Jaeger
-metadata:
-  name: ingress-with-tls
-spec:
-  ingress:
-    secretName: my-tls-secret
-```
-
-Further details on how to configure the Ingress / Route on OpenShift are documented in the [OpenShift section](#openshift).
-
 ## Finer grained configuration
 
 The custom resource can be used to define finer grained Kubernetes configuration applied to all Jaeger components or at the individual component level.
@@ -685,6 +657,18 @@ simplest-query   *         192.168.122.34   80        3m
 ```
 
 In this example, the Jaeger UI is available at http://192.168.122.34.
+
+To enable TLS in the Ingress, pass a `secretName` with the name to a [Secret](https://kubernetes.io/docs/concepts/configuration/secret/) containing the TLS certificate:
+
+```yaml
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: ingress-with-tls
+spec:
+  ingress:
+    secretName: my-tls-secret
+```
 
 ## OpenShift
 

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -658,7 +658,7 @@ simplest-query   *         192.168.122.34   80        3m
 
 In this example, the Jaeger UI is available at http://192.168.122.34.
 
-To enable TLS in the Ingress, pass a `secretName` with the name to a [Secret](https://kubernetes.io/docs/concepts/configuration/secret/) containing the TLS certificate:
+To enable TLS in the Ingress, pass a `secretName` with the name of a [Secret](https://kubernetes.io/docs/concepts/configuration/secret/) containing the TLS certificate:
 
 ```yaml
 apiVersion: jaegertracing.io/v1


### PR DESCRIPTION
This commit adds a new section to 'Configuring the CRD' with examples on how to disable the Ingress and how to add a TLS certificate to it.

Issue #307
Relates to https://github.com/jaegertracing/jaeger-operator/pull/681

Signed-off-by: Cedric Kring <cedric@kring-online.de>