### PR TITLE
Use latest docs version for canonical URL

### DIFF
--- a/themes/jaeger-docs/layouts/partials/meta.html
+++ b/themes/jaeger-docs/layouts/partials/meta.html
@@ -14,15 +14,17 @@
 
 <!-- OpenGraph metadata -->
 <meta property="og:title" content="{{ $title }}" />
+<meta property="og:url" content="{{ .Permalink }}" />
 {{ if $isDoc }}
+<meta property="og:type" content="documentation" />
 {{ $version := index (split .Path "/") 1 }}
 {{ $latest := site.Params.latest }}
-{{ $url := replace .RelPermalink $version "latest" }}
-<meta property="og:type" content="documentation" />
-<meta property="og:url" content="{{ .Permalink }}" />
-<link rel="canonical" href="{{ .Permalink }}" />
+{{ $url := .RelPermalink }}
+{{ if in site.Params.versions $version }}
+{{ $url = replace .RelPermalink $version $latest }}
+{{ end }}
+<link rel="canonical" href="{{ $url }}" />
 {{ else }}
-<meta property="og:url" content="{{ .Permalink }}" />
 <link rel="canonical" href="{{ .Permalink }}" />
 {{ end }}
 <meta property="og:locale" content="en_US" />


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

With this change, the latest docs version is used as canonical URL to improve indexing in search engines.

## Short description of the changes

The canonical URL should point to the latest
version of the docs, so Google will index the
most current documentation.

Previous related change: https://github.com/jaegertracing/documentation/pull/440

https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls#rel-canonical-link-method

### Motivation

I copied parts of this canonical-logic for another docs-site and noticed this issue.