### PR TITLE
White space is allowed in CASSANDRA_SERVERS

### DIFF
--- a/content/docs/next-release/deployment.md
+++ b/content/docs/next-release/deployment.md
@@ -297,6 +297,8 @@ docker run \
   jaegertracing/jaeger-collector:{{< currentVersion >}}
 ```
 
+Note: White space characters are allowed in `CASSANDA_SERVERS`. For Example: Servers can be passed as `CASSANDRA_SERVERS="1.2.3.4, 5.6.7.8" for better readability.
+
 ##### All options
 To view the full list of configuration options, you can run the following command:
 ```sh


### PR DESCRIPTION
<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Adds documentation for https://github.com/jaegertracing/jaeger/issues/1300

## Short description of the changes
Add documentation mentioning white space characters are allowed in CASSANDRA_SERVERS parameter.
