### PR TITLE
Fix slack URL

### DIFF
--- a/content/get-in-touch.md
+++ b/content/get-in-touch.md
@@ -4,7 +4,7 @@ title: Getting in touch
 
 ## Via chat or email
 
-Join our Google mail group [jaeger-tracing@googlegroups.com](https://groups.google.com/forum/#!forum/jaeger-tracing) or the chat room [#jaeger at the CNCF Slack](https://cloud-native.slack.com/archives/CGG7NFUJ3Lobby). You can get an invitation at https://slack.cncf.io in order to register to this Slack workspace.
+Join our Google mail group [jaeger-tracing@googlegroups.com](https://groups.google.com/forum/#!forum/jaeger-tracing) or the chat room [#jaeger at the CNCF Slack](https://cloud-native.slack.com/archives/CGG7NFUJ3). You can get an invitation at https://slack.cncf.io in order to register to this Slack workspace.
 
 ## Bi-weekly project meetings
 
@@ -19,4 +19,4 @@ Our GitHub org has many different repos, please make sure to pick the one approp
 * For features or issues with client libraries, pick the [corresponding repository](/docs/latest/client-libraries/#supported-libraries).
 
 [bi-weekly-call]: https://docs.google.com/document/d/1ZuBAwTJvQN7xkWVvEFXj5WU9_JmS5TPiNbxCJSvPqX0/
-[jaeger-project-calendar]: https://calendar.google.com/calendar/u/0/embed?src=77a1bva4sn9cm822r8oa03l2j0@group.calendar.google.com 
+[jaeger-project-calendar]: https://calendar.google.com/calendar/u/0/embed?src=77a1bva4sn9cm822r8oa03l2j0@group.calendar.google.com


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

From the ["Getting in touch" page](https://www.jaegertracing.io/get-in-touch/), clicking on the "#jaeger at the CNCF Slack" link results in an error.

I've been [testing a broken link detector in my fork](https://github.com/albertteoh/documentation/actions), but it doesn't pickup on this broken link :( maybe because it returns a 302 HTTP redirect instead of a 404.

## Expected
<img width="506" alt="Screen Shot 2021-04-08 at 7 16 32 pm" src="https://user-images.githubusercontent.com/26584478/114001775-96abde00-989f-11eb-86d5-298271f1d9f0.png">

## Actual
<img width="544" alt="Screen Shot 2021-04-08 at 12 38 43 pm" src="https://user-images.githubusercontent.com/26584478/114001707-84ca3b00-989f-11eb-8096-1bfeb35c0225.png">
