### PR TITLE
Add openshift specific permission setup in daemonset agent section

### DIFF
--- a/content/docs/1.14/operator.md
+++ b/content/docs/1.14/operator.md
@@ -80,35 +80,6 @@ oc create \
 
 After the role is granted, switch back to a non-privileged user.
 
-Jaeger Agent can be configured to be deployed as a `DaemonSet` using a `HostPort` to allow Jaeger clients in the same node to discover the agent. In OpenShift, a `HostPort` can only be set when a special security context is set. A separate service account can be used by the Jaeger Agent with the permission to bind to `HostPort`, as follows:
-
-```bash
-oc create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/examples/openshift/hostport-scc-daemonset.yaml # <1>
-oc new-project myappnamespace
-oc create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/examples/openshift/service_account_jaeger-agent-daemonset.yaml # <2>
-oc adm policy add-scc-to-user daemonset-with-hostport -z jaeger-agent-daemonset # <3>
-oc apply -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/examples/openshift/agent-as-daemonset.yaml # <4>
-```
-<1> The `SecurityContextConstraints` with the `allowHostPorts` policy
-
-<2> The `ServiceAccount` to be used by the Jaeger Agent
-
-<3> Adds the security policy to the service account
-
-<4> Creates the Jaeger Instance using the `serviceAccount` created in the steps above
-
-{{< warning >}}
-Without such a policy, errors like the following will prevent a `DaemonSet` to be created: `Warning FailedCreate 4s (x14 over 45s) daemonset-controller Error creating: pods "agent-as-daemonset-agent-daemonset-" is forbidden: unable to validate against any security context constraint: [spec.containers[0].securityContext.containers[0].hostPort: Invalid value: 5775: Host ports are not allowed to be used`
-{{< /warning >}}
-
-After a few seconds, the `DaemonSet` should be up and running:
-
-```bash
-$ oc get daemonset agent-as-daemonset-agent-daemonset
-NAME                                 DESIRED   CURRENT   READY     UP-TO-DATE   AVAILABLE
-agent-as-daemonset-agent-daemonset   1         1         1         1            1
-```
-
 # Quick Start - Deploying the AllInOne image
 
 The simplest possible way to create a Jaeger instance is by creating a YAML file like the following example.  This will install the default AllInOne strategy, which deploys the "all-in-one" image (agent, collector, query, ingestor, Jaeger UI) in a single pod, using in-memory storage by default.
@@ -502,6 +473,14 @@ oc apply -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/mast
 {{< warning >}}
 Without such a policy, errors like the following will prevent a `DaemonSet` to be created: `Warning FailedCreate 4s (x14 over 45s) daemonset-controller Error creating: pods "agent-as-daemonset-agent-daemonset-" is forbidden: unable to validate against any security context constraint: [spec.containers[0].securityContext.containers[0].hostPort: Invalid value: 5775: Host ports are not allowed to be used`
 {{< /warning >}}
+
+After a few seconds, the `DaemonSet` should be up and running:
+
+```bash
+$ oc get daemonset agent-as-daemonset-agent-daemonset
+NAME                                 DESIRED   CURRENT   READY     UP-TO-DATE   AVAILABLE
+agent-as-daemonset-agent-daemonset   1         1         1         1            1
+```
 
 ## Secrets Support
 

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -80,35 +80,6 @@ oc create \
 
 After the role is granted, switch back to a non-privileged user.
 
-Jaeger Agent can be configured to be deployed as a `DaemonSet` using a `HostPort` to allow Jaeger clients in the same node to discover the agent. In OpenShift, a `HostPort` can only be set when a special security context is set. A separate service account can be used by the Jaeger Agent with the permission to bind to `HostPort`, as follows:
-
-```bash
-oc create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/examples/openshift/hostport-scc-daemonset.yaml # <1>
-oc new-project myappnamespace
-oc create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/examples/openshift/service_account_jaeger-agent-daemonset.yaml # <2>
-oc adm policy add-scc-to-user daemonset-with-hostport -z jaeger-agent-daemonset # <3>
-oc apply -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/examples/openshift/agent-as-daemonset.yaml # <4>
-```
-<1> The `SecurityContextConstraints` with the `allowHostPorts` policy
-
-<2> The `ServiceAccount` to be used by the Jaeger Agent
-
-<3> Adds the security policy to the service account
-
-<4> Creates the Jaeger Instance using the `serviceAccount` created in the steps above
-
-{{< warning >}}
-Without such a policy, errors like the following will prevent a `DaemonSet` to be created: `Warning FailedCreate 4s (x14 over 45s) daemonset-controller Error creating: pods "agent-as-daemonset-agent-daemonset-" is forbidden: unable to validate against any security context constraint: [spec.containers[0].securityContext.containers[0].hostPort: Invalid value: 5775: Host ports are not allowed to be used`
-{{< /warning >}}
-
-After a few seconds, the `DaemonSet` should be up and running:
-
-```bash
-$ oc get daemonset agent-as-daemonset-agent-daemonset
-NAME                                 DESIRED   CURRENT   READY     UP-TO-DATE   AVAILABLE
-agent-as-daemonset-agent-daemonset   1         1         1         1            1
-```
-
 # Quick Start - Deploying the AllInOne image
 
 The simplest possible way to create a Jaeger instance is by creating a YAML file like the following example.  This will install the default AllInOne strategy, which deploys the "all-in-one" image (agent, collector, query, ingestor, Jaeger UI) in a single pod, using in-memory storage by default.
@@ -502,6 +473,14 @@ oc apply -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/mast
 {{< warning >}}
 Without such a policy, errors like the following will prevent a `DaemonSet` to be created: `Warning FailedCreate 4s (x14 over 45s) daemonset-controller Error creating: pods "agent-as-daemonset-agent-daemonset-" is forbidden: unable to validate against any security context constraint: [spec.containers[0].securityContext.containers[0].hostPort: Invalid value: 5775: Host ports are not allowed to be used`
 {{< /warning >}}
+
+After a few seconds, the `DaemonSet` should be up and running:
+
+```bash
+$ oc get daemonset agent-as-daemonset-agent-daemonset
+NAME                                 DESIRED   CURRENT   READY     UP-TO-DATE   AVAILABLE
+agent-as-daemonset-agent-daemonset   1         1         1         1            1
+```
 
 ## Secrets Support
 


### PR DESCRIPTION
Signed-off-by: Gary Brown <gary@brownuk.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Setting up the security context to enable host port binding in openshift is discussed in the section on installing in openshift, but not in the section specific to using agent as daemonset.

## Short description of the changes
This PR adds the same description in the agent daemonset section - may want to consider removing it from the "Installing the Operator on OKD/OpenShift" section so only discussed in the context of using a daemonset agent.

@JStickler thoughts?
