### PR TITLE
Fix typo in description of JAEGER_SAMPLER_REFRESH_INTERVAL

### DIFF
--- a/data/clients.yaml
+++ b/data/clients.yaml
@@ -113,7 +113,7 @@ featureGroups:
     - name: env_JAEGER_SAMPLER_REFRESH_INTERVAL
       description: >
         `JAEGER_SAMPLER_REFRESH_INTERVAL` defines how often the sampler polls the config server
-        for updates to the samling strategies.
+        for updates to the sampling strategies.
     - name: env_JAEGER_SAMPLER_MAX_OPERATIONS
       description: >
         `JAEGER_SAMPLER_MAX_OPERATIONS` instructs the adaptive sampler to limit how many distinct


### PR DESCRIPTION
## Which problem is this PR solving?
there is a minor typo in the description of `JAEGER_SAMPLER_REFRESH_INTERVAL`

## Short description of the changes
- I corrected the spelling of 'sampling'
