### PR TITLE
Remove redundant Configuration section

### DIFF
--- a/content/docs/1.18/deployment.md
+++ b/content/docs/1.18/deployment.md
@@ -37,7 +37,7 @@ Jaeger binaries can be configured in a number of ways (in the order of decreasin
   * environment variables,
   * configuration files in JSON, TOML, YAML, HCL, or Java properties formats.
 
-To see the complete list of options, run the binary with `help` command. Options that are specific to a certain storage backend are only listed if the storage type is selected. For example, to see all available options in the Collector with Cassandra storage:
+To see the complete list of options, run the binary with `help` command or refer to the [CLI Flags](../cli/) page for more information. Options that are specific to a certain storage backend are only listed if the storage type is selected. For example, to see all available options in the Collector with Cassandra storage:
 
 ```sh
 $ docker run --rm \
@@ -516,10 +516,6 @@ Please refer to the [dedicated Frontend/UI page](../frontend-ui/).
 ## Aggregation Jobs for Service Dependencies
 
 Production deployments need an external process which aggregates data and creates dependency links between services. Project [spark-dependencies](https://github.com/jaegertracing/spark-dependencies) is a Spark job which derives dependency links and stores them directly to the storage.
-
-## Configuration
-
-All binaries accepts command line properties and environmental variables, power by [viper](https://github.com/spf13/viper) and [cobra](https://github.com/spf13/cobra) libraries. Please refer to the [CLI Flags](../cli/) page for more information.
 
 [cqlsh]: http://cassandra.apache.org/doc/latest/tools/cqlsh.html
 [zipkin-thrift]: https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/zipkincore.thrift

--- a/content/docs/next-release/deployment.md
+++ b/content/docs/next-release/deployment.md
@@ -37,7 +37,7 @@ Jaeger binaries can be configured in a number of ways (in the order of decreasin
   * environment variables,
   * configuration files in JSON, TOML, YAML, HCL, or Java properties formats.
 
-To see the complete list of options, run the binary with `help` command. Options that are specific to a certain storage backend are only listed if the storage type is selected. For example, to see all available options in the Collector with Cassandra storage:
+To see the complete list of options, run the binary with `help` command or refer to the [CLI Flags](../cli/) page for more information. Options that are specific to a certain storage backend are only listed if the storage type is selected. For example, to see all available options in the Collector with Cassandra storage:
 
 ```sh
 $ docker run --rm \
@@ -516,10 +516,6 @@ Please refer to the [dedicated Frontend/UI page](../frontend-ui/).
 ## Aggregation Jobs for Service Dependencies
 
 Production deployments need an external process which aggregates data and creates dependency links between services. Project [spark-dependencies](https://github.com/jaegertracing/spark-dependencies) is a Spark job which derives dependency links and stores them directly to the storage.
-
-## Configuration
-
-All binaries accepts command line properties and environmental variables, power by [viper](https://github.com/spf13/viper) and [cobra](https://github.com/spf13/cobra) libraries. Please refer to the [CLI Flags](../cli/) page for more information.
 
 [cqlsh]: http://cassandra.apache.org/doc/latest/tools/cqlsh.html
 [zipkin-thrift]: https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/zipkincore.thrift


### PR DESCRIPTION
It gets a weird anchor `#configuration-3` and we already have a top `Configuration Options` section.