### PR TITLE
Add back api sub-menu

### DIFF
--- a/content/docs/1.14/architecture.md
+++ b/content/docs/1.14/architecture.md
@@ -2,6 +2,8 @@
 title: Architecture
 weight: 3
 children:
+- title: APIs
+  url: apis
 - title: Sampling
   url: sampling
 ---

--- a/content/docs/1.15/architecture.md
+++ b/content/docs/1.15/architecture.md
@@ -2,6 +2,8 @@
 title: Architecture
 weight: 3
 children:
+- title: APIs
+  url: apis
 - title: Sampling
   url: sampling
 ---

--- a/content/docs/1.16/architecture.md
+++ b/content/docs/1.16/architecture.md
@@ -2,6 +2,8 @@
 title: Architecture
 weight: 3
 children:
+- title: APIs
+  url: apis
 - title: Sampling
   url: sampling
 ---

--- a/content/docs/next-release/architecture.md
+++ b/content/docs/next-release/architecture.md
@@ -2,6 +2,8 @@
 title: Architecture
 weight: 3
 children:
+- title: APIs
+  url: apis
 - title: Sampling
   url: sampling
 ---


### PR DESCRIPTION
Signed-off-by: Gary Brown <gary@brownuk.com>

## Which problem is this PR solving?
Adding "APIs" submenu back to the lefthand menu - removed after 1.13 release for some reason?

## Short description of the changes
Add apis.md as child of architecture page.
