### PR TITLE
Added doc about tracing the operator

### DIFF
--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -892,7 +892,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
 ...
       # add as a second container to .Spec.Template.Spec.Containers
       - name: jaeger-agent
-        image: jaegertracing/jaeger-agent:1.15.1
+        image: jaegertracing/jaeger-agent:latest # it's best to keep this version in sync with the operator's
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -883,7 +883,7 @@ Deleting the instance will not remove the data from any permanent storage used w
 
 # Tracing the operator
 
-Starting from version 1.16.0, the Jaeger Operator is able to generate spans related to its own operations. To take advantage of that, the `operator.yaml` has to be configured to enable tracing by setting the flag `--tracing-enabled=true` to the `args` of the container and to add a Jaeger Agent as sidecar to the pod. Here's an excerpt from an `operator.yaml` that has tracing enabled:
+Starting from version 1.16.0, the Jaeger Operator is able to generate spans related to its own operations. To take advantage of that, the `operator.yaml` has to be configured to enable tracing by setting the flag `--tracing-enabled=true` to the `args` of the container and to add a Jaeger Agent as sidecar to the pod. Here's an excerpt from an `operator.yaml` that has tracing enabled and assumes that the Jaeger instance is at the same namespace as the Jaeger Operator:
 
 ```yaml
 ...

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -883,9 +883,9 @@ Deleting the instance will not remove the data from any permanent storage used w
 
 # Tracing the operator
 
-The Jaeger Operator is able to emit spans for its own operations. By default, the Jaeger Operator ships with an `operator.yaml` that is already configured to send spans to a Jaeger instance named `jaeger`, located in the same namespace as the operator. To use a different instance, change the `operator.yaml` and adjust the flag `reporter.grpc.host-port` to use the appropriate host.
+The Jaeger Operator is able to generate spans for its own operations. By default, the Jaeger Operator ships with an `operator.yaml` that is already configured to send spans to a Jaeger instance named `jaeger`, located in the same namespace as the operator. To use a different instance, change the `operator.yaml` and adjust the flag `reporter.grpc.host-port` to use the appropriate host.
 
-Note that the Jaeger instance has to be manually provisioned and can be done after the Jaeger Operator has been initialized. The Jaeger Agent will keep the spans in the internal buffer until a connection to the instance is made. The following Jaeger CR can be used to provision a Jaeger instance suitable for non-production purposes:
+Note that you must manually provision the Jaeger instance. You can do this after the Jaeger Operator has been initialized. The Jaeger Agent will keep the Operator spans in the internal buffer until it makes a connection to the Jaeger instance. The following Jaeger CR can be used to provision a Jaeger instance suitable for non-production purposes:
 
 ```yaml
 apiVersion: jaegertracing.io/v1
@@ -894,10 +894,10 @@ metadata:
   name: jaeger
 ```
 
-Tracing can be disabled by setting the flag `--tracing-enabled` to `false`.
+Tracing the operator can be disabled by setting the flag `--tracing-enabled` to `false`.
 
 {{< info >}}
-At this moment, the Operator Lifecycle Manager (OLM) does not offer a way to configure an operator. As such, the default configuration for the Jaeger Operator disables tracing when installed via OLM.
+Currently the Operator Lifecycle Manager (OLM) does not offer a way to configure an operator. As a result, if you install the Jaeger Operator via OLM, collecting traces from the Operator is disabled by default.
 {{< /info >}}
 
 # Monitoring the operator

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -881,6 +881,25 @@ kubectl delete jaeger simplest
 Deleting the instance will not remove the data from any permanent storage used with this instance. Data from in-memory instances, however, will be lost.
 {{< /info >}}
 
+# Tracing the operator
+
+The Jaeger Operator is able to emit spans for its own operations. By default, the Jaeger Operator ships with an `operator.yaml` that is already configured to send spans to a Jaeger instance named `jaeger`, located in the same namespace as the operator. To use a different instance, change the `operator.yaml` and adjust the flag `reporter.grpc.host-port` to use the appropriate host.
+
+Note that the Jaeger instance has to be manually provisioned and can be done after the Jaeger Operator has been initialized. The Jaeger Agent will keep the spans in the internal buffer until a connection to the instance is made. The following Jaeger CR can be used to provision a Jaeger instance suitable for non-production purposes:
+
+```yaml
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: jaeger
+```
+
+Tracing can be disabled by setting the flag `--tracing-enabled` to `false`.
+
+{{< info >}}
+At this moment, the Operator Lifecycle Manager (OLM) does not offer a way to configure an operator. As such, the default configuration for the Jaeger Operator disables tracing when installed via OLM.
+{{< /info >}}
+
 # Monitoring the operator
 
 The Jaeger Operator starts a Prometheus-compatible endpoint on `0.0.0.0:8383/metrics` with internal metrics that can be used to monitor the process.


### PR DESCRIPTION
This PR documents what's needed to get traces out of the Jaeger Operator. This new feature is being added as part of jaegertracing/jaeger-operator#738.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
