### PR TITLE
Fix release by allowing force push on protected branch

### DIFF
--- a/travis/release.sh
+++ b/travis/release.sh
@@ -45,7 +45,7 @@ if [[ "$TRAVIS_TAG" =~ ^release-[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+?$ ]]; t
     fi
     git add config.toml ./content/docs/${versionMajorMinor} ./data/cli/${versionMajorMinor}
     git commit -m "Release ${version}" -s
-    git push origin $checkoutBranch
+    git push -f origin $checkoutBranch
 else
     echo "TRAVIS_TAG=$TRAVIS_TAG is not in the form release-x.y.z, skipping release"
 fi


### PR DESCRIPTION
Resolves #505 

There are two ways to solve this:
1. remove master from protected branches
2. allow force push to protected master branch

This PR chooses 2.

https://github.com/jaegertracing/documentation/settings/branch_protection_rules/1620218

