### PR TITLE
fix: grpc is not running on the ui port

### DIFF
--- a/content/docs/1.22/deployment.md
+++ b/content/docs/1.22/deployment.md
@@ -554,13 +554,14 @@ At default settings the query service exposes the following port(s):
 
 Port  | Protocol | Function
 ----- | -------  | ---
+16685 | gRPC     | Protobuf/gRPC [QueryService](https://github.com/jaegertracing/jaeger-idl/blob/master/proto/api_v2/query.proto)
 16686 | HTTP     | `/api/*` endpoints and Jaeger UI at `/`
-16686 | gRPC     | Protobuf/gRPC [QueryService](https://github.com/jaegertracing/jaeger-idl/blob/master/proto/api_v2/query.proto)
 16687 | HTTP     | admin port: health check at `/` and metrics at `/metrics`
 
 ### Minimal deployment example (Elasticsearch backend):
 ```sh
 docker run -d --rm \
+  -p 16685:16685 \
   -p 16686:16686 \
   -p 16687:16687 \
   -e SPAN_STORAGE_TYPE=elasticsearch \

--- a/content/docs/next-release/deployment.md
+++ b/content/docs/next-release/deployment.md
@@ -554,13 +554,14 @@ At default settings the query service exposes the following port(s):
 
 Port  | Protocol | Function
 ----- | -------  | ---
+16685 | gRPC     | Protobuf/gRPC [QueryService](https://github.com/jaegertracing/jaeger-idl/blob/master/proto/api_v2/query.proto)
 16686 | HTTP     | `/api/*` endpoints and Jaeger UI at `/`
-16686 | gRPC     | Protobuf/gRPC [QueryService](https://github.com/jaegertracing/jaeger-idl/blob/master/proto/api_v2/query.proto)
 16687 | HTTP     | admin port: health check at `/` and metrics at `/metrics`
 
 ### Minimal deployment example (Elasticsearch backend):
 ```sh
 docker run -d --rm \
+  -p 16685:16685 \
   -p 16686:16686 \
   -p 16687:16687 \
   -e SPAN_STORAGE_TYPE=elasticsearch \


### PR DESCRIPTION
## Short description of the changes

`all-in-one` and `jaeger-query` do not, in fact, listen for grpc on the same port as http.

If you send grpc requests to this port, you get complete garbage back.

Do not tell people to use the wrong port.

```
% docker run -it jaegertracing/jaeger-query:1.22 --help  | fgrep -m1 grpc
      --query.grpc-server.host-port string              The host:port (e.g. 127.0.0.1:14250 or :14250) of the query's gRPC server (default ":16685")
```

Especially relevant as [it segfaults if you look at it funny](https://github.com/jaegertracing/jaeger/issues/2996).