### PR TITLE
Fix value type in Jaeger Operator default sampling example

### DIFF
--- a/content/docs/1.13/operator.md
+++ b/content/docs/1.13/operator.md
@@ -526,7 +526,7 @@ spec:
     options:
       default_strategy:
         type: probabilistic
-        param: 50
+        param: .5
 ```
 
 This example defines a default sampling strategy that is probabilistic, with a 50% chance of the trace instances being sampled.

--- a/content/docs/1.13/operator.md
+++ b/content/docs/1.13/operator.md
@@ -526,7 +526,7 @@ spec:
     options:
       default_strategy:
         type: probabilistic
-        param: .5
+        param: 0.5
 ```
 
 This example defines a default sampling strategy that is probabilistic, with a 50% chance of the trace instances being sampled.

--- a/content/docs/1.14/operator.md
+++ b/content/docs/1.14/operator.md
@@ -544,7 +544,7 @@ spec:
     options:
       default_strategy:
         type: probabilistic
-        param: .5
+        param: 0.5
 ```
 
 This example defines a default sampling strategy that is probabilistic, with a 50% chance of the trace instances being sampled.

--- a/content/docs/1.14/operator.md
+++ b/content/docs/1.14/operator.md
@@ -544,7 +544,7 @@ spec:
     options:
       default_strategy:
         type: probabilistic
-        param: 50
+        param: .5
 ```
 
 This example defines a default sampling strategy that is probabilistic, with a 50% chance of the trace instances being sampled.

--- a/content/docs/1.15/operator.md
+++ b/content/docs/1.15/operator.md
@@ -619,7 +619,7 @@ spec:
     options:
       default_strategy:
         type: probabilistic
-        param: .5
+        param: 0.5
 ```
 
 This example defines a default sampling strategy that is probabilistic, with a 50% chance of the trace instances being sampled.

--- a/content/docs/1.15/operator.md
+++ b/content/docs/1.15/operator.md
@@ -619,7 +619,7 @@ spec:
     options:
       default_strategy:
         type: probabilistic
-        param: 50
+        param: .5
 ```
 
 This example defines a default sampling strategy that is probabilistic, with a 50% chance of the trace instances being sampled.

--- a/content/docs/1.16/operator.md
+++ b/content/docs/1.16/operator.md
@@ -693,7 +693,7 @@ spec:
     options:
       default_strategy:
         type: probabilistic
-        param: 50
+        param: .5
 ```
 
 This example defines a default sampling strategy that is probabilistic, with a 50% chance of the trace instances being sampled.

--- a/content/docs/1.16/operator.md
+++ b/content/docs/1.16/operator.md
@@ -693,7 +693,7 @@ spec:
     options:
       default_strategy:
         type: probabilistic
-        param: .5
+        param: 0.5
 ```
 
 This example defines a default sampling strategy that is probabilistic, with a 50% chance of the trace instances being sampled.

--- a/content/docs/1.17/operator.md
+++ b/content/docs/1.17/operator.md
@@ -859,7 +859,7 @@ spec:
     options:
       default_strategy:
         type: probabilistic
-        param: 50
+        param: .5
 ```
 
 This example defines a default sampling strategy that is probabilistic, with a 50% chance of the trace instances being sampled.

--- a/content/docs/1.17/operator.md
+++ b/content/docs/1.17/operator.md
@@ -859,7 +859,7 @@ spec:
     options:
       default_strategy:
         type: probabilistic
-        param: .5
+        param: 0.5
 ```
 
 This example defines a default sampling strategy that is probabilistic, with a 50% chance of the trace instances being sampled.

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -859,7 +859,7 @@ spec:
     options:
       default_strategy:
         type: probabilistic
-        param: 50
+        param: .5
 ```
 
 This example defines a default sampling strategy that is probabilistic, with a 50% chance of the trace instances being sampled.

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -859,7 +859,7 @@ spec:
     options:
       default_strategy:
         type: probabilistic
-        param: .5
+        param: 0.5
 ```
 
 This example defines a default sampling strategy that is probabilistic, with a 50% chance of the trace instances being sampled.


### PR DESCRIPTION
Resolves #386 

## Which problem is this PR solving?
- Jaeger Operator default sampling configuration uses integer value type instead of double

## Short description of the changes
- Value of 50 was changed to .5
