### PR TITLE
Add esc command not found Troubleshooting guide

### DIFF
--- a/content/docs/next-release/troubleshooting.md
+++ b/content/docs/next-release/troubleshooting.md
@@ -105,3 +105,18 @@ For Visual Studio Code, you need to have the following configuration at the root
             }
         ]
     }
+
+## make: esc: Command not found
+
+Make sure `esc` is installed:
+```
+make install-tools
+```
+
+`esc` will be installed in your `$GOPATH`; check it is added in your `$PATH`:
+```
+export PATH=$PATH:$(go env GOPATH)/bin
+```
+
+To make this more permanent, add the above `export` command to your preferred
+login shell: `~/.bash_profile`, `~/.zshrc`, etc.


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

## Which problem is this PR solving?
- Address the frequent number of similar questions surrounding failing builds due to `esc: Command not found` such as https://github.com/jaegertracing/jaeger/issues/2963.

## Short description of the changes
- Add instructions to address this problem in Troubleshooting guide.
- I understand there was an attempt to use the built-in "embed" package but not sure of its status right now. If we're still planning to go ahead with using "embed" I'm happy to abandon this PR.
