### PR TITLE
Update required Go-Version from 1.11 to 1.16.

### DIFF
--- a/content/docs/1.22/getting-started.md
+++ b/content/docs/1.22/getting-started.md
@@ -84,7 +84,7 @@ It can be run standalone, but requires Jaeger backend to view the traces.
 
 ### Prerequisites
 
--   You need Go 1.11 or higher installed on your machine to run from source.
+-   You need Go 1.16 or higher installed on your machine to run from source.
 -   Requires a [running Jaeger backend](#all-in-one) to view the traces.
 
 ### Running

--- a/content/docs/1.22/getting-started.md
+++ b/content/docs/1.22/getting-started.md
@@ -84,7 +84,8 @@ It can be run standalone, but requires Jaeger backend to view the traces.
 
 ### Prerequisites
 
--   You need Go 1.16 or higher installed on your machine to run from source.
+-   You need [Go toolchain](https://golang.org/doc/install) installed on your machine to run from source
+    (see [go.mod](https://github.com/jaegertracing/jaeger/blob/master/go.mod#L3) file for required Go version).
 -   Requires a [running Jaeger backend](#all-in-one) to view the traces.
 
 ### Running

--- a/content/docs/next-release/getting-started.md
+++ b/content/docs/next-release/getting-started.md
@@ -84,7 +84,8 @@ It can be run standalone, but requires Jaeger backend to view the traces.
 
 ### Prerequisites
 
--   You need Go 1.11 or higher installed on your machine to run from source.
+-   You need [Go toolchain](https://golang.org/doc/install) installed on your machine to run from source
+    (see [go.mod](https://github.com/jaegertracing/jaeger/blob/master/go.mod) file for required Go version).
 -   Requires a [running Jaeger backend](#all-in-one) to view the traces.
 
 ### Running


### PR DESCRIPTION
## Which problem is this PR solving?
- The documentation mentions a too old Go-Version as prerequisite for the HotROD-Installation. The latest HotROD-Version uses the 'embed'-package from go, which is only available in Go-Version 1.16 or higher.

## Short description of the changes
- Update required Go-Version from 1.11 to 1.16.
