### PR TITLE
Modify links to prevent 404 error

### DIFF
--- a/content/docs/1.17/apis.md
+++ b/content/docs/1.17/apis.md
@@ -23,9 +23,7 @@ For legacy reasons, the Agent also accepts spans in Zipkin format, however, only
 
 ### Protobuf via gRPC (stable)
 
-In a typical Jaeger deployment, Agents receive spans from Clients and forward them to Collectors. Since Jaeger version 1.11 the official and recommended protocol between Agents and Collectors is gRPC with Protobuf. 
-
-The Protobuf IDL [collector.proto][collector.proto] is currently located in the main Jaeger repository, under [model/proto/api_v2][collector.proto]. In the future it will be moved to [jaeger-idl][jaeger-idl] repository ([jaeger-idl/issues/55](https://github.com/jaegertracing/jaeger-idl/issues/55)).
+In a typical Jaeger deployment, Agents receive spans from Clients and forward them to Collectors. Since Jaeger version 1.11 the official and recommended protocol between Agents and Collectors is gRPC with Protobuf as defined in [collector.proto][collector.proto] IDL file.
 
 ### Thrift over HTTP (stable)
 
@@ -58,7 +56,7 @@ Traces saved in the storage can be retrieved by calling Jaeger Query Service.
 
 ### gRPC/Protobuf (stable)
 
-The recommended way for programmatically retrieving traces and other data is via gRPC endpoint defined in [query.proto][query.proto] IDL file (located in the main Jaeger repository, similar to [collector.proto][collector.proto]).
+The recommended way for programmatically retrieving traces and other data is via gRPC endpoint defined in [query.proto][query.proto] IDL file.
 
 ### HTTP JSON (internal)
 
@@ -83,5 +81,5 @@ For programmatic access to service graph, the recommended API is gRPC/Protobuf d
 [jaeger.thrift]: https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift
 [agent.thrift]: https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/agent.thrift
 [sampling.thrift]: https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/sampling.thrift
-[collector.proto]: https://github.com/jaegertracing/jaeger/blob/master/model/proto/api_v2/collector.proto
-[query.proto]: https://github.com/jaegertracing/jaeger/blob/master/model/proto/api_v2/query.proto
+[collector.proto]: https://github.com/jaegertracing/jaeger-idl/blob/master/proto/api_v2/collector.proto
+[query.proto]: https://github.com/jaegertracing/jaeger-idl/blob/master/proto/api_v2/query.proto

--- a/content/docs/next-release/apis.md
+++ b/content/docs/next-release/apis.md
@@ -23,9 +23,7 @@ For legacy reasons, the Agent also accepts spans in Zipkin format, however, only
 
 ### Protobuf via gRPC (stable)
 
-In a typical Jaeger deployment, Agents receive spans from Clients and forward them to Collectors. Since Jaeger version 1.11 the official and recommended protocol between Agents and Collectors is gRPC with Protobuf. 
-
-The Protobuf IDL [collector.proto][collector.proto] is currently located in the main Jaeger repository, under [model/proto/api_v2][collector.proto]. In the future it will be moved to [jaeger-idl][jaeger-idl] repository ([jaeger-idl/issues/55](https://github.com/jaegertracing/jaeger-idl/issues/55)).
+In a typical Jaeger deployment, Agents receive spans from Clients and forward them to Collectors. Since Jaeger version 1.11 the official and recommended protocol between Agents and Collectors is gRPC with Protobuf as defined in [collector.proto][collector.proto] IDL file.
 
 ### Thrift over HTTP (stable)
 
@@ -58,7 +56,7 @@ Traces saved in the storage can be retrieved by calling Jaeger Query Service.
 
 ### gRPC/Protobuf (stable)
 
-The recommended way for programmatically retrieving traces and other data is via gRPC endpoint defined in [query.proto][query.proto] IDL file (located in the main Jaeger repository, similar to [collector.proto][collector.proto]).
+The recommended way for programmatically retrieving traces and other data is via gRPC endpoint defined in [query.proto][query.proto] IDL file.
 
 ### HTTP JSON (internal)
 
@@ -83,5 +81,5 @@ For programmatic access to service graph, the recommended API is gRPC/Protobuf d
 [jaeger.thrift]: https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift
 [agent.thrift]: https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/agent.thrift
 [sampling.thrift]: https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/sampling.thrift
-[collector.proto]: https://github.com/jaegertracing/jaeger/blob/master/model/proto/api_v2/collector.proto
-[query.proto]: https://github.com/jaegertracing/jaeger/blob/master/model/proto/api_v2/query.proto
+[collector.proto]: https://github.com/jaegertracing/jaeger-idl/blob/master/proto/api_v2/collector.proto
+[query.proto]: https://github.com/jaegertracing/jaeger-idl/blob/master/proto/api_v2/query.proto


### PR DESCRIPTION
Now the links for collector.proto and query.proto in the
docs/1.17/apis [page](https://www.jaegertracing.io/docs/1.17/apis/#protobuf-via-grpc-stable) will triger 404 error, so I modify the links to
jump to the proper location in jaeger-idl repository.

Signed-off-by: Panlichen <plch368@qq.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Now the links for collector.proto and query.proto in the docs/1.17/apis [page](https://www.jaegertracing.io/docs/1.17/apis/#protobuf-via-grpc-stable) will triger 404 error.

## Short description of the changes
- Modify the links to jump to the proper location in jaeger-idl repository.
