### PR TITLE
Update Hugo version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@ HUGO_THEME   = jaeger-docs
 THEME_DIR    := themes/$(HUGO_THEME)
 
 develop:
-	HUGO_PREVIEW=true \
-	hugo server \
+	HUGO_PREVIEW=true hugo server \
         --buildDrafts \
         --buildFuture \
 	--ignoreCache
@@ -12,10 +11,25 @@ develop:
 clean:
 	rm -rf public
 
-build-content:
-	hugo -v
+netlify-production-build:
+	hugo --minify
 
-build: clean build-content
+netlify-deploy-preview:
+	HUGO_PREVIEW=true hugo \
+	--buildDrafts \
+	--buildFuture \
+	--baseURL $(DEPLOY_PRIME_URL) \
+	--minify
+
+netlify-branch-deploy:
+	hugo \
+	--buildDrafts \
+	--buildFuture \
+	--baseURL $(DEPLOY_PRIME_URL) \
+	--minify
+
+build: clean
+	hugo -v
 
 link-checker-setup:
 	curl https://raw.githubusercontent.com/wjdp/htmltest/master/godownloader.sh | bash

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,12 @@
 [build]
 publish = "public"
-command = "hugo"
+command = "make netlify-production-build"
 
 [build.environment]
-HUGO_VERSION = "0.53"
+HUGO_VERSION = "0.65.0"
 
 [context.deploy-preview]
-command = "HUGO_PREVIEW=true hugo --buildDrafts --buildFuture --baseURL $DEPLOY_PRIME_URL"
+command = "make netlify-deploy-preview"
 
 [context.branch-deploy]
-command = "hugo --buildDrafts --buildFuture --baseURL $DEPLOY_PRIME_URL"
+command = "make netlify-branch-deploy"

--- a/themes/jaeger-docs/layouts/404.html
+++ b/themes/jaeger-docs/layouts/404.html
@@ -1,4 +1,4 @@
-{{- $latest   := site.Params.latest }}
+{{ $latest   := site.Params.latest }}
 <!DOCTYPE html>
 <html lang="{{ site.LanguageCode }}">
   <head>

--- a/themes/jaeger-docs/layouts/_default/single.html
+++ b/themes/jaeger-docs/layouts/_default/single.html
@@ -1,6 +1,6 @@
-{{- define "title" }}
+{{ define "title" }}
 Jaeger &ndash; {{ .Title }}
-{{- end }}
+{{ end }}
 
 {{ define "main" }}
 <article class="article article--docs">

--- a/themes/jaeger-docs/layouts/_default/taxonomy.html
+++ b/themes/jaeger-docs/layouts/_default/taxonomy.html
@@ -1,26 +1,26 @@
 {{ define "main" }}
-{{- $taxonomyNameSingular := .Data.Singular }}
-{{- $taxonomyNamePlural := .Data.Plural }}
-{{- $term := .Data.Term }}
+{{ $taxonomyNameSingular := .Data.Singular }}
+{{ $taxonomyNamePlural := .Data.Plural }}
+{{ $term := .Data.Term }}
 <article class="article article--terms">
   <div class="container">
     <h1 class="is-size-1">All pages with the {{ $taxonomyNameSingular }} <strong>{{ $term }}</strong></h1>
     <hr class="hr" />
     <div class="content">
       <ul>
-        {{- range .Data.Pages }}
-        {{- .Render "li" }}
-        {{- end }}
+        {{ range .Data.Pages }}
+        {{ .Render "li" }}
+        {{ end }}
       </ul>
       <h3 class="is-size-3">Other {{ $taxonomyNamePlural }}</h3>
       <ul>
-        {{- range $name, $value := site.Taxonomies.tags }}
-        {{- if ne $name $term }}
+        {{ range $name, $value := site.Taxonomies.tags }}
+        {{ if ne $name $term }}
         <li>
           <a href="/{{ $taxonomyNamePlural }}/{{ $name }}">{{ $name }}</a>
           </li>
-        {{- end }}
-        {{- end }}
+        {{ end }}
+        {{ end }}
       </ul>
     </div>
   </div>

--- a/themes/jaeger-docs/layouts/_default/terms.html
+++ b/themes/jaeger-docs/layouts/_default/terms.html
@@ -1,27 +1,27 @@
 {{ define "main" }}
-{{- $taxonomyNamePlural := .Data.Plural }}
+{{ $taxonomyNamePlural := .Data.Plural }}
 <article class="article article--terms">
   <div class="container">
     <h1 class="is-size-1">All {{ $taxonomyNamePlural }}</h1>
     <hr class="hr" />
     <div class="content">
       <ul>
-        {{- range $name, $term := .Data.Terms }}
+        {{ range $name, $term := .Data.Terms }}
         <li>
           <a href="/{{ $taxonomyNamePlural }}/{{ $name }}">{{ $name }}</a>
         </li>
