### PR TITLE
Update link to InfluxDB plugin

### DIFF
--- a/content/docs/next-release/deployment.md
+++ b/content/docs/next-release/deployment.md
@@ -521,7 +521,7 @@ Jaeger supports gRPC based storage plugins. For more information refer to [jaege
 
 Available plugins:
 
-* [InfluxDB](https://github.com/influxdata/jaeger-influxdb/)
+* [InfluxDB](https://github.com/influxdata/influxdb-observability/tree/main/jaeger-query-plugin) - time series database.
 * [Logz.io](https://github.com/logzio/jaeger-logzio) - secure, scalable, managed, cloud-based ELK storage.
 
 ```sh


### PR DESCRIPTION
The first experimental InfluxDB Jaeger plugin has been archived, and new work is active in a new repository.

## Which problem is this PR solving?
There is no open issue.

## Short description of the changes
Update one URL in the deployment markdown document.