### PR TITLE
Ignore unbound vars

### DIFF
--- a/travis/release.sh
+++ b/travis/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -x -u -o errexit -o nounset -o pipefail
+set -x -o errexit -o nounset -o pipefail
 
 safe_checkout_master() {
   # We need to be on a branch to be able to create commits,


### PR DESCRIPTION
## Which problem is this PR solving?
One more fix to the build process.

## Short description of the changes
Build is currently failing with the following.  See: https://travis-ci.com/github/jaegertracing/documentation/builds/201930757

```
./travis/release.sh: line 40: DRY_RUN: unbound variable
```

This is due to `set -u` at the top of the script.  Leaving -u out should be fine.  The lines containing `$TRAVIS_TAG` and `$DRY_RUN` are written in a way that they will behave as expected if they are unset.