### PR TITLE
Fix jaeger-operator sampling strategy example

### DIFF
--- a/content/docs/1.13/operator.md
+++ b/content/docs/1.13/operator.md
@@ -526,7 +526,7 @@ spec:
     options:
       default_strategy:
         type: probabilistic
-        param: 50
+        param: 0.5
 ```
 
 This example defines a default sampling strategy that is probabilistic, with a 50% chance of the trace instances being sampled.

--- a/content/docs/1.14/operator.md
+++ b/content/docs/1.14/operator.md
@@ -544,7 +544,7 @@ spec:
     options:
       default_strategy:
         type: probabilistic
-        param: 50
+        param: 0.5
 ```
 
 This example defines a default sampling strategy that is probabilistic, with a 50% chance of the trace instances being sampled.

--- a/content/docs/1.15/operator.md
+++ b/content/docs/1.15/operator.md
@@ -619,7 +619,7 @@ spec:
     options:
       default_strategy:
         type: probabilistic
-        param: 50
+        param: 0.5
 ```
 
 This example defines a default sampling strategy that is probabilistic, with a 50% chance of the trace instances being sampled.

--- a/content/docs/1.16/operator.md
+++ b/content/docs/1.16/operator.md
@@ -693,7 +693,7 @@ spec:
     options:
       default_strategy:
         type: probabilistic
-        param: 50
+        param: 0.5
 ```
 
 This example defines a default sampling strategy that is probabilistic, with a 50% chance of the trace instances being sampled.

--- a/content/docs/1.17/operator.md
+++ b/content/docs/1.17/operator.md
@@ -859,7 +859,7 @@ spec:
     options:
       default_strategy:
         type: probabilistic
-        param: 50
+        param: 0.5
 ```
 
 This example defines a default sampling strategy that is probabilistic, with a 50% chance of the trace instances being sampled.

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -859,7 +859,7 @@ spec:
     options:
       default_strategy:
         type: probabilistic
-        param: 50
+        param: 0.5
 ```
 
 This example defines a default sampling strategy that is probabilistic, with a 50% chance of the trace instances being sampled.


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- The param for probabilistic strategy when setting sampling options using the jaeger-operator should lie in the range [0,1], not [0,100] - https://github.com/jaegertracing/jaeger-client-node/issues/435

## Short description of the changes
- This PR changes the probabilistic param from 50 to 0.5 on the provided example
