### PR TITLE
Remove the other option that will break on unbound variables

### DIFF
--- a/travis/release.sh
+++ b/travis/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -x -o errexit -o nounset -o pipefail
+set -x -o errexit -o pipefail
 
 safe_checkout_master() {
   # We need to be on a branch to be able to create commits,


### PR DESCRIPTION
## Which problem is this PR solving?
- Related to #457 
- Removed the other option that will cause a script to fail if there are unbound variables.
