### PR TITLE
Adjusted the info in the security page

### DIFF
--- a/content/report-security-issue.md
+++ b/content/report-security-issue.md
@@ -8,8 +8,8 @@ If you find something suspicious and want to report it, we'd really appreciate!
 
 * Prefer to always encrypt your message, no matter the channel you choose to report the issue
 * Contact us on our open chat room on [Gitter][gitter-room]
-* Send a message to [jaeger-tracing@googlegroups.com][mailing-list]
-* Merge request on GitHub: if you can, fork the affected repository and send us a pull request. We really prefer if you'd talk to us before, though, as our repositories are public and we would like to give a heads up to our users before disclosing it publicly
+* If you can't use Gitter, send a message to [jaeger-tracing@googlegroups.com][mailing-list]
+* If you can't use Gitter nor send an email, open a merge request on GitHub: fork the affected repository and send us a pull request. We really prefer if you'd talk to us before, though, as our repositories are public and we would like to give a heads up to our users before disclosing it publicly
 
 ## Our PGP key
 

--- a/content/report-security-issue.md
+++ b/content/report-security-issue.md
@@ -6,17 +6,18 @@ If you find something suspicious and want to report it, we'd really appreciate!
 
 ## Ways to report
 
+* Prefer to always encrypt your message, no matter the channel you choose to report the issue
 * Contact us on our open chat room on [Gitter][gitter-room]
-* Send a message to [jaeger-tracing@googlegroups.com][mailing-list]. Ideally, encrypt it using our [published key][published-key], which should match the one shown below.
-* Merge request on GitHub: if you can, fork the affected repository and send us a pull request. We really prefer if you'd talk to us before, though, as our repositories are public and we would like to give a heads up to our users before disclosing it publicly.
+* Send a message to [jaeger-tracing@googlegroups.com][mailing-list]
+* Merge request on GitHub: if you can, fork the affected repository and send us a pull request. We really prefer if you'd talk to us before, though, as our repositories are public and we would like to give a heads up to our users before disclosing it publicly
 
 ## Our PGP key
 
-No matter what channel you choose to communicate with us, feel free to encrypt your message using our [published key][published-key], which should match the one shown below. If you are new to PGP, you can run the following command to encrypt a file called "message.txt":
+No matter what channel you choose to communicate with us, feel free to encrypt your message using our [published key][published-key], available in all major key servers and which should match the one shown below. If you are new to PGP, you can run the following command to encrypt a file called "message.txt":
 
 1. Receive our keys from the key server:
 
-    `gpg --keyserver sks-keyservers.net --recv-keys C043A4D2B3F2AC31`
+    `gpg --keyserver pool.sks-keyservers.net --recv-keys C043A4D2B3F2AC31`
 
 1. Encrypt a "message.txt" file into "message.txt.asc":
 
@@ -80,6 +81,6 @@ oF+qZY4uEvqFvYo8
 -----END PGP PUBLIC KEY BLOCK-----
 ```
 
-[published-key]: https://sks-keyservers.net/pks/lookup?op=get&search=0xC043A4D2B3F2AC31
+[published-key]: http://pool.sks-keyservers.net/pks/lookup?op=get&search=0xC043A4D2B3F2AC31
 [mailing-list]: https://groups.google.com/forum/#!forum/jaeger-tracing
 [gitter-room]: https://gitter.im/jaegertracing/Lobby

--- a/content/report-security-issue.md
+++ b/content/report-security-issue.md
@@ -6,14 +6,14 @@ If you find something suspicious and want to report it, we'd really appreciate!
 
 ## Ways to report
 
-* Prefer to always encrypt your message, no matter the channel you choose to report the issue
+* It is preferable to always encrypt your message, no matter the channel you choose to report the issue
 * Contact us on our open chat room on [Gitter][gitter-room]
 * If you can't use Gitter, send a message to [jaeger-tracing@googlegroups.com][mailing-list]
 * If you can't use Gitter nor send an email, open a merge request on GitHub: fork the affected repository and send us a pull request. We really prefer if you'd talk to us before, though, as our repositories are public and we would like to give a heads up to our users before disclosing it publicly
 
 ## Our PGP key
 
-No matter what channel you choose to communicate with us, prefer to encrypt your message using our [published key][published-key], available in all major key servers and which should match the one shown below. If you are new to PGP, you can run the following command to encrypt a file called "message.txt":
+No matter what channel you choose to communicate with us, we would prefer you to encrypt your message using our [published key][published-key], available in all major key servers and which should match the one shown below. If you are new to PGP, you can run the following command to encrypt a file called "message.txt":
 
 1. Receive our keys from the key server:
 

--- a/content/report-security-issue.md
+++ b/content/report-security-issue.md
@@ -13,7 +13,7 @@ If you find something suspicious and want to report it, we'd really appreciate!
 
 ## Our PGP key
 
-No matter what channel you choose to communicate with us, feel free to encrypt your message using our [published key][published-key], available in all major key servers and which should match the one shown below. If you are new to PGP, you can run the following command to encrypt a file called "message.txt":
+No matter what channel you choose to communicate with us, prefer to encrypt your message using our [published key][published-key], available in all major key servers and which should match the one shown below. If you are new to PGP, you can run the following command to encrypt a file called "message.txt":
 
 1. Receive our keys from the key server:
 


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Which problem is this PR solving?
- Currently listed server seems to be having problems
- Inconsistencies in the request to encrypt messages

## Short description of the changes
- Use the server pool for the keyserver, even if the TLS certs are typically not matching the request
- Clarified that all communication with us should preferrably be encrypted
