### PR TITLE
Update Python header support info

### DIFF
--- a/data/clients.yaml
+++ b/data/clients.yaml
@@ -271,8 +271,8 @@ clients:
       propagation_uber: yes
       propagation_b3: yes
       propagation_w3c: coming
-      jaeger_debug_id:
-      jaeger_baggage:
+      jaeger_debug_id: yes
+      jaeger_baggage: yes
       standard_tracer_metrics: yes
       standard_rpc_metrics: no
       prometheus_metrics: yes


### PR DESCRIPTION
The Python client supports both the `jaeger-debug-id` and `jaeger-bagage` headers. 

See these constant definitions:

https://github.com/jaegertracing/jaeger-client-python/blob/7984b2872b09a36b7ea0ae6479035ed61666af30/jaeger_client/constants.py#L42-L51

and the code to handle text map extraction (which is responsible for HTTP header handling too) ; the constants above have been propagated to this section as `self.debug_id_header` and `self.baggage_header`:

https://github.com/jaegertracing/jaeger-client-python/blob/7984b2872b09a36b7ea0ae6479035ed61666af30/jaeger_client/codecs.py#L91-L136

and finally the code that handles setting the debug tag when a debug header was present:

https://github.com/jaegertracing/jaeger-client-python/blob/7984b2872b09a36b7ea0ae6479035ed61666af30/jaeger_client/tracer.py#L188-L191