-        {{- end }}
+        {{ end }}
       </ul>
       <!-- Leave this commented out until a second taxonomy is added beyond tags
       <h3 class="is-size-3">Other taxonomies</h3>
       <ul>
-        {{- range $name, $taxonomy := site.Taxonomies }}
-        {{- if ne $name $.Data.Plural }}
+        {{ range $name, $taxonomy := site.Taxonomies }}
+        {{ if ne $name $.Data.Plural }}
         <li>
           <a href="/{{ $name }}">{{ $name }}</a>
         </li>
-        {{- end }}
-        {{- end }}
+        {{ end }}
+        {{ end }}
       </ul>
       -->
     </div>

--- a/themes/jaeger-docs/layouts/docs/single.html
+++ b/themes/jaeger-docs/layouts/docs/single.html
@@ -1,13 +1,13 @@
-{{- define "title" -}}
+{{ define "title" }}
 {{ .Title }} &mdash; Jaeger documentation
-{{- end -}}
+{{ end }}
 
-{{- define "main" -}}
+{{ define "main" }}
 <article class="article article--docs">
   <div class="container is-fluid">
 
     <div class="columns">
-      {{- if ne .Params.widescreen true }}
+      {{ if ne .Params.widescreen true }}
       <div class="column is-2 is-hidden-touch">
         {{ partial "docs/panel.html" . }}
       </div>
@@ -22,7 +22,7 @@
       <div class="column is-2 is-hidden-touch">
         {{ partial "docs/toc.html" . }}
       </div>
-      {{- else }}
+      {{ else }}
       <div class="column is-2 is-hidden-touch">
         {{ partial "docs/panel.html" . }}
       </div>
@@ -32,8 +32,8 @@
           {{ .Content }}
         </section>
       </div>
-      {{- end }}
+      {{ end }}
     </div>
   </div>
 </article>
-{{- end -}}
+{{ end -}}

--- a/themes/jaeger-docs/layouts/download/list.html
+++ b/themes/jaeger-docs/layouts/download/list.html
@@ -1,10 +1,10 @@
-{{- define "title" }}
+{{ define "title" }}
 Jaeger &ndash; {{ .Title }}
-{{- end }}
+{{ end }}
 
 {{ define "main" }}
-{{- $binaries     := site.Data.download.binaries }}
-{{- $dockerImages := site.Data.download.docker }}
+{{ $binaries     := site.Data.download.binaries }}
+{{ $dockerImages := site.Data.download.docker }}
 <article class="article article--download">
   <div class="container">
     <header>

--- a/themes/jaeger-docs/layouts/index.html
+++ b/themes/jaeger-docs/layouts/index.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
-{{- $json         := getJSON "https://api.rss2json.com/v1/api.json?rss_url=https://medium.com/feed/jaegertracing" }}
-{{- $posts        := first 100 $json.items }}
+{{ $json         := getJSON "https://api.rss2json.com/v1/api.json?rss_url=https://medium.com/feed/jaegertracing" }}
+{{ $posts        := first 100 $json.items }}
 
 {{ partial "home/hero.html" (dict "posts" $posts "title" site.Title "tagline" site.Params.tagline "latestVersion" site.Params.latest) }}
 {{ partial "home/why.html" . }}

