### PR TITLE
Add image pull secrets to Jaeger resources

### DIFF
--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -1000,6 +1000,8 @@ spec:
             path: log_level
 ```
 
+Note: If necessary, imagePullSecrets can be configured for components through their serviceAccounts (see https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-image-pull-secret-to-service-account). For the sidecar, see the [Deployment-level Configurations for Injected Sidecars](#deployment-level-configurations-for-injected-sidecars) section.
+
 # Accessing the Jaeger Console (UI)
 <!-- TODO Add tabs shortcode -->
 

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -895,6 +895,8 @@ The types of supported configuration  include:
 
 * [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
 
+* [imagePullSecrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod) to run containers based on images in private registries
+
 * [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
 
 * [resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container) to limit cpu and memory
@@ -957,6 +959,8 @@ spec:
       operator: "Equal"
       value: "value1"
       effect: "NoExecute"
+  imagePullSecrets:
+  - name: nameOfImagePullSecret
   serviceAccount: nameOfServiceAccount
   securityContext:
     runAsUser: 1000

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -713,7 +713,7 @@ Since the sidecar may be injected in Deployments that are not managed by the jae
 - Volumes (& VolumeMounts)
 - ImagePullSecrets
 
-E.g. the following Jaeger configuration will add the `agent-volume` and `agent-imagePullSecrets` to the sidecar's deployment, but not the `common-volume` and `common-imagePullSecret`.
+E.g. the following Jaeger configuration will add the `agent-volume` and `agent-imagePullSecrets` to the sidecar's deployment.
 
 ```yaml
 apiVersion: jaegertracing.io/v1
@@ -729,19 +729,9 @@ spec:
     volumes:
       - name: agent-volume
         secret:
-          secretName: agent-volume
+          secretName: agent-secret
     imagePullSecrets:
     - name: agent-imagePullSecret
-  volumeMounts:
-  - name: common-volume
-    mountPath: /tmp/common
-    readOnly: true
-  volumes:
-    - name: common-volume
-      secret:
-        secretName: common-volume
-  imagePullSecrets:
-  - name: common-imagePullSecret
 ```
 
 ## Manually Defining Jaeger Agent Sidecars
@@ -933,8 +923,6 @@ The types of supported configuration  include:
 
 * [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
 
-* [imagePullSecrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod) to run containers based on images in private registries
-
 * [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
 
 * [resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container) to limit cpu and memory
@@ -997,8 +985,6 @@ spec:
       operator: "Equal"
       value: "value1"
       effect: "NoExecute"
-  imagePullSecrets:
-  - name: nameOfImagePullSecret
   serviceAccount: nameOfServiceAccount
   securityContext:
     runAsUser: 1000

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -706,6 +706,44 @@ A complete sample deployment is available at [`deploy/examples/business-applicat
 
 When the sidecar is injected, the Jaeger Agent can then be accessed at its default location on `localhost`.
 
+### Deployment-level Configurations for Injected Sidecars
+
+Since the sidecar may be injected in Deployments that are not managed by the jaeger-operator, many configurations that apply at the Deployment-level are not applied to a sidecar's Deployment *unless* they are specified under the agent node. The following configurations are supported for the sidecar's Deployment:
+
+- Volumes (& VolumeMounts)
+- ImagePullSecrets
+
+E.g. the following Jaeger configuration will add the `agent-volume` and `agent-imagePullSecrets` to the sidecar's deployment, but not the `common-volume` and `common-imagePullSecret`.
+
+```yaml
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: my-jaeger
+spec:
+  agent:
+    volumeMounts:
+    - name: agent-volume
+      mountPath: /tmp/agent
+      readOnly: true
+    volumes:
+      - name: agent-volume
+        secret:
+          secretName: agent-volume
+    imagePullSecrets:
+    - name: agent-imagePullSecret
+  volumeMounts:
+  - name: common-volume
+    mountPath: /tmp/common
+    readOnly: true
+  volumes:
+    - name: common-volume
+      secret:
+        secretName: common-volume
+  imagePullSecrets:
+  - name: common-imagePullSecret
+```
+
 ## Manually Defining Jaeger Agent Sidecars
 
 For controller types other than `Deployments` (e.g. `StatefulSets`, `DaemonSets`, etc), the Jaeger Agent sidecar can be manually defined in your specification.


### PR DESCRIPTION
~~Associated PR: https://github.com/jaegertracing/jaeger-operator/pull/1103~~
Associated PR: https://github.com/jaegertracing/jaeger-operator/pull/1115

This PR updates the documentation to mention the capability to specify imagePullSecrets for Jaeger resources.