### PR TITLE
Remove tchannel collector port

### DIFF
--- a/content/docs/1.18/apis.md
+++ b/content/docs/1.18/apis.md
@@ -39,10 +39,6 @@ Content-Type: application/vnd.apache.thrift.binary
 
 There is no official Jaeger JSON format that can be accepted by the collector. In the future the Protobuf-generated JSON may be supported.
 
-### Thrift via TChannel (deprecated)
-
-Agent and Collector can communicate using TChannel protocol. This protocol is generally not supported by the routing infrastructure and has been deprecated. It will be eventually removed from Jaeger.
-
 ### Zipkin Formats (stable)
 
 Jaeger Collector can also accept spans in several Zipkin data format, namely JSON v1/v2 and Thrift. The Collector needs to be configured to enable Zipkin HTTP server, e.g. on port 9411 used by Zipkin collectors. The server enables two endpoints that expect POST requests:

--- a/content/docs/1.18/deployment.md
+++ b/content/docs/1.18/deployment.md
@@ -108,7 +108,7 @@ When using gRPC, you have several options for load balancing and name resolution
 
 ### Agent level tags
 
-Jaeger supports agent level tags, that can be added to the process tags of all spans passing through the agent. This is supported through the command line flag `--jaeger.tags=key1=value1,key2=value2,...,keyn=valuen`. Tags can also be set through an environment flag like so - `--jaeger.tags=key=${envFlag:defaultValue}` - The tag value will be set to the value of the `envFlag` environment key and `defaultValue` if not set. This feature is not supported for the tchannel reporter, enabled using the flags `--collector.host-port` or `--reporter.tchannel.host-port`.
+Jaeger supports agent level tags, that can be added to the process tags of all spans passing through the agent. This is supported through the command line flag `--jaeger.tags=key1=value1,key2=value2,...,keyn=valuen`. Tags can also be set through an environment flag like so - `--jaeger.tags=key=${envFlag:defaultValue}` - The tag value will be set to the value of the `envFlag` environment key and `defaultValue` if not set.
 
 ## Collectors
 
@@ -131,7 +131,6 @@ At default settings the collector exposes the following ports:
 
 Port  | Protocol | Function
 ----- | -------  | ---
-14267 | TChannel | used by **jaeger-agent** to send spans in jaeger.thrift format
 14250 | gRPC     | used by **jaeger-agent** to send spans in model.proto format
 14268 | HTTP     | can accept spans directly from clients in jaeger.thrift format over binary thrift protocol
 9411  | HTTP     | can accept Zipkin spans in Thrift, JSON and Proto (disabled by default)

--- a/content/docs/next-release/apis.md
+++ b/content/docs/next-release/apis.md
@@ -39,10 +39,6 @@ Content-Type: application/vnd.apache.thrift.binary
 
 There is no official Jaeger JSON format that can be accepted by the collector. In the future the Protobuf-generated JSON may be supported.
 
-### Thrift via TChannel (deprecated)
-
-Agent and Collector can communicate using TChannel protocol. This protocol is generally not supported by the routing infrastructure and has been deprecated. It will be eventually removed from Jaeger.
-
 ### Zipkin Formats (stable)
 
 Jaeger Collector can also accept spans in several Zipkin data format, namely JSON v1/v2 and Thrift. The Collector needs to be configured to enable Zipkin HTTP server, e.g. on port 9411 used by Zipkin collectors. The server enables two endpoints that expect POST requests:

--- a/content/docs/next-release/deployment.md
+++ b/content/docs/next-release/deployment.md
@@ -108,7 +108,7 @@ When using gRPC, you have several options for load balancing and name resolution
 
 ### Agent level tags
 
-Jaeger supports agent level tags, that can be added to the process tags of all spans passing through the agent. This is supported through the command line flag `--jaeger.tags=key1=value1,key2=value2,...,keyn=valuen`. Tags can also be set through an environment flag like so - `--jaeger.tags=key=${envFlag:defaultValue}` - The tag value will be set to the value of the `envFlag` environment key and `defaultValue` if not set. This feature is not supported for the tchannel reporter, enabled using the flags `--collector.host-port` or `--reporter.tchannel.host-port`.
+Jaeger supports agent level tags, that can be added to the process tags of all spans passing through the agent. This is supported through the command line flag `--jaeger.tags=key1=value1,key2=value2,...,keyn=valuen`. Tags can also be set through an environment flag like so - `--jaeger.tags=key=${envFlag:defaultValue}` - The tag value will be set to the value of the `envFlag` environment key and `defaultValue` if not set.
 
 ## Collectors
 
@@ -131,7 +131,6 @@ At default settings the collector exposes the following ports:
 
 Port  | Protocol | Function
 ----- | -------  | ---
-14267 | TChannel | used by **jaeger-agent** to send spans in jaeger.thrift format
 14250 | gRPC     | used by **jaeger-agent** to send spans in model.proto format
 14268 | HTTP     | can accept spans directly from clients in jaeger.thrift format over binary thrift protocol
 9411  | HTTP     | can accept Zipkin spans in Thrift, JSON and Proto (disabled by default)


### PR DESCRIPTION
Tchannel was removed in 1.18.0 https://github.com/jaegertracing/jaeger/blob/master/CHANGELOG.md#backend-changes-2