### PR TITLE
Two changes to fix the release process

### DIFF
--- a/travis/gen-cli-data.py
+++ b/travis/gen-cli-data.py
@@ -9,7 +9,7 @@ if len(sys.argv) < 3:
 jaeger_ver=sys.argv[1]
 output_path=sys.argv[2]
 
-with open("data/cli/%s/config.json" % jaeger_ver, 'r') as f:
+with open("%s/data/cli/%s/config.json" % (output_path, jaeger_ver), 'r') as f:
     cfg=json.load(f)
 
 def generate(tool, storage=''):

--- a/travis/release.sh
+++ b/travis/release.sh
@@ -34,7 +34,6 @@ if [[ "$TRAVIS_TAG" =~ ^release-[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+?$ ]]; t
     chmod a+w -R ${cliDocsTempDir}
     python ./travis/gen-cli-data.py ${versionMajorMinor} ${cliDocsTempDir}
     mv ${cliDocsTempDir}/data/cli/${versionMajorMinor} ./data/cli/
-    
     sed -i -e "s/latest *=.*$/latest = \"${versionMajorMinor}\"/" config.toml
     sed -i -e "s/binariesLatest *=.*$/binariesLatest = \"${version}\"/" config.toml
     sed -i -e "s/versions *= *\[/versions = \[\"${versionMajorMinor}\"\,/" config.toml

--- a/travis/release.sh
+++ b/travis/release.sh
@@ -33,9 +33,8 @@ if [[ "$TRAVIS_TAG" =~ ^release-[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+?$ ]]; t
     cp -r ./data/cli/next-release/ ${cliDocsTempDir}/data/cli/${versionMajorMinor}
     chmod a+w -R ${cliDocsTempDir}
     python ./travis/gen-cli-data.py ${versionMajorMinor} ${cliDocsTempDir}
-    chmod 644 -R ${cliDocsTempDir}
     mv ${cliDocsTempDir}/data/cli/${versionMajorMinor} ./data/cli/
-
+    
     sed -i -e "s/latest *=.*$/latest = \"${versionMajorMinor}\"/" config.toml
     sed -i -e "s/binariesLatest *=.*$/binariesLatest = \"${version}\"/" config.toml
     sed -i -e "s/versions *= *\[/versions = \[\"${versionMajorMinor}\"\,/" config.toml


### PR DESCRIPTION
# Which problem is this PR solving?
- Release is currently broken: https://travis-ci.com/github/jaegertracing/documentation/builds/201798015

```
+python ./travis/gen-cli-data.py 1.21 /tmp/cli-docs-MgMaiwdl
Traceback (most recent call last):
  File "./travis/gen-cli-data.py", line 12, in <module>
    with open("data/cli/%s/config.json" % jaeger_ver, 'r') as f:
```

## Short description of the changes
These changes allow me to run the build successfully locally in "dry run" mode.

`with open("%s/data/cli/%s/config.json" % (output_path, jaeger_ver), 'r') as f:`
The python script needs to be updated to point to the new temp path where the files are copied and then generated.

`chmod 644 -R ${cliDocsTempDir}`
This was removed b/c the files created by the docker container were owned by root and this command was failing on my local system.  Unsure if this would pass in travis.   I know I am leaving this world readable, but I think this is fine for CI.  The files are immediately cleaned up when the container exits and, even if they weren't, they are public documents and having them world readable shouldn't compromise anything.
