### PR TITLE
Document self-provisioned Elasticsearch example CR

### DIFF
--- a/content/docs/1.16/operator.md
+++ b/content/docs/1.16/operator.md
@@ -359,7 +359,7 @@ The default create-schema job uses `MODE=prod`, which implies a replication fact
 
 By default Elasticsearch storage does not require any initialization job to be run. However Elasticsearch
 storage requires a cron job to be run to clean old data from the storage.
- 
+
 When rollover (`es.use-aliases`) is enabled, Jaeger operator also deploys a job to initialize Elasticsearch storage
 and another two cron jobs to perform required index management actions.
 
@@ -406,13 +406,51 @@ spec:
 <5> Volume mounts and volumes which are mounted into all storage components.
 
 #### Self provisioned
-Under some circumstances, the Jaeger Operator can make use of the [Elasticsearch Operator](https://github.com/openshift/elasticsearch-operator) to provision a suitable Elasticsearch cluster.
+
+Under some circumstances, the Jaeger Operator can make use of the [Elasticsearch Operator](https://github.com/openshift/elasticsearch-operator) to provision a suitable Elasticsearch cluster. Jaeger CR exposes the same configuration as [OpenShift Cluster Logging](https://docs.openshift.com/container-platform/4.2/logging/config/cluster-logging-elasticsearch.html).
 
 {{< warning >}}
 This feature is supported only on OKD/OpenShift clusters. Spark dependencies are not supported with this feature [Issue #294](https://github.com/jaegertracing/jaeger-operator/issues/294).
 {{< /warning >}}
 
 When there is no `es.server-urls` option as part of a Jaeger `production` instance and `elasticsearch` is set as the storage type, the Jaeger Operator creates an Elasticsearch cluster via the Elasticsearch Operator by creating a Custom Resource based on the configuration provided in storage section. The Elasticsearch cluster is meant to be dedicated for a single Jaeger instance.
+
+Follows an example of Jaeger with a single node Elasticsearch cluster with AWS `gp2` persistent storage:
+
+```yaml
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: simple-prod
+spec:
+  strategy: production
+  storage:
+    type: elasticsearch
+    elasticsearch:
+      nodeCount: 1 # <1>
+      storage: # <2>
+        storageClassName: gp2
+        size: 5Gi
+      resources: # <3>
+        requests:
+          cpu: 200m
+          memory: 4Gi
+        limits:
+          memory: 4Gi
+      redundancyPolicy: ZeroRedundancy # <4>
+```
+<1> Number of Elasticsearch nodes. For high availability use at least 3 nodes. Do not use 2 nodes as "split brain" problem can happen.
+
+<2> Persistent storage configuration. In this case AWS `gp2` with `5Gi` size. When omitted `emptyDir` is used. Elasticsearch operator provisions `PersistentVolumeClaim` and `PersistentVolume` which are not removed with Jaeger instance. The same volumes can be mounted if Jaeger with the same name and namespace is crated. Some storages might fail in `default` namespace because of OpenShift SCC policy.
+
+<3> Resources for Elasticsearch nodes. In this case `4Gi` which results to by default required `2Gi` of heap space. Refer to Elasticsearch [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/heap-size.html) for memory recommendations.
+
+<4> Data replication policy defines how Elasticsearch shards are replicated across data nodes in the cluster. If not specified Jaeger Operator automatically determines the most appropriate replication based on number of nodes.
+
+* `FullRedundancy` Elasticsearch fully replicates the primary shards for each index to every data node. This provides the highest safety, but at the cost of the highest amount of disk required and the poorest performance.
+* `MultipleRedundancy` Elasticsearch fully replicates the primary shards for each index to half of the data nodes. This provides a good tradeoff between safety and performance.
+* `SingleRedundancy` Elasticsearch makes one copy of the primary shards for each index. Data are always available and recoverable as long as at least two data nodes exist. Better performance than MultipleRedundancy, when using 5 or more nodes. You cannot apply this policy on deployments of single Elasticsearch node.
+* `ZeroRedundancy` Elasticsearch does not make copies of the primary shards. Data might be unavailable or lost in the event a node is down or fails. Use this mode when you are more concerned with performance than safety, or have implemented your own disk/PVC backup/restore strategy.
 
 The self-provision of an Elasticsearch cluster can be disabled by setting the flag `--es-provision` to `false`. The default value is `auto`, which will make the Jaeger Operator query the Kubernetes cluster for its ability to handle a `Elasticsearch` custom resource. This is usually set by the Elasticsearch Operator during its installation process, so, if the Elasticsearch Operator is expected to run *after* the Jaeger Operator, the flag can be set to `true`.
 

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -433,18 +433,18 @@ spec:
       resources: # <3>
         requests:
           cpu: 200m
-          memory: 2Gi
+          memory: 4Gi
         limits:
-          memory: 2Gi
+          memory: 4Gi
       redundancyPolicy: ZeroRedundancy # <4>
 ```
 <1> Number of Elasticsearch nodes. For high availability use at least 3 nodes. Do not use 2 nodes as "split brain" problem can happen.
 
 <2> Persistent storage configuration. In this case AWS `gp2` with `5Gi` size. When omitted `emptyDir` is used. Elasticsearch operator provisions `PersistentVolumeClaim` and `PersistentVolume` which are not removed with Jaeger instance. The same volumes can be mounted if Jaeger with the same name and namespace is crated. Some storages might fail in `default` namespace because of OpenShift SCC policy.
 
-<3> Resources for Elasticsearch nodes. In this case `2Gi` which is not suitable for production ready cluster. Refer to Elasticsearch documentation for memory recommendations.
+<3> Resources for Elasticsearch nodes. In this case `4Gi` which results to by default required `2Gi` of heap space. Refer to Elasticsearch [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/heap-size.html) for memory recommendations.
 
-<4> Data replication policy defines how Elasticsearch shards are replicated across data nodes in the cluster. If not specified Jaeger operator automatically determines the most appropriate replication based on number of nodes.
+<4> Data replication policy defines how Elasticsearch shards are replicated across data nodes in the cluster. If not specified Jaeger Operator automatically determines the most appropriate replication based on number of nodes.
 
 * `FullRedundancy` Elasticsearch fully replicates the primary shards for each index to every data node. This provides the highest safety, but at the cost of the highest amount of disk required and the poorest performance.
 * `MultipleRedundancy` Elasticsearch fully replicates the primary shards for each index to half of the data nodes. This provides a good tradeoff between safety and performance.

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -406,6 +406,7 @@ spec:
 <5> Volume mounts and volumes which are mounted into all storage components.
 
 #### Self provisioned
+
 Under some circumstances, the Jaeger Operator can make use of the [Elasticsearch Operator](https://github.com/openshift/elasticsearch-operator) to provision a suitable Elasticsearch cluster. Jaeger CR exposes the same configuration as [OpenShift Cluster Logging](https://docs.openshift.com/container-platform/4.2/logging/config/cluster-logging-elasticsearch.html).
 
 {{< warning >}}

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -414,7 +414,7 @@ This feature is supported only on OKD/OpenShift clusters. Spark dependencies are
 
 When there is no `es.server-urls` option as part of a Jaeger `production` instance and `elasticsearch` is set as the storage type, the Jaeger Operator creates an Elasticsearch cluster via the Elasticsearch Operator by creating a Custom Resource based on the configuration provided in storage section. The Elasticsearch cluster is meant to be dedicated for a single Jaeger instance.
 
-Follows and example of Jaeger with a single node Elasticsearch cluster with persistent storage:
+Follows an example of Jaeger with a single node Elasticsearch cluster with AWS `gp2` persistent storage:
 
 ```yaml
 apiVersion: jaegertracing.io/v1
@@ -440,7 +440,7 @@ spec:
 ```
 <1> Number of Elasticsearch nodes. For high availability use at least 3 nodes. Do not use 2 nodes as "split brain" problem can happen.
 
-<2> Storage configuration. In this case AWS `gp2` with `5Gi` size. When omitted `emptyDir` is used. Elasticsearch operator provisions `PersistentVolumeClaim` and `PersistentVolume` which are not removed with Jaeger instance. The same volumes can be mounted if Jaeger with the same name is crated in the same namespace.
+<2> Storage configuration. In this case AWS `gp2` with `5Gi` size. When omitted `emptyDir` is used. Elasticsearch operator provisions `PersistentVolumeClaim` and `PersistentVolume` which are not removed with Jaeger instance. The same volumes can be mounted if Jaeger with the same name and namespace is crated.
 
 <3> Resources for Elasticsearch nodes. In this case `2Gi` which is not suitable for production ready cluster. Refer to Elasticsearch documentation for memory recommendations.
 

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -440,7 +440,7 @@ spec:
 ```
 <1> Number of Elasticsearch nodes. For high availability use at least 3 nodes. Do not use 2 nodes as "split brain" problem can happen.
 
-<2> Storage configuration. In this case AWS `gp2` with `5Gi` size. When omitted `emptyDir` is used. Elasticsearch operator provisions `PersistentVolumeClaim` and `PersistentVolume` which are not removed with Jaeger instance. The same volumes can be mounted if Jaeger with the same name and namespace is crated.
+<2> Persistent storage configuration. In this case AWS `gp2` with `5Gi` size. When omitted `emptyDir` is used. Elasticsearch operator provisions `PersistentVolumeClaim` and `PersistentVolume` which are not removed with Jaeger instance. The same volumes can be mounted if Jaeger with the same name and namespace is crated. Some storages might fail in `default` namespace because of OpenShift SCC policy.
 
 <3> Resources for Elasticsearch nodes. In this case `2Gi` which is not suitable for production ready cluster. Refer to Elasticsearch documentation for memory recommendations.
 


### PR DESCRIPTION
Resolves #336 

https://deploy-preview-338--jaegertracing.netlify.com/docs/next-release/operator/#self-provisioned

Once approved I will copy it to current and older releases.