### PR TITLE
Updated the data format/transport table for clients

### DIFF
--- a/data/clients.yaml
+++ b/data/clients.yaml
@@ -5,8 +5,6 @@ featureGroups:
       description: Report [`jaeger.thrift`](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift), [Compact](https://github.com/apache/thrift/blob/v0.13.0/doc/specs/thrift-compact-protocol.md) protocol, over UDP
     - name: report_jaeger_thrift_binary_udp
       description: Report [`jaeger.thrift`](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift), [Binary](https://github.com/apache/thrift/blob/v0.13.0/doc/specs/thrift-binary-protocol.md) protocol, over UDP
-    - name: report_jaeger_thrift_compact_http
-      description: Report [`jaeger.thrift`](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift), [Compact](https://github.com/apache/thrift/blob/v0.13.0/doc/specs/thrift-compact-protocol.md) protocol, over TCP (HTTP)
     - name: report_jaeger_thrift_binary_http
       description: Report [`jaeger.thrift`](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift), [Binary](https://github.com/apache/thrift/blob/v0.13.0/doc/specs/thrift-binary-protocol.md) protocol, over TCP (HTTP)
     - name: report_zipkin_thrift_binary_http
@@ -141,7 +139,6 @@ clients:
     features:
       report_jaeger_thrift_compact_udp: yes
       report_jaeger_thrift_binary_udp: no
-      report_jaeger_thrift_compact_http: no
       report_jaeger_thrift_binary_http: yes
       report_zipkin_thrift_binary_http: yes
       propagation_uber: yes
@@ -184,7 +181,6 @@ clients:
     features:
       report_jaeger_thrift_compact_udp: yes
       report_jaeger_thrift_binary_udp: no
-      report_jaeger_thrift_compact_http: no
       report_jaeger_thrift_binary_http: yes
       report_zipkin_thrift_binary_http: yes
       propagation_uber: yes
@@ -227,7 +223,6 @@ clients:
     features:
       report_jaeger_thrift_compact_udp: no
       report_jaeger_thrift_binary_udp: yes
-      report_jaeger_thrift_compact_http: no
       report_jaeger_thrift_binary_http: yes
       report_zipkin_thrift_binary_http: no
       propagation_uber: yes
@@ -270,7 +265,6 @@ clients:
     features:
       report_jaeger_thrift_compact_udp: yes
       report_jaeger_thrift_binary_udp: no
-      report_jaeger_thrift_compact_http: no
       report_jaeger_thrift_binary_http: no
       report_zipkin_thrift_binary_http: no
       propagation_uber: yes
@@ -313,7 +307,6 @@ clients:
     features:
       report_jaeger_thrift_compact_udp: yes
       report_jaeger_thrift_binary_udp: no
-      report_jaeger_thrift_compact_http: no
       report_jaeger_thrift_binary_http: yes
       report_zipkin_thrift_binary_http: no
       propagation_uber: yes
@@ -356,7 +349,6 @@ clients:
     features:
       report_jaeger_thrift_compact_udp: yes
       report_jaeger_thrift_binary_udp: no
-      report_jaeger_thrift_compact_http: no
       report_jaeger_thrift_binary_http: yes
       report_zipkin_thrift_binary_http: no
       propagation_uber: yes

--- a/data/clients.yaml
+++ b/data/clients.yaml
@@ -8,6 +8,13 @@ featureGroups:
     - name: report_zipkin_thrift_http
       description: Report Zipkin Thrift over HTTP
 
+  - description: Available Thrift protocols
+    features:
+    - name: report_thrift_compact
+      description: "[Thrift Compact](https://github.com/apache/thrift/blob/v0.13.0/doc/specs/thrift-compact-protocol.md) protocol"
+    - name: report_thrift_binary
+      description: "[Thrift Binary](https://github.com/apache/thrift/blob/v0.13.0/doc/specs/thrift-binary-protocol.md) protocol"
+
   - description: Inter-process propagation wire format (headers)
     features:
     - name: propagation_uber
@@ -138,6 +145,8 @@ clients:
       report_jaeger_thrift_udp: yes
       report_jaeger_thrift_http: yes # https://github.com/jaegertracing/jaeger-client-go/issues/152
       report_zipkin_thrift_http: yes
+      report_thrift_compact: yes
+      report_thrift_binary: no
       propagation_uber: yes
       propagation_b3: yes
       propagation_w3c: coming
@@ -179,6 +188,8 @@ clients:
       report_jaeger_thrift_udp: yes
       report_jaeger_thrift_http: yes
       report_zipkin_thrift_http: yes # https://github.com/jaegertracing/jaeger-client-java/tree/v0.35.5/jaeger-zipkin#thrift
+      report_thrift_compact: yes
+      report_thrift_binary: yes
       propagation_uber: yes
       propagation_b3: yes
       propagation_w3c: coming
@@ -220,6 +231,8 @@ clients:
       report_jaeger_thrift_udp: yes
       report_jaeger_thrift_http: yes # https://github.com/jaegertracing/jaeger-client-node#reporting-spans-via-http
       report_zipkin_thrift_http: no
+      report_thrift_compact: no
+      report_thrift_binary: yes
       propagation_uber: yes
       propagation_b3: yes
       propagation_w3c: coming
@@ -261,6 +274,8 @@ clients:
       report_jaeger_thrift_udp: yes
       report_jaeger_thrift_http: no
       report_zipkin_thrift_http: no
+      report_thrift_compact: yes
+      report_thrift_binary: no
       propagation_uber: yes
       propagation_b3: yes
       propagation_w3c: coming
@@ -302,6 +317,8 @@ clients:
       report_jaeger_thrift_udp: yes
       report_jaeger_thrift_http: yes # https://github.com/jaegertracing/jaeger-client-cpp/pull/171
       report_zipkin_thrift_http: no
+      report_thrift_compact: yes
+      report_thrift_binary: no
       propagation_uber: yes
       propagation_b3: no
       propagation_w3c: coming
@@ -343,6 +360,8 @@ clients:
       report_jaeger_thrift_udp: yes
       report_jaeger_thrift_http: yes
       report_zipkin_thrift_http: no
+      report_thrift_compact: yes
+      report_thrift_binary: no
       propagation_uber: yes
       propagation_b3: yes
       propagation_w3c: coming

--- a/data/clients.yaml
+++ b/data/clients.yaml
@@ -1,19 +1,16 @@
 featureGroups:
   - description: Data format and transport for reporting spans to Jaeger backend
     features:
-    - name: report_jaeger_thrift_udp
-      description: Report [`jaeger.thrift`](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift) over UDP
-    - name: report_jaeger_thrift_http
-      description: Report [`jaeger.thrift`](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift) over HTTP
-    - name: report_zipkin_thrift_http
-      description: Report Zipkin Thrift over HTTP
-
-  - description: Thrift protocols sent via UDP to the Jaeger Agent
-    features:
-    - name: report_thrift_compact
-      description: "[Thrift Compact](https://github.com/apache/thrift/blob/v0.13.0/doc/specs/thrift-compact-protocol.md) protocol"
-    - name: report_thrift_binary
-      description: "[Thrift Binary](https://github.com/apache/thrift/blob/v0.13.0/doc/specs/thrift-binary-protocol.md) protocol"
+    - name: report_jaeger_thrift_compact_udp
+      description: Report [`jaeger.thrift`](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift), [Compact](https://github.com/apache/thrift/blob/v0.13.0/doc/specs/thrift-compact-protocol.md) protocol, over UDP
+    - name: report_jaeger_thrift_binary_udp
+      description: Report [`jaeger.thrift`](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift), [Binary](https://github.com/apache/thrift/blob/v0.13.0/doc/specs/thrift-binary-protocol.md) protocol, over UDP
+    - name: report_jaeger_thrift_compact_http
+      description: Report [`jaeger.thrift`](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift), [Compact](https://github.com/apache/thrift/blob/v0.13.0/doc/specs/thrift-compact-protocol.md) protocol, over TCP (HTTP)
+    - name: report_jaeger_thrift_binary_http
+      description: Report [`jaeger.thrift`](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift), [Binary](https://github.com/apache/thrift/blob/v0.13.0/doc/specs/thrift-binary-protocol.md) protocol, over TCP (HTTP)
+    - name: report_zipkin_thrift_binary_http
+      description: Report Zipkin Thrift, Binary protocol, over TCP (HTTP)
 
   - description: Inter-process propagation wire format (headers)
     features:
@@ -142,11 +139,11 @@ clients:
   - language: Go
     repo: jaegertracing/jaeger-client-go
     features:
-      report_jaeger_thrift_udp: yes
-      report_jaeger_thrift_http: yes # https://github.com/jaegertracing/jaeger-client-go/issues/152
-      report_zipkin_thrift_http: yes
-      report_thrift_compact: yes
-      report_thrift_binary: no
+      report_jaeger_thrift_compact_udp: yes
+      report_jaeger_thrift_binary_udp: no
+      report_jaeger_thrift_compact_http: no
+      report_jaeger_thrift_binary_http: yes
+      report_zipkin_thrift_binary_http: yes
       propagation_uber: yes
       propagation_b3: yes
       propagation_w3c: coming
@@ -185,11 +182,11 @@ clients:
   - language: Java
     repo: jaegertracing/jaeger-client-java
     features:
-      report_jaeger_thrift_udp: yes
-      report_jaeger_thrift_http: yes
-      report_zipkin_thrift_http: yes # https://github.com/jaegertracing/jaeger-client-java/tree/v0.35.5/jaeger-zipkin#thrift
-      report_thrift_compact: yes
-      report_thrift_binary: no
+      report_jaeger_thrift_compact_udp: yes
+      report_jaeger_thrift_binary_udp: no
+      report_jaeger_thrift_compact_http: no
+      report_jaeger_thrift_binary_http: yes
+      report_zipkin_thrift_binary_http: yes
       propagation_uber: yes
       propagation_b3: yes
       propagation_w3c: coming
@@ -228,11 +225,11 @@ clients:
   - language: Node.js
     repo: jaegertracing/jaeger-client-node
     features:
-      report_jaeger_thrift_udp: yes
-      report_jaeger_thrift_http: yes # https://github.com/jaegertracing/jaeger-client-node#reporting-spans-via-http
-      report_zipkin_thrift_http: no
-      report_thrift_compact: no
-      report_thrift_binary: yes
+      report_jaeger_thrift_compact_udp: no
+      report_jaeger_thrift_binary_udp: yes
+      report_jaeger_thrift_compact_http: no
+      report_jaeger_thrift_binary_http: yes
+      report_zipkin_thrift_binary_http: no
       propagation_uber: yes
       propagation_b3: yes
       propagation_w3c: coming
@@ -271,11 +268,11 @@ clients:
   - language: Python
     repo: jaegertracing/jaeger-client-python
     features:
-      report_jaeger_thrift_udp: yes
-      report_jaeger_thrift_http: no
-      report_zipkin_thrift_http: no
-      report_thrift_compact: yes
-      report_thrift_binary: no
+      report_jaeger_thrift_compact_udp: yes
+      report_jaeger_thrift_binary_udp: no
+      report_jaeger_thrift_compact_http: no
+      report_jaeger_thrift_binary_http: no
+      report_zipkin_thrift_binary_http: no
       propagation_uber: yes
       propagation_b3: yes
       propagation_w3c: coming
@@ -314,11 +311,11 @@ clients:
   - language: C++
     repo: jaegertracing/jaeger-client-cpp
     features:
-      report_jaeger_thrift_udp: yes
-      report_jaeger_thrift_http: yes # https://github.com/jaegertracing/jaeger-client-cpp/pull/171
-      report_zipkin_thrift_http: no
-      report_thrift_compact: yes
-      report_thrift_binary: no
+      report_jaeger_thrift_compact_udp: yes
+      report_jaeger_thrift_binary_udp: no
+      report_jaeger_thrift_compact_http: no
+      report_jaeger_thrift_binary_http: yes
+      report_zipkin_thrift_binary_http: no
       propagation_uber: yes
       propagation_b3: no
       propagation_w3c: coming
@@ -357,11 +354,11 @@ clients:
   - language: C#
     repo: jaegertracing/jaeger-client-csharp
     features:
-      report_jaeger_thrift_udp: yes
-      report_jaeger_thrift_http: yes
-      report_zipkin_thrift_http: no
-      report_thrift_compact: yes
-      report_thrift_binary: no
+      report_jaeger_thrift_compact_udp: yes
+      report_jaeger_thrift_binary_udp: no
+      report_jaeger_thrift_compact_http: no
+      report_jaeger_thrift_binary_http: yes
+      report_zipkin_thrift_binary_http: no
       propagation_uber: yes
       propagation_b3: yes
       propagation_w3c: coming

--- a/data/clients.yaml
+++ b/data/clients.yaml
@@ -136,7 +136,7 @@ clients:
     repo: jaegertracing/jaeger-client-go
     features:
       report_jaeger_thrift_udp: yes
-      report_jaeger_thrift_http: no
+      report_jaeger_thrift_http: yes # https://github.com/jaegertracing/jaeger-client-go/issues/152
       report_zipkin_thrift_http: yes
       propagation_uber: yes
       propagation_b3: yes
@@ -178,7 +178,7 @@ clients:
     features:
       report_jaeger_thrift_udp: yes
       report_jaeger_thrift_http: yes
-      report_zipkin_thrift_http: no
+      report_zipkin_thrift_http: yes # https://github.com/jaegertracing/jaeger-client-java/tree/v0.35.5/jaeger-zipkin#thrift
       propagation_uber: yes
       propagation_b3: yes
       propagation_w3c: coming
@@ -218,7 +218,7 @@ clients:
     repo: jaegertracing/jaeger-client-node
     features:
       report_jaeger_thrift_udp: yes
-      report_jaeger_thrift_http: no
+      report_jaeger_thrift_http: yes # https://github.com/jaegertracing/jaeger-client-node#reporting-spans-via-http
       report_zipkin_thrift_http: no
       propagation_uber: yes
       propagation_b3: yes
@@ -300,7 +300,7 @@ clients:
     repo: jaegertracing/jaeger-client-cpp
     features:
       report_jaeger_thrift_udp: yes
-      report_jaeger_thrift_http:
+      report_jaeger_thrift_http: yes # https://github.com/jaegertracing/jaeger-client-cpp/pull/171
       report_zipkin_thrift_http: no
       propagation_uber: yes
       propagation_b3: no

--- a/data/clients.yaml
+++ b/data/clients.yaml
@@ -8,7 +8,7 @@ featureGroups:
     - name: report_zipkin_thrift_http
       description: Report Zipkin Thrift over HTTP
 
-  - description: Available Thrift protocols
+  - description: Thrift protocols sent via UDP to the Jaeger Agent
     features:
     - name: report_thrift_compact
       description: "[Thrift Compact](https://github.com/apache/thrift/blob/v0.13.0/doc/specs/thrift-compact-protocol.md) protocol"
@@ -189,7 +189,7 @@ clients:
       report_jaeger_thrift_http: yes
       report_zipkin_thrift_http: yes # https://github.com/jaegertracing/jaeger-client-java/tree/v0.35.5/jaeger-zipkin#thrift
       report_thrift_compact: yes
-      report_thrift_binary: yes
+      report_thrift_binary: no
       propagation_uber: yes
       propagation_b3: yes
       propagation_w3c: coming


### PR DESCRIPTION
## Which problem is this PR solving?
- The doc page with the data format/transport seems to be outdated. I went over the listed clients and tried to sync the data based on different types of evidence (code, test, example or documentation), resulting in this PR.

I also checked which Thrift encoding formats are supported by each client, but we don't seem to be recording this anywhere. Is this something we'd want to record somewhere?

Client | Compact | Binary
-- | -- | --
Java | ✔️ | ✔️
Go | ✔️ | ❌
C# | ✔️ | ❌
C++ | ✔️ | ❌
Python | ✔️ | ❌
Node | ❌ | ✔️

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>