### PR TITLE
Replace deprecated/removed flags in examples

### DIFF
--- a/content/docs/1.22/getting-started.md
+++ b/content/docs/1.22/getting-started.md
@@ -18,7 +18,7 @@ The simplest way to start the all-in-one is to use the pre-built image published
 
 ```bash
 $ docker run -d --name jaeger \
-  -e COLLECTOR_ZIPKIN_HTTP_PORT=9411 \
+  -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
   -p 5775:5775/udp \
   -p 6831:6831/udp \
   -p 6832:6832/udp \
@@ -33,7 +33,7 @@ $ docker run -d --name jaeger \
 Or run the `jaeger-all-in-one(.exe)` executable from the [binary distribution archives][download]:
 
 ```bash
-$ jaeger-all-in-one --collector.zipkin.http-port=9411
+$ jaeger-all-in-one --collector.zipkin.host-port=:9411
 ```
 
 You can then navigate to `http://localhost:16686` to access the Jaeger UI.
@@ -122,7 +122,7 @@ Then navigate to `http://localhost:8080`.
 ## Migrating from Zipkin
 
 Collector service exposes Zipkin compatible REST API `/api/v1/spans` which accepts both Thrift and JSON. Also there is `/api/v2/spans` for JSON and Proto.
-By default it's disabled. It can be enabled with `--collector.zipkin.http-port=9411`.
+By default it's disabled. It can be enabled with `--collector.zipkin.host-port=:9411`.
 
 Zipkin [Thrift](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/zipkincore.thrift) IDL and Zipkin [Proto](https://github.com/jaegertracing/jaeger-idl/blob/master/proto/zipkin.proto) IDL files can be found in [jaegertracing/jaeger-idl](https://github.com/jaegertracing/jaeger-idl) repository.
 They're compatible with [openzipkin/zipkin-api](https://github.com/openzipkin/zipkin-api) [Thrift](https://github.com/openzipkin/zipkin-api/blob/master/thrift/zipkinCore.thrift) and [Proto](https://github.com/openzipkin/zipkin-api/blob/master/zipkin.proto).

--- a/content/docs/1.22/monitoring.md
+++ b/content/docs/1.22/monitoring.md
@@ -10,7 +10,7 @@ Jaeger itself is a distributed, microservices based system. If you run it in pro
 
 By default Jaeger microservices expose metrics in Prometheus format. It is controlled by the following command line options:
 
-* `--admin-http-port` the port number where the HTTP admin server is running
+* `--admin.http.host-port` the port number where the HTTP admin server is running
 * `--metrics-backend` controls how the measurements are exposed. The default value is `prometheus`, another option is `expvar`, the Go standard mechanism for exposing process level statistics.
 * `--metrics-http-route` specifies the name of the HTTP endpoint used to scrape the metrics (`/metrics` by default).
 
@@ -33,7 +33,8 @@ The Prometheus monitoring mixin for Jaeger provides a starting point for people 
 Jaeger components only log to standard out, using structured logging library [go.uber.org/zap](https://github.com/uber-go/zap) configured to write log lines as JSON encoded strings, for example:
 
 ```json
-{"level":"info","ts":1517621222.261759,"caller":"healthcheck/handler.go:99","msg":"Health Check server started","http-port":14269,"status":"unavailable"}
+{"level":"info","ts":1615914981.7914007,"caller":"flags/admin.go:111","msg":"Starting admin HTTP server","http-addr":":14269"}
+{"level":"info","ts":1615914981.7914548,"caller":"flags/admin.go:97","msg":"Admin server started","http.host-port":"[::]:14269","health-status":"unavailable"}
 ```
 
 The log level can be adjusted via `--log-level` command line switch; default level is `info`.

--- a/content/docs/next-release/getting-started.md
+++ b/content/docs/next-release/getting-started.md
@@ -18,7 +18,7 @@ The simplest way to start the all-in-one is to use the pre-built image published
 
 ```bash
 $ docker run -d --name jaeger \
-  -e COLLECTOR_ZIPKIN_HTTP_PORT=9411 \
+  -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
   -p 5775:5775/udp \
   -p 6831:6831/udp \
   -p 6832:6832/udp \
@@ -33,7 +33,7 @@ $ docker run -d --name jaeger \
 Or run the `jaeger-all-in-one(.exe)` executable from the [binary distribution archives][download]:
 
 ```bash
-$ jaeger-all-in-one --collector.zipkin.http-port=9411
+$ jaeger-all-in-one --collector.zipkin.host-port=:9411
 ```
 
 You can then navigate to `http://localhost:16686` to access the Jaeger UI.
@@ -122,7 +122,7 @@ Then navigate to `http://localhost:8080`.
 ## Migrating from Zipkin
 
 Collector service exposes Zipkin compatible REST API `/api/v1/spans` which accepts both Thrift and JSON. Also there is `/api/v2/spans` for JSON and Proto.
-By default it's disabled. It can be enabled with `--collector.zipkin.http-port=9411`.
+By default it's disabled. It can be enabled with `--collector.zipkin.host-port=:9411`.
 
 Zipkin [Thrift](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/zipkincore.thrift) IDL and Zipkin [Proto](https://github.com/jaegertracing/jaeger-idl/blob/master/proto/zipkin.proto) IDL files can be found in [jaegertracing/jaeger-idl](https://github.com/jaegertracing/jaeger-idl) repository.
 They're compatible with [openzipkin/zipkin-api](https://github.com/openzipkin/zipkin-api) [Thrift](https://github.com/openzipkin/zipkin-api/blob/master/thrift/zipkinCore.thrift) and [Proto](https://github.com/openzipkin/zipkin-api/blob/master/zipkin.proto).

--- a/content/docs/next-release/monitoring.md
+++ b/content/docs/next-release/monitoring.md
@@ -10,7 +10,7 @@ Jaeger itself is a distributed, microservices based system. If you run it in pro
 
 By default Jaeger microservices expose metrics in Prometheus format. It is controlled by the following command line options:
 
-* `--admin-http-port` the port number where the HTTP admin server is running
+* `--admin.http.host-port` the port number where the HTTP admin server is running
 * `--metrics-backend` controls how the measurements are exposed. The default value is `prometheus`, another option is `expvar`, the Go standard mechanism for exposing process level statistics.
 * `--metrics-http-route` specifies the name of the HTTP endpoint used to scrape the metrics (`/metrics` by default).
 
@@ -33,7 +33,8 @@ The Prometheus monitoring mixin for Jaeger provides a starting point for people 
 Jaeger components only log to standard out, using structured logging library [go.uber.org/zap](https://github.com/uber-go/zap) configured to write log lines as JSON encoded strings, for example:
 
 ```json
-{"level":"info","ts":1517621222.261759,"caller":"healthcheck/handler.go:99","msg":"Health Check server started","http-port":14269,"status":"unavailable"}
+{"level":"info","ts":1615914981.7914007,"caller":"flags/admin.go:111","msg":"Starting admin HTTP server","http-addr":":14269"}
+{"level":"info","ts":1615914981.7914548,"caller":"flags/admin.go:97","msg":"Admin server started","http.host-port":"[::]:14269","health-status":"unavailable"}
 ```
 
 The log level can be adjusted via `--log-level` command line switch; default level is `info`.


### PR DESCRIPTION
In v1.22 many deprecated flags were removed, but the docs still mention them. I found & changed a few instances, but there may be others, it's unclear how to find them all.