### PR TITLE
Add OTLP receiver port to OpenTelemetry page

### DIFF
--- a/content/docs/next-release/opentelemetry.md
+++ b/content/docs/next-release/opentelemetry.md
@@ -26,6 +26,7 @@ The Jaeger OpenTelemetry binaries are **almost** backward compatible with the cu
 
 The differences are:
 
+* OTLP receiver listening on port 55680
 * Health check port changed to `13133`
 * Not all current Jaeger flags are exposed (e.g. health check port)
 * Exposed metrics
@@ -35,7 +36,7 @@ The differences are:
 Jaeger OpenTelemetry components can be configured by a subset of Jaeger current flags (or other [configuration sources](../cli/))
 and [OpenTelemetry configuration file](https://opentelemetry.io/docs/collector/configuration/).
 The OpenTelemetry configuration takes precedence over Jaeger configuration.
-The Jaeger OpenTelemetry binaries use hardcoded default configuration that enables predefined set of components - Jaeger receiver, attribute processor, (storage) exporter.
+The Jaeger OpenTelemetry binaries use hardcoded default configuration that enables predefined set of components - OTLP receiver, Jaeger receiver, attribute processor, (storage) exporter.
 The opinionated default configuration ensures compatibility between Jaeger current binaries.
 The user provided OpenTelemetry configuration is merged with the default configuration.
 


### PR DESCRIPTION
## Which problem is this PR solving?
This makes it easier for users to configure their OpenTelemetry clients.

## Short description of the changes
Mention that the OTLP receiver is on by default, and which port it listens on.
My understanding of the previous text was that I would have to configure it myself.

I found its configuration in the source code here: https://github.com/jaegertracing/jaeger/blob/3c0505fc779e2d054c23304134bef4f22ce9ce75/cmd/opentelemetry/app/defaultconfig/default_config.go#L163

and here: https://github.com/open-telemetry/opentelemetry-collector/blob/7dd853ab95834619169360fa2abbb981af42f061/receiver/otlpreceiver/factory.go#L62
