### PR TITLE
Update docs for Zipkin Proto support

### DIFF
--- a/content/docs/1.14/deployment.md
+++ b/content/docs/1.14/deployment.md
@@ -131,7 +131,7 @@ Port  | Protocol | Function
 14267 | TChannel | used by **jaeger-agent** to send spans in jaeger.thrift format
 14250 | gRPC     | used by **jaeger-agent** to send spans in model.proto format
 14268 | HTTP     | can accept spans directly from clients in jaeger.thrift format over binary thrift protocol
-9411  | HTTP     | can accept Zipkin spans in JSON or Thrift (disabled by default)
+9411  | HTTP     | can accept Zipkin spans in Thrift, JSON and Proto (disabled by default)
 14269 | HTTP     | Healthcheck at `/` and metrics at `/metrics`
 
 

--- a/content/docs/1.14/getting-started.md
+++ b/content/docs/1.14/getting-started.md
@@ -119,11 +119,11 @@ Then navigate to `http://localhost:8080`.
 
 ## Migrating from Zipkin
 
-Collector service exposes Zipkin compatible REST API `/api/v1/spans` which accepts both Thrift and JSON. Also there is `/api/v2/spans` for JSON only.
+Collector service exposes Zipkin compatible REST API `/api/v1/spans` which accepts both Thrift and JSON. Also there is `/api/v2/spans` for JSON and Proto.
 By default it's disabled. It can be enabled with `--collector.zipkin.http-port=9411`.
 
-Zipkin Thrift IDL file can be found in [jaegertracing/jaeger-idl](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/zipkincore.thrift).
-It's compatible with [openzipkin/zipkin-api](https://github.com/openzipkin/zipkin-api/blob/master/thrift/zipkinCore.thrift)
+Zipkin [Thrift](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/zipkincore.thrift) IDL and Zipkin [Proto](https://github.com/jaegertracing/jaeger-idl/blob/master/proto/zipkin.proto) IDL files can be found in [jaegertracing/jaeger-idl](https://github.com/jaegertracing/jaeger-idl) repository.
+They're compatible with [openzipkin/zipkin-api](https://github.com/openzipkin/zipkin-api) [Thrift](https://github.com/openzipkin/zipkin-api/blob/master/thrift/zipkinCore.thrift) and [Proto](https://github.com/openzipkin/zipkin-api/blob/master/zipkin.proto).
 
 [hotrod-tutorial]: https://medium.com/@YuriShkuro/take-opentracing-for-a-hotrod-ride-f6e3141f7941
 [download]: ../../../download/

--- a/content/docs/next-release/deployment.md
+++ b/content/docs/next-release/deployment.md
@@ -131,7 +131,7 @@ Port  | Protocol | Function
 14267 | TChannel | used by **jaeger-agent** to send spans in jaeger.thrift format
 14250 | gRPC     | used by **jaeger-agent** to send spans in model.proto format
 14268 | HTTP     | can accept spans directly from clients in jaeger.thrift format over binary thrift protocol
-9411  | HTTP     | can accept Zipkin spans in JSON or Thrift (disabled by default)
+9411  | HTTP     | can accept Zipkin spans in Thrift, JSON and Proto (disabled by default)
 14269 | HTTP     | Healthcheck at `/` and metrics at `/metrics`
 
 

--- a/content/docs/next-release/getting-started.md
+++ b/content/docs/next-release/getting-started.md
@@ -119,11 +119,11 @@ Then navigate to `http://localhost:8080`.
 
 ## Migrating from Zipkin
 
-Collector service exposes Zipkin compatible REST API `/api/v1/spans` which accepts both Thrift and JSON. Also there is `/api/v2/spans` for JSON only.
+Collector service exposes Zipkin compatible REST API `/api/v1/spans` which accepts both Thrift and JSON. Also there is `/api/v2/spans` for JSON and Proto.
 By default it's disabled. It can be enabled with `--collector.zipkin.http-port=9411`.
 
-Zipkin Thrift IDL file can be found in [jaegertracing/jaeger-idl](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/zipkincore.thrift).
-It's compatible with [openzipkin/zipkin-api](https://github.com/openzipkin/zipkin-api/blob/master/thrift/zipkinCore.thrift)
+Zipkin [Thrift](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/zipkincore.thrift) IDL and Zipkin [Proto](https://github.com/jaegertracing/jaeger-idl/blob/master/proto/zipkin.proto) IDL files can be found in [jaegertracing/jaeger-idl](https://github.com/jaegertracing/jaeger-idl) repository.
+They're compatible with [openzipkin/zipkin-api](https://github.com/openzipkin/zipkin-api) [Thrift](https://github.com/openzipkin/zipkin-api/blob/master/thrift/zipkinCore.thrift) and [Proto](https://github.com/openzipkin/zipkin-api/blob/master/zipkin.proto).
 
 [hotrod-tutorial]: https://medium.com/@YuriShkuro/take-opentracing-for-a-hotrod-ride-f6e3141f7941
 [download]: ../../../download/


### PR DESCRIPTION
Signed-off-by: Abhilash Gnan <abhilashgnan@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Zipkin Proto support was added in Jaeger1.14. This PR updates Getting Started docs for that.
- Refer https://github.com/jaegertracing/jaeger/pull/1695 and https://github.com/jaegertracing/jaeger/releases/tag/v1.14.0. We've missed this change in https://github.com/jaegertracing/documentation/pull/295

## Short description of the changes
- Update `1.14/getting-started.md`