--- a/themes/jaeger-docs/layouts/index.redirects
+++ b/themes/jaeger-docs/layouts/index.redirects
@@ -1,5 +1,5 @@
-{{- $versions     := site.Params.versions }}
-{{- $latest       := site.Params.latest }}
+{{ $versions := site.Params.versions }}
+{{ $latest   := site.Params.latest }}
 /docs    /docs/{{ $latest }}
 /docs/latest     /docs/{{ $latest }}
 /docs/latest/*     /docs/{{ $latest }}/:splat

--- a/themes/jaeger-docs/layouts/partials/css.html
+++ b/themes/jaeger-docs/layouts/partials/css.html
@@ -1,19 +1,19 @@
-{{- $inServerMode := site.IsServer }}
-{{- $sass         := "sass/style.sass" }}
-{{- $target       := "css/style.css" }}
-{{- $includePaths := (slice "node_modules") }}
-{{- $cssDevOpts   := (dict "targetPath" $target "includePaths" $includePaths "enableSourceMap" true) }}
-{{- $cssProdOpts  := (dict "targetPath" $target "includePaths" $includePaths "outputStyle" "compressed") }}
-{{- $isDocs       := eq .Section "docs" }}
-{{- if $isDocs }}
+{{ $inServerMode := site.IsServer }}
+{{ $sass         := "sass/style.sass" }}
+{{ $target       := "css/style.css" }}
+{{ $includePaths := (slice "node_modules") }}
+{{ $cssDevOpts   := (dict "targetPath" $target "includePaths" $includePaths "enableSourceMap" true) }}
+{{ $cssProdOpts  := (dict "targetPath" $target "includePaths" $includePaths "outputStyle" "compressed") }}
+{{ $isDocs       := eq .Section "docs" }}
+{{ if $isDocs }}
 <link rel="stylesheet" href="/css/tocbot.css">
-{{- end }}
+{{ end }}
 <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-{{- $cssOpts := cond ($inServerMode) $cssDevOpts $cssProdOpts }}
-{{- $css := resources.Get "sass/style.sass" | toCSS $cssOpts }}
-{{- if $inServerMode }}
+{{ $cssOpts := cond ($inServerMode) $cssDevOpts $cssProdOpts }}
+{{ $css := resources.Get "sass/style.sass" | toCSS $cssOpts }}
+{{ if $inServerMode }}
 <link rel="stylesheet" media="screen" href="{{ $css.RelPermalink }}">
-{{- else }}
-{{- $prodCss := $css | fingerprint }}
+{{ else }}
+{{ $prodCss := $css | fingerprint }}
 <link rel="stylesheet" media="screen" href="{{ $prodCss.RelPermalink }}" integrity="{{ $prodCss.Data.Integrity }}">
-{{- end }}
+{{ end }}

--- a/themes/jaeger-docs/layouts/partials/docs/header.html
+++ b/themes/jaeger-docs/layouts/partials/docs/header.html
@@ -1,28 +1,30 @@
-{{- $versions      := site.Params.versions }}
-{{- $latest        := site.Params.latest }}
-{{- $version       := index (split .File.Path "/") 1 }}
-{{- $isLatest      := eq $version $latest }}
-{{- $isNextRelease := eq $version "next-release" }}
-{{- $latestUrl     := .RelPermalink | replaceRE $version $latest }}
+{{ $versions      := site.Params.versions }}
+{{ $latest        := site.Params.latest }}
+{{ $version       := index (split .File.Path "/") 1 }}
+{{ $isLatest      := eq $version $latest }}
+{{ $isNextRelease := eq $version "next-release" }}
+{{ $latestUrl     := .RelPermalink | replaceRE $version $latest }}
 <header>
   <p class="title is-1">{{ .Title }}</p>
-  {{- with .Params.description }}<p class="subtitle is-3">{{ . }}</p>{{ end }}
+  {{ with .Params.description }}
+  <p class="subtitle is-3">{{ . }}</p>
+  {{ end }}
 
   <div class="tags has-addons">
     <span class="tag is-medium">
       Version&nbsp;&nbsp;<strong>{{ $version }}</strong>
     </span>
-    {{- if $isLatest }}
+    {{ if $isLatest }}
     <span class="tag is-medium is-success">Latest</span>
-    {{- else if $isNextRelease }}
+    {{ else if $isNextRelease }}
     <a class="tag is-medium is-info">
       Preview
     </a>
-    {{- else }}
+    {{ else }}
     <a class="tag is-medium is-warning" href="{{ $latestUrl }}">
       Click here for the latest version
     </a>
-    {{- end }}
+    {{ end }}
   </div>
 
   <hr class="hr" />
@@ -30,16 +32,15 @@
   {{ if .Params.children }}
     <p>See also:</p>
     <ul>
-      {{- range .Params.children }}
-        {{- $url := printf "/docs/%s/%s/" $version .url }}
-        <li>
-          <a href="{{ $url }}">
-            {{ .title }}
-          </a>
-        </li>
-      {{- end }}
+      {{ range .Params.children }}
+      {{ $url := printf "/docs/%s/%s/" $version .url }}
+      <li>
+        <a href="{{ $url }}">
+          {{ .title }}
+        </a>
+      </li>
+      {{ end }}
     </ul>
     <hr class="hr" />
   {{ end }}
-
 </header>

--- a/themes/jaeger-docs/layouts/partials/docs/panel.html
+++ b/themes/jaeger-docs/layouts/partials/docs/panel.html
@@ -1,28 +1,28 @@
-{{- $currentVersion := index (split .File.Path "/") 1 }}
-{{- $versionDocsPath := printf "content/docs/%s" $currentVersion }}
-{{- $url := .RelPermalink }}
+{{ $currentVersion := index (split .File.Path "/") 1 }}
+{{ $versionDocsPath := printf "content/docs/%s" $currentVersion }}
+{{ $url := .RelPermalink }}
 <aside class="nav">
-  {{- range site.Pages }}
-  {{- $docVersion := index (split .File.Path "/") 1 }}
-  {{- if and (eq $docVersion $currentVersion) (not .Params.hasParent) }}
-  {{- $isCurrentPage := eq $url .RelPermalink }}
-  {{- $hasParent := .Params.hasparent }}
+  {{ range site.Pages }}
+  {{ $docVersion := index (split .File.Path "/") 1 }}
+  {{ if and (eq $docVersion $currentVersion) (not .Params.hasParent) }}
+  {{ $isCurrentPage := eq $url .RelPermalink }}
+  {{ $hasParent := .Params.hasparent }}
   <div class="nav-link">
     <a href="{{ .Permalink }}"{{ if $isCurrentPage }} class="is-active"{{ end }}>
       {{ if .Params.navtitle }}{{ .Params.navtitle }}{{ else }}{{ .Title }}{{ end }}
     </a>
 
-    {{- with .Params.children }}
-    {{- range . }}
-    {{- $url := printf "/docs/%s/%s/" $currentVersion .url }}
-    {{- $isCurrentPage := eq $url $.RelPermalink }}
+    {{ with .Params.children }}
+    {{ range . }}
+    {{ $url := printf "/docs/%s/%s/" $currentVersion .url }}
+    {{ $isCurrentPage := eq $url $.RelPermalink }}
     <br />
     <a class="nav-sublink{{ if $isCurrentPage }} is-active{{ end }}" href="{{ $url }}">
       &cir; {{ if .navtitle }}{{ .navtitle }}{{ else }}{{ .title }}{{ end }}
     </a>
-    {{- end }}
-    {{- end }}
+    {{ end }}
+    {{ end }}
   </div>
-  {{- end }}
-  {{- end }}
+  {{ end }}
+  {{ end }}
 </aside>

--- a/themes/jaeger-docs/layouts/partials/footer.html
+++ b/themes/jaeger-docs/layouts/partials/footer.html
@@ -1,7 +1,7 @@
-{{- $githubRepo    := .Site.Params.githubrepo }}
-{{- $twitterHandle := .Site.Params.twitterhandle }}
-{{- $gitterHandle  := .Site.Params.gitterhandle }}
-{{- $mediumHandle  := .Site.Params.mediumhandle }}
+{{ $githubRepo    := .Site.Params.githubrepo }}
+{{ $twitterHandle := .Site.Params.twitterhandle }}
+{{ $gitterHandle  := .Site.Params.gitterhandle }}
+{{ $mediumHandle  := .Site.Params.mediumhandle }}
 <footer class="footer">
   <div class="container">
     <div class="columns">
@@ -12,34 +12,34 @@
         <h4 class="is-size-4 is-size-3-mobile">
           Community
         </h4>
-        {{- with $githubRepo }}
+        {{ with $githubRepo }}
         <a href="https://github.com/{{ . }}">
           <span class="icon has-text-light">
             <i class="fab fa-lg fa-github"></i>
           </span>
         </a>
-        {{- end }}
-        {{- with $twitterHandle }}
+        {{ end }}
+        {{ with $twitterHandle }}
         <a href="https://twitter.com/{{ . }}">
           <span class="icon" style="color: #55acee;">
             <i class="fab fa-lg fa-twitter"></i>
           </span>
         </a>
-        {{- end }}
-        {{- with $gitterHandle }}
+        {{ end }}
+        {{ with $gitterHandle }}
         <a href="https://gitter.im/{{ . }}">
           <span class="icon" style="color: #e03464;">
             <i class="fab fa-gitter"></i>
           </span>
         </a>
-        {{- end }}
-        {{- with $mediumHandle }}
+        {{ end }}
+        {{ with $mediumHandle }}
         <a href="https://medium.com/{{ . }}">
           <span class="icon has-text-light">
             <i class="fab fa-lg fa-medium"></i>
           </span>
         </a>
-        {{- end }}
+        {{ end }}
       </div>
       <div class="column">
         <h4 class="is-size-4 is-size-3-mobile">

--- a/themes/jaeger-docs/layouts/partials/home/articles.html
+++ b/themes/jaeger-docs/layouts/partials/home/articles.html
@@ -4,14 +4,14 @@
 
     <div class="blog__container">
       <ul class="blog__slider">
-        {{- range .posts }}
-        {{- $link    := .link }}
-        {{- $img     := .thumbnail }}
-        {{- $title   := .title }}
-        {{- $author  := .author }}
-        {{- $dateRaw := .pubDate }}
-        {{- $date    := dateFormat "January 2, 2006" $dateRaw }}
-        {{- $summary := .content | plainify | truncate 150 }}
+        {{ range .posts }}
+        {{ $link    := .link }}
+        {{ $img     := .thumbnail }}
+        {{ $title   := .title }}
+        {{ $author  := .author }}
+        {{ $dateRaw := .pubDate }}
+        {{ $date    := dateFormat "January 2, 2006" $dateRaw }}
+        {{ $summary := .content | plainify | truncate 150 }}
 
 
         <li class="blog__post">
@@ -19,11 +19,11 @@
             <img src="{{ $img }}" class="blog__topImg"></img>
             <div class="blog__content">
               <div class="blog__preview">
-                  <h2 class="blog__title">{{ $title }}</h2>
+                <h2 class="blog__title">{{ $title }}</h2>
 
-                  <p class="blog__intro">
-                    {{ $summary }}
-                  </p>
+                <p class="blog__intro">
+                  {{ $summary }}
+                </p>
               </div>
               <hr>
               <div class="blog__info">
@@ -38,7 +38,7 @@
             </div>
           </a>
          </li>
-        {{- end }}
+        {{ end }}
       </ul>
     </div>
   </div>

--- a/themes/jaeger-docs/layouts/partials/home/features.html
+++ b/themes/jaeger-docs/layouts/partials/home/features.html
@@ -4,14 +4,14 @@
       Problems that Jaeger addresses
     </h2>
     <div class="columns">
-      {{- range site.Data.indexpage.features }}
+      {{ range site.Data.indexpage.features }}
       <div class="column has-text-centered">
         <span class="icon is-large">
           <i class="material-icons is-size-1 has-text-primary">{{ default "data_usage" .icon }}</i>
         </span>
         <h4 class="is-size-4 is-size-5-mobile">{{ .text | markdownify }}</h4>
       </div>
-      {{- end }}
+      {{ end }}
     </div>
   </div>
 </section>

--- a/themes/jaeger-docs/layouts/partials/javascript.html
+++ b/themes/jaeger-docs/layouts/partials/javascript.html
@@ -1,7 +1,7 @@
 <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
 <script defer src="https://use.fontawesome.com/releases/v5.0.7/js/all.js"></script>
-{{- $jsFiles := (slice "jquery-ui-1.9.1.custom.min.js" "anchor.min.js" "tocbot.min.js" "app.js" "lunr-2.3.6.min.js") }}
-{{- range $jsFiles }}
-{{- $js := resources.Get (printf "js/%s" .) | minify | fingerprint }}
+{{ $jsFiles := (slice "jquery-ui-1.9.1.custom.min.js" "anchor.min.js" "tocbot.min.js" "app.js" "lunr-2.3.6.min.js") }}
+{{ range $jsFiles }}
+{{ $js := resources.Get (printf "js/%s" .) | minify | fingerprint }}
 <script src="{{ $js.Permalink }}" integrity="{{ $js.Data.Integrity }}"></script>
-{{- end }}
+{{ end }}

--- a/themes/jaeger-docs/layouts/partials/meta.html
+++ b/themes/jaeger-docs/layouts/partials/meta.html
@@ -1,31 +1,37 @@
-{{- $isHome := eq .Kind "home" }}
-{{- $title := cond $isHome site.Title .Title }}
-{{- $description := cond $isHome site.Params.tagline .Params.description }}
-{{- $isDoc := eq .Section "docs" }}
-{{- $type := cond $isHome "website" "article" }}
-{{- $twitterHandle := site.Params.twitterHandle }}
-{{- $imageUrl := printf "%s/%s" site.BaseURL site.Params.openGraphImage }}
+{{ $isHome := eq .Kind "home" }}
+{{ $title := cond $isHome site.Title .Title }}
+{{ $description := cond $isHome site.Params.tagline .Params.description }}
+{{ $isDoc := eq .Section "docs" }}
+{{ $type := cond $isHome "website" "article" }}
+{{ $twitterHandle := site.Params.twitterHandle }}
+{{ $imageUrl := printf "%s/%s" site.BaseURL site.Params.openGraphImage }}
 <meta charset="utf-8" />
 <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
-{{- with $description }}<meta name="description" content="{{ . }}" />{{- end }}
+{{ with $description }}
+<meta name="description" content="{{ . }}" />
+{{ end }}
 {{ hugo.Generator }}
 
 <!-- OpenGraph metadata -->
 <meta property="og:title" content="{{ $title }}" />
-{{- if $isDoc }}
-{{- $version := index (split .File.Path "/") 1 }}
-{{- $latest := site.Params.latest }}
-{{- $url := replace .Permalink $version "latest" }}
+{{ if $isDoc }}
+{{ $version := index (split .File.Path "/") 1 }}
+{{ $latest := site.Params.latest }}
+{{ $url := replace .Permalink $version "latest" }}
 <meta property="og:type" content="documentation" />
 <meta property="og:url" content="{{ $url }}" />
 <link rel="canonical" href="{{ $url }}" />
-{{- else }}
+{{ else }}
 <meta property="og:url" content="{{ .Permalink }}" />
 <link rel="canonical" href="{{ .Permalink }}" />
-{{- end }}
+{{ end }}
 <meta property="og:locale" content="en_US" />
-{{- if not $isHome }}<meta property="og:site_name" content="{{ site.Title }}" />{{- end }}
-{{- with $description }}<meta property="og:description" content="{{ . }}" />{{- end }}
+{{ if not $isHome }}
+<meta property="og:site_name" content="{{ site.Title }}" />
+{{ end }}
+{{ with $description }}
+<meta property="og:description" content="{{ . }}" />
+{{ end }}
 <meta name="og:type" content="{{ $type }}" />
 <meta name="og:image" content="{{ $imageUrl }}" />
 <meta name="og:image:alt" content="Jaeger tracing project logo" />

--- a/themes/jaeger-docs/layouts/partials/navbar.html
+++ b/themes/jaeger-docs/layouts/partials/navbar.html
@@ -1,13 +1,13 @@
-{{- $menuPages     := site.Menus.docs }}
-{{- $githubRepo    := site.Params.githubrepo }}
-{{- $twitterHandle := site.Params.twitterhandle }}
-{{- $versions      := site.Params.versions }}
-{{- $latest        := site.Params.latest }}
-{{- $docs          := where site.Pages "Section" "docs" }}
-{{- $isDocsPage    := eq .Section "docs" }}
-{{- $preview       := getenv "HUGO_PREVIEW" }}
-{{- $isPreview     := eq $preview "true" }}
-{{- $currentVersion := index (split .File.Path "/") 1 }}
+{{ $menuPages     := site.Menus.docs }}
+{{ $githubRepo    := site.Params.githubrepo }}
+{{ $twitterHandle := site.Params.twitterhandle }}
+{{ $versions      := site.Params.versions }}
+{{ $latest        := site.Params.latest }}
+{{ $docs          := where site.Pages "Section" "docs" }}
+{{ $isDocsPage    := eq .Section "docs" }}
+{{ $preview       := getenv "HUGO_PREVIEW" }}
+{{ $isPreview     := eq $preview "true" }}
+{{ $currentVersion := index (split .File.Path "/") 1 }}
 <nav class="navbar is-fixed-top">
   <div class="container is-fluid">
     <div class="navbar-brand">
@@ -56,9 +56,9 @@
             Docs
           </a>
           <div class="navbar-dropdown">
-            {{- range $docs }}
-            {{- $docVersion := index (split .File.Path "/") 1 }}
-            {{- if and (eq $docVersion $latest) (not .Params.hasparent) }}
+            {{ range $docs }}
+            {{ $docVersion := index (split .File.Path "/") 1 }}
+            {{ if and (eq $docVersion $latest) (not .Params.hasparent) }}
             <a class="navbar-item" href="{{ .RelPermalink }}">
               {{ .Title }}
             </a>
@@ -71,32 +71,32 @@
             </a>
             {{ end }}
             {{ end }}
-            {{- end }}
-            {{- end }}
+            {{ end }}
+            {{ end }}
           </div>
         </div>
 
-        {{- if $isDocsPage }}
+        {{ if $isDocsPage }}
         <div class="navbar-item has-dropdown is-hoverable">
           <a class="navbar-link">
             Versions
           </a>
           <div class="navbar-dropdown">
-            {{- range $versions }}
-            {{- $version := . }}
-            {{- $isLatest := eq $version $latest }}
+            {{ range $versions }}
+            {{ $version := . }}
+            {{ $isLatest := eq $version $latest }}
             <a class="navbar-item" href="/docs/{{ $version }}">
               {{ $version }}{{ if $isLatest }}&nbsp;&nbsp;(<strong>latest</strong>){{ end }}
             </a>
-            {{- end }}
-            {{- if $isPreview }}
+            {{ end }}
+            {{ if $isPreview }}
               <a class="navbar-item" href="/docs/next-release">
                 next-release&nbsp;&nbsp;(preview)
               </a>
-            {{- end }}
+            {{ end }}
           </div>
         </div>
-        {{- end }}
+        {{ end }}
 
         <a class="navbar-item" href="https://medium.com/jaegertracing" target="_blank">
           Blog
@@ -138,20 +138,20 @@
           </div>
         </div>
 
-        {{- with $githubRepo }}
+        {{ with $githubRepo }}
         <a class="navbar-item" href="https://github.com/{{ . }}" target="_blank">
           <span class="icon">
             <i class="fab fa-github" style="color: #333;"></i>
           </span>
         </a>
-        {{- end }}
-        {{- with $twitterHandle }}
+        {{ end }}
+        {{ with $twitterHandle }}
         <a class="navbar-item" href="https://twitter.com/{{ . }}" target="_blank">
           <span class="icon" style="color: #55acee;">
             <i class="fab fa-twitter"></i>
           </span>
         </a>
-        {{- end }}
+        {{ end }}
       </div>
     </div>
   </div>

--- a/themes/jaeger-docs/layouts/shortcodes/binaries.html
+++ b/themes/jaeger-docs/layouts/shortcodes/binaries.html
@@ -1,9 +1,9 @@
-{{- $latest        := .Site.Params.binariesLatest }}
-{{- $binaries      := .Site.Data.download.binaries }}
-{{- $releaseUrl    := printf "https://github.com/jaegertracing/jaeger/releases/tag/v%s" $latest }}
-{{- $zipUrl        := printf "https://github.com/jaegertracing/jaeger/archive/v%s.zip" $latest }}
-{{- $tarUrl        := printf "https://github.com/jaegertracing/jaeger/archive/v%s.tar.gz" $latest }}
-{{- $platforms     := $binaries.platforms }}
+{{ $latest        := .Site.Params.binariesLatest }}
+{{ $binaries      := .Site.Data.download.binaries }}
+{{ $releaseUrl    := printf "https://github.com/jaegertracing/jaeger/releases/tag/v%s" $latest }}
+{{ $zipUrl        := printf "https://github.com/jaegertracing/jaeger/archive/v%s.zip" $latest }}
+{{ $tarUrl        := printf "https://github.com/jaegertracing/jaeger/archive/v%s.tar.gz" $latest }}
+{{ $platforms     := $binaries.platforms }}
 <table class="table is-striped">
   <thead>
     <tr>
@@ -28,13 +28,13 @@
       </td>
       <td>
         <p class="buttons">
-          {{- range $key, $platform := $platforms }}
-          {{- $name        := $platform.name }}
-          {{- $icon        := $platform.icon }}
-          {{- $asset       := printf "jaeger-%s-%s-amd64.tar.gz" $latest $key }}
-          {{- $downloadUrl := printf "https://github.com/jaegertracing/jaeger/releases/download/v%s/%s" $latest $asset }}
-          {{- $zipUrl      := printf "https://github.com/jaegertracing/jaeger/archive/v%s.zip" $latest }}
-          {{- $tarUrl      := printf "https://github.com/jaegertracing/jaeger/archive/v%s.tar.gz" $latest }}
+          {{ range $key, $platform := $platforms }}
+          {{ $name        := $platform.name }}
+          {{ $icon        := $platform.icon }}
+          {{ $asset       := printf "jaeger-%s-%s-amd64.tar.gz" $latest $key }}
+          {{ $downloadUrl := printf "https://github.com/jaegertracing/jaeger/releases/download/v%s/%s" $latest $asset }}
+          {{ $zipUrl      := printf "https://github.com/jaegertracing/jaeger/archive/v%s.zip" $latest }}
+          {{ $tarUrl      := printf "https://github.com/jaegertracing/jaeger/archive/v%s.tar.gz" $latest }}
           <a class="button is-medium is-{{ $key }}" href="{{ $downloadUrl }}" download>
             <span class="icon">
               <i class="fab {{ $icon }}"></i>
@@ -43,7 +43,7 @@
               {{ $name }}
             </span>
           </a>
-          {{- end }}
+          {{ end }}
           <a class="button is-medium is-zip" href="{{ $zipUrl }}" download>
             <span class="icon">
               <i class="fas fa-file-archive"></i>

--- a/themes/jaeger-docs/layouts/shortcodes/cli/tools-list.html
+++ b/themes/jaeger-docs/layouts/shortcodes/cli/tools-list.html
@@ -1,8 +1,8 @@
-{{- $versionFromPath := index (split $.Page.File.Path "/") 1 }}
-{{- $isNextRelease := eq $versionFromPath "next-release" }}
-{{- $version := cond ($isNextRelease) site.Params.latest $versionFromPath }}
-{{- $data    := index site.Data.cli $version }}
-{{- $config  := index (index site.Data.cli $versionFromPath) "config" }}
+{{ $versionFromPath := index (split $.Page.File.Path "/") 1 }}
+{{ $isNextRelease := eq $versionFromPath "next-release" }}
+{{ $version := cond ($isNextRelease) site.Params.latest $versionFromPath }}
+{{ $data    := index site.Data.cli $version }}
+{{ $config  := index (index site.Data.cli $versionFromPath) "config" }}
 
 {{ if $isNextRelease }}
   <p><b>NOTE: This page is generated for version {{ $version }}.</b></p>

--- a/themes/jaeger-docs/layouts/shortcodes/clientsTable.html
+++ b/themes/jaeger-docs/layouts/shortcodes/clientsTable.html
@@ -1,5 +1,5 @@
-{{- $clients := site.Data.clients.clients }}
-{{- $features := site.Data.clients.features }}
+{{ $clients := site.Data.clients.clients }}
+{{ $features := site.Data.clients.features }}
 <table>
   <thead>
     <tr>
@@ -8,13 +8,13 @@
     </tr>
   </thead>
   <tbody>
-    {{- range $clients }}
+    {{ range $clients }}
     <tr>
       <td>{{ .language }}</td>
       <td>
         <a href="https://github.com/{{ .repo }}">{{ .repo }}</a>
       </td>
     </tr>
-    {{- end }}
+    {{ end }}
   </tbody>
 </table>

--- a/themes/jaeger-docs/layouts/shortcodes/definition.html
+++ b/themes/jaeger-docs/layouts/shortcodes/definition.html
@@ -1,3 +1,3 @@
-{{- $term := .Get 0 }}
-{{- $definition := index site.Data.definitions $term }}
+{{ $term := .Get 0 }}
+{{ $definition := index site.Data.definitions $term }}
 <p>{{ $definition | markdownify }}</p>

--- a/themes/jaeger-docs/layouts/shortcodes/dockerImages.html
+++ b/themes/jaeger-docs/layouts/shortcodes/dockerImages.html
@@ -1,5 +1,5 @@
-{{- $dockerImages := site.Data.download.docker }}
-{{- $latest       := site.Params.latest }}
+{{ $dockerImages := site.Data.download.docker }}
+{{ $latest       := site.Params.latest }}
 <table>
   <thead>
     <tr>
@@ -9,15 +9,15 @@
     </tr>
   </thead>
   <tbody>
-    {{- range $dockerImages }}
-    {{- $org         := "jaegertracing" }}
-    {{- $image       := .image }}
-    {{- $fullImage   := printf "%s/%s" $org $image }}
-    {{- $link        := printf "https://hub.docker.com/r/%s/%s" $org $image }}
-    {{- $description := .description | markdownify }}
-    {{- $since       := .since }}
-    {{- $latestImg   := .latest | default $latest }}
-    {{- $pullCmd     := printf "<code><span class=\"is-dollar\">$</span> docker pull %s:%s</code>" $fullImage $latestImg | safeHTML }}
+    {{ range $dockerImages }}
+    {{ $org         := "jaegertracing" }}
+    {{ $image       := .image }}
+    {{ $fullImage   := printf "%s/%s" $org $image }}
+    {{ $link        := printf "https://hub.docker.com/r/%s/%s" $org $image }}
+    {{ $description := .description | markdownify }}
+    {{ $since       := .since }}
+    {{ $latestImg   := .latest | default $latest }}
+    {{ $pullCmd     := printf "<code><span class=\"is-dollar\">$</span> docker pull %s:%s</code>" $fullImage $latestImg | safeHTML }}
     <tr>
       <td>
         <a href="{{ $link }}">
@@ -25,11 +25,11 @@
         </a>
       </td>
       <td>
-        {{- with $description }}
+        {{ with $description }}
         <p>
           {{ . }}
         </p>
-        {{- end }}
+        {{ end }}
         <div>
           {{ $pullCmd }}
         </div>
@@ -38,6 +38,6 @@
         {{ $since }}
       </td>
     </tr>
-    {{- end }}
+    {{ end }}
   </tbody>
 </table>

--- a/themes/jaeger-docs/layouts/shortcodes/featuresTable.html
+++ b/themes/jaeger-docs/layouts/shortcodes/featuresTable.html
@@ -1,35 +1,35 @@
-{{- $clients := site.Data.clients.clients }}
-{{- $featureGroups := site.Data.clients.featureGroups }}
+{{ $clients := site.Data.clients.clients }}
+{{ $featureGroups := site.Data.clients.featureGroups }}
 <table>
   <tbody>
-    {{- range $featureGroups }}
+    {{ range $featureGroups }}
     <tr class="feature-table-sticky-row">
       <th class="feature-table-header" colspan="7">{{ .description | markdownify }}</th>
     </tr>
     <tr class="feature-table-sticky-row">
       <th class="feature-table-sub-header">Feature</th>
-      {{- range $clients }}
+      {{ range $clients }}
       <th class="feature-table-sub-header">{{ .language }}</th>
-      {{- end }}
+      {{ end }}
     </tr>
-    {{- range .features }}
-    {{- $featureName := .name }}
+    {{ range .features }}
+    {{ $featureName := .name }}
     <tr>
-      {{- $description := default .name .description }}
+      {{ $description := default .name .description }}
       <td>{{ $description | markdownify }}</td>
-      {{- range $clients }}
-      {{- $supported := index .features $featureName }}
-      {{- if eq $supported true }}
+      {{ range $clients }}
+      {{ $supported := index .features $featureName }}
+      {{ if eq $supported true }}
       <td>{{ emojify ":white_check_mark:" }}</td>
-      {{- else if eq $supported false }}
+      {{ else if eq $supported false }}
       <td>{{ emojify ":x:" }}</td>
-      {{- else }}
-      {{- $supported := default (emojify ":grey_question:") $supported }}
+      {{ else }}
+      {{ $supported := default (emojify ":grey_question:") $supported }}
       <td>{{ $supported | markdownify }}</td>
-      {{- end }}
-      {{- end }}
+      {{ end }}
+      {{ end }}
     </tr>
-    {{- end }}
-    {{- end }}
+    {{ end }}
+    {{ end }}
   </tbody>
   </table>


### PR DESCRIPTION
This PR updates the site to the latest version of Hugo and makes a few changes related to the site build:

* It minifies HTML output, which allows for more compact assets and should speed up page load times a little bit
* It moves the Netlify build commands into the Makefile
* It eliminates markup that's no longer necessary given HTML minification (i.e. `{{- ... -}}` can now be `{{ ... }}` in most cases)