### PR TITLE
Add copy to clipboard button for code snippets on Get started page.

### DIFF
--- a/themes/jaeger-docs/assets/js/app.js
+++ b/themes/jaeger-docs/assets/js/app.js
@@ -79,3 +79,52 @@ $(function () {
     listItemClass: 'jaeger-toc-page-item',
   });
 });
+
+//Add Copy button to code snippets. 
+
+function addCopyButtons(clipboard) {
+  document.querySelectorAll('pre > code').forEach(function (codeBlock) {
+      var button = document.createElement('button');
+      button.className = 'copy-code-button';
+      button.type = 'button';
+      button.innerText = 'Copy';
+
+      button.addEventListener('click', function () {
+          clipboard.writeText(codeBlock.innerText).then(function () {
+              /* Chrome doesn't seem to blur automatically,
+                 leaving the button in a focused state. */
+              button.blur();
+
+              button.innerText = 'Copied!';
+
+              setTimeout(function () {
+                  button.innerText = 'Copy';
+              }, 1000);
+          }, function (error) {
+              button.innerText = 'Error';
+          });
+      });
+
+      var pre = codeBlock.parentNode;
+      if (pre.parentNode.classList.contains('highlight')) {
+          var highlight = pre.parentNode;
+          highlight.parentNode.insertBefore(button, highlight);
+      } else {
+          pre.parentNode.insertBefore(button, pre);
+      }
+  });
+}
+
+if (navigator && navigator.clipboard) {
+  addCopyButtons(navigator.clipboard);
+} else {
+  var script = document.createElement('script');
+  script.src = 'https://cdnjs.cloudflare.com/ajax/libs/clipboard-polyfill/2.7.0/clipboard-polyfill.promise.js';
+  script.integrity = 'sha256-waClS2re9NUbXRsryKoof+F9qc1gjjIhc2eT7ZbIv94=';
+  script.crossOrigin = 'anonymous';
+  script.onload = function() {
+      addCopyButtons(clipboard);
+  };
+
+  document.body.appendChild(script);
+}

--- a/themes/jaeger-docs/assets/sass/copy-button.sass
+++ b/themes/jaeger-docs/assets/sass/copy-button.sass
@@ -1,0 +1,36 @@
+.copy-code-button 
+    color: #272822;
+    background-color: #FFF;
+    border-color: #272822;
+    border: 2px solid;
+    border-radius: 3px 3px 0px 0px;
+
+    /* right-align */
+    display: block;
+    margin-left: auto;
+    margin-right: 0;
+
+    margin-bottom: 2px;
+    padding: 3px 8px;
+    font-size: 0.8em;
+
+
+.copy-code-button:hover 
+    cursor: pointer;
+    background-color: #F2F2F2;
+    
+
+.copy-code-button:focus 
+    
+    background-color: #E6E6E6;
+    outline: 0;
+
+
+.copy-code-button:active 
+    background-color: #D9D9D9;
+
+
+.highlight pre 
+    /* Avoid pushing up the copy buttons. */
+    margin: 0;
+

--- a/themes/jaeger-docs/assets/sass/style.sass
+++ b/themes/jaeger-docs/assets/sass/style.sass
@@ -12,6 +12,7 @@
 @import "navbar"
 @import "pages"
 @import "syntax"
+@import "copy-button"
 @import "toc"
 
 @import "bulma-tooltip/dist/css/bulma-tooltip"


### PR DESCRIPTION
Hi, 
This resolves #444 .
I tried adding a copy button on the right top corner of all the code snippets. 

A preview 
![Copy-button](https://user-images.githubusercontent.com/33135343/95651313-2c3ffe00-0b07-11eb-8dfa-4258323aae39.png)

Signed-off-by: Shreya Gupta <shreyagupta3011@gmail.com>
