### PR TITLE
Added port forword for grpc port

### DIFF
--- a/content/docs/1.16/getting-started.md
+++ b/content/docs/1.16/getting-started.md
@@ -23,6 +23,7 @@ $ docker run -d --name jaeger \
   -p 5778:5778 \
   -p 16686:16686 \
   -p 14268:14268 \
+  -p 14250:14250 \
   -p 9411:9411 \
   jaegertracing/all-in-one:{{< currentVersion >}}
 ```

--- a/content/docs/next-release/getting-started.md
+++ b/content/docs/next-release/getting-started.md
@@ -23,6 +23,7 @@ $ docker run -d --name jaeger \
   -p 5778:5778 \
   -p 16686:16686 \
   -p 14268:14268 \
+  -p 14250:14250 \
   -p 9411:9411 \
   jaegertracing/all-in-one:{{< currentVersion >}}
 ```


### PR DESCRIPTION
It was missing in the docker run statement but mentioned below in the exposed ports.
