### PR TITLE
Fix --es.server-urls flag example

### DIFF
--- a/content/docs/next-release/opentelemetry.md
+++ b/content/docs/next-release/opentelemetry.md
@@ -46,7 +46,7 @@ $ docker run --rm -it -v ${PWD}:/config \
     -e SPAN_STORAGE_TYPE=elasticsearch \
     jaegertracing/jaeger-opentelemetry-collector \
     --config-file=/config/config.yaml \
-    --es.server.urls=http://localhost:9200 \
+    --es.server-urls=http://localhost:9200 \
     --es.num-shards=3
 ```
 


### PR DESCRIPTION
This flag is wrong and causes an error when try to use it.

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
documentation typo

## Short description of the changed
 --es.server.urls  ->  --es.server-urls