### PR TITLE
Update getting-started.md

### DIFF
--- a/content/docs/1.20/getting-started.md
+++ b/content/docs/1.20/getting-started.md
@@ -94,7 +94,6 @@ mkdir -p $GOPATH/src/github.com/jaegertracing
 cd $GOPATH/src/github.com/jaegertracing
 git clone git@github.com:jaegertracing/jaeger.git jaeger
 cd jaeger
-make install
 go run ./examples/hotrod/main.go all
 ```
 #### From docker


### PR DESCRIPTION
I did not confirm on all hosts, only using Mac.  "make install" does not work out of box, it also diverges from the actual hot rod page (where make install is removed).

https://github.com/jaegertracing/jaeger/tree/master/examples/hotrod

Unclear where to place this (1.20, latest, etc.).