### PR TITLE
Remove rollover enabled option

### DIFF
--- a/content/docs/1.18/operator.md
+++ b/content/docs/1.18/operator.md
@@ -629,7 +629,6 @@ storage:
     es:
       use-aliases: true
   esRollover:
-    enabled: true                                // turn the cron job deployment on and off
     conditions: "{\"max_age\": \"2d\"}"          // conditions when to rollover to a new index
     readTTL: 168h                                // how long should be old data available for reading (7 days)
     schedule: "55 23 * * *"                      // cron expression for it to run

--- a/content/docs/1.19/operator.md
+++ b/content/docs/1.19/operator.md
@@ -633,7 +633,6 @@ storage:
     es:
       use-aliases: true
   esRollover:
-    enabled: true                                // turn the cron job deployment on and off
     conditions: "{\"max_age\": \"2d\"}"          // conditions when to rollover to a new index
     readTTL: 168h                                // how long should be old data available for reading (7 days)
     schedule: "55 23 * * *"                      // cron expression for it to run

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -633,7 +633,6 @@ storage:
     es:
       use-aliases: true
   esRollover:
-    enabled: true                                // turn the cron job deployment on and off
     conditions: "{\"max_age\": \"2d\"}"          // conditions when to rollover to a new index
     readTTL: 168h                                // how long should be old data available for reading (7 days)
     schedule: "55 23 * * *"                      // cron expression for it to run


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>


There is no `enabled` option in the rollover spec https://godoc.org/github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1#JaegerEsRolloverSpec