### PR TITLE
Add notice about retiring Jaeger clients

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,12 @@ THEME_DIR    := themes/$(HUGO_THEME)
 
 client-libs-docs:
 	@for d in $(shell ls -d content/docs/*); do \
-		cp content/_client_libs/*.md $$d/; \
-		echo "copied content/_client_libs/*.md -> $$d/"; \
+		pushd $$d/; \
+		rm -f client-libraries.md client-features.md; \
+		ln -s ../../_client_libs/client-libraries.md; \
+		ln -s ../../_client_libs/client-features.md; \
+		popd; \
+		echo "sym-linked content/_client_libs/*.md -> $$d/"; \
 	done
 
 generate:	client-libs-docs

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,13 @@ HUGO_THEME   = jaeger-docs
 THEME_DIR    := themes/$(HUGO_THEME)
 
 client-libs-docs:
+	# invoke one group of commands in bash to allow pushd/popd
 	@for d in $(shell ls -d content/docs/*); do \
-		pushd $$d/; \
-		rm -f client-libraries.md client-features.md; \
-		ln -s ../../_client_libs/client-libraries.md; \
-		ln -s ../../_client_libs/client-features.md; \
-		popd; \
+		/bin/bash -c "pushd $$d/; \
+			rm -f client-libraries.md client-features.md; \
+			ln -s ../../_client_libs/client-libraries.md; \
+			ln -s ../../_client_libs/client-features.md; \
+			popd"; \
 		echo "sym-linked content/_client_libs/*.md -> $$d/"; \
 	done
 

--- a/content/_client_libs/client-features.md
+++ b/content/_client_libs/client-features.md
@@ -5,6 +5,14 @@ hasparent: true
 weight: 5
 ---
 
+{{< warning >}}
+Jaeger clients are being retired. Please refer to this [notice](../client-libraries/#deprecating-jaeger-clients).
+{{< /warning >}}
+
 The table below provides a feature matrix for the existing client libraries. Cells marked with `?` indicate that it's not known if the given client supports the given feature and additional research & documentation update is required.
+
+{{< info >}}
+The table is auto-generated from [data/clients.yaml](https://github.com/jaegertracing/documentation/blob/master/data/clients.yaml)
+{{< /info >}}
 
 {{< featuresTable >}}

--- a/content/_client_libs/client-libraries.md
+++ b/content/_client_libs/client-libraries.md
@@ -7,8 +7,70 @@ children:
 ---
 
 {{< warning >}}
-For the future, we recommend using the [OpenTelemetry](https://opentelemetry.io) APIs and SDKs. For applications that are already instrumented with the OpenTracing API, we recommend replacing the Jaeger client with the OpenTelemetry SDK and the OpenTracing shim that is available to use with it. We published a blog post with the migration steps: ["Migrating from Jaeger client to OpenTelemetry SDK"](https://medium.com/jaegertracing/migrating-from-jaeger-client-to-opentelemetry-sdk-bd337d796759).
+Jaeger clients are being retired.
 {{< /warning >}}
+
+## Deprecating Jaeger clients
+
+The Jaeger clients have faithfully served our community for several years. We pioneered many new features, such as remotely controlled samplers and per-operation / adaptive sampling, which were critical to the success of distributed tracing deployments at large organizations. However, now that the larger community in OpenTelemetry has caught up with the Jaeger clients in terms of feature parity and there is full support for exporting data to Jaeger, we believe it is time to **decommission Jaeger's native clients and refocus the efforts on the OpenTelemetry SDKs**.
+
+For new applications, we recommend using the [OpenTelemetry](https://opentelemetry.io/) APIs and SDKs. For existing applications that are already instrumented with the OpenTracing API, we recommend replacing the Jaeger clients with the corresponding OpenTelemetry SDKs and the OpenTracing shim/bridge (available in most languages supported by Jaeger). We published a blog post that shows an example of the migration steps for Java: ["Migrating from Jaeger client to OpenTelemetry SDK"][blog-otel-java].
+
+### Timeline
+
+We plan to continue accepting pull requests and making new releases of Jaeger clients **through the end of 2021**. From 2022 we will enter a code freeze period **for 6 months**, during which we will no longer accept pull requests with new features, only with security-related fixes.  After that the client library repositories will be archived and accept no new changes.
+
+### Migration to OpenTelemetry
+
+The OpenTelemetry project is working on publishing the migration guides from OpenTracing API to OpenTelemetry SDKs via OpenTracing bridges/shims. There may be different level of maturity and features in the SDKs. We will keep updating the information below as more of it becomes available.
+
+**Baggage support**: OpenTelemetry implements baggage propagation differently from OpenTracing and they are not completely equivalent. In OpenTelemetry the `context` layer sits below the tracing API and relies on immutable context objects, whereas baggage in OpenTracing is stored in a `span` which is mutable (and may occasionally lead to tricky race conditions when starting children spans).
+
+**We need your help!** If you find inaccuracies or have information that can be added, please open an issue or a PR to the [documentation repo](https://github.com/jaegertracing/documentation). If some features are missing and you need them, please open tickets in the respective OpenTelemetry repos or contibute. For example, Jaeger's remote samplers are not yet implemented in every OpenTelemetry SDK, but porting them from the Jaeger codebase is a fairly straightforward task.
+
+#### Java
+* OpenTelemetry SDK: https://github.com/open-telemetry/opentelemetry-java
+  * Remote sampling: [sdk-extensions/jaeger-remote-sampler](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/jaeger-remote-sampler)
+  * Internal SDK metrics: n/a
+* OpenTracing Bridge: [opentracing-shim](https://github.com/open-telemetry/opentelemetry-java/tree/main/opentracing-shim)
+  * Migration Guide: ["Migrating from Jaeger client to OpenTelemetry SDK"][blog-otel-java]
+
+#### Python
+* OpenTelemetry SDK: https://github.com/open-telemetry/opentelemetry-python
+  * Remote sampling: ?
+  * Internal SDK metrics: n/a
+* OpenTracing Bridge: [opentelemetry-opentracing-shim](https://github.com/open-telemetry/opentelemetry-python/tree/main/shim/opentelemetry-opentracing-shim)
+  * Migration Guide: available in the shim's README
+
+#### Node.js
+* OpenTelemetry SDK: https://github.com/open-telemetry/opentelemetry-js
+  * Remote sampling: ?
+  * Internal SDK metrics: n/a
+* OpenTracing Bridge: [opentelemetry-shim-opentracing](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-shim-opentracing)
+  * Migration Guide: available in the shim's README and the corresponding readthedocs
+
+#### Go
+* OpenTelemetry SDK: https://github.com/open-telemetry/opentelemetry-go
+  * Remote sampling: https://github.com/open-telemetry/opentelemetry-go-contrib/pull/936
+  * Internal SDK metrics: n/a
+* OpenTracing Bridge: [bridge/opentracing](https://github.com/open-telemetry/opentelemetry-go/tree/main/bridge/opentracing)
+  * Migration Guide: ?
+
+#### C# / .NET
+* OpenTelemetry SDK: https://github.com/open-telemetry/opentelemetry-dotnet
+  * Remote sampling: ?
+  * Internal SDK metrics: n/a
+* OpenTracing Bridge: [OpenTelemetry.Shims.OpenTracing](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Shims.OpenTracing)
+  * Migration Guide: available in the shim's README, but is very terse
+
+#### C++
+* OpenTelemetry SDK: https://github.com/open-telemetry/opentelemetry-cpp
+  * Remote sampling: ?
+  * Internal SDK metrics: n/a
+* OpenTracing Bridge: n/a
+  * Migration Guide: n/a
+
+## Intro
 
 All Jaeger client libraries support the [OpenTracing APIs](http://opentracing.io). The following resources provide more information about instrumenting your application with OpenTracing:
 
@@ -41,7 +103,7 @@ simpler parameterization of the Tracer, such as changing the default sampler or 
 
 ### Sampling
 
-See [here](../sampling#client-sampling-configuration).
+See [Architecture | Sampling](../sampling#client-sampling-configuration).
 
 ### Reporters
 
@@ -159,3 +221,4 @@ uberctx-key1: value%201%20%2F%20blah
 
 [HttpSender]: https://github.com/jaegertracing/jaeger-client-java/blob/master/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/senders/HttpSender.java
 [http-latency-medium]: https://medium.com/@YuriShkuro/tracing-http-request-latency-in-go-with-opentracing-7cc1282a100a
+[blog-otel-java]: https://medium.com/jaegertracing/migrating-from-jaeger-client-to-opentelemetry-sdk-bd337d796759

--- a/content/_client_libs/client-libraries.md
+++ b/content/_client_libs/client-libraries.md
@@ -18,11 +18,11 @@ For new applications, we recommend using the [OpenTelemetry](https://opentelemet
 
 ### Timeline
 
-We plan to continue accepting pull requests and making new releases of Jaeger clients **through the end of 2021**. From 2022 we will enter a code freeze period **for 6 months**, during which we will no longer accept pull requests with new features, only with security-related fixes.  After that the client library repositories will be archived and accept no new changes.
+We plan to continue accepting pull requests and making new releases of Jaeger clients **through the end of 2021**. In January 2022 we will enter a code freeze period **for 6 months**, during which we will no longer accept pull requests with new features, with the exception of security-related fixes.  After that we will archive the client library repositories and will no longer accept new changes.
 
 ### Migration to OpenTelemetry
 
-The OpenTelemetry project is working on publishing the migration guides from OpenTracing API to OpenTelemetry SDKs via OpenTracing bridges/shims. There may be different level of maturity and features in the SDKs. We will keep updating the information below as more of it becomes available.
+The OpenTelemetry project is working on publishing the migration guides from OpenTracing API to OpenTelemetry SDKs via OpenTracing bridges/shims. There may be different levels of maturity and features in the SDKs. We will keep updating the information below as more of it becomes available.
 
 **Baggage support**: OpenTelemetry implements baggage propagation differently from OpenTracing and they are not completely equivalent. In OpenTelemetry the `context` layer sits below the tracing API and relies on immutable context objects, whereas baggage in OpenTracing is stored in a `span` which is mutable (and may occasionally lead to tricky race conditions when starting children spans).
 

--- a/data/clients.yaml
+++ b/data/clients.yaml
@@ -43,7 +43,7 @@ featureGroups:
     - name: remote_sampler
       description: Allow remote configuration of samplers
     - name: adaptive_sampler
-      description: Remotely configurable [adaptive sampler](../sampling)
+      description: Remotely configurable [per-endpoint sampler](../sampling)
     - name: baggage_restriction
       description: Remotely configurable baggage restrictions
 


### PR DESCRIPTION
Part of https://github.com/jaegertracing/jaeger/issues/3362

I am not sure how extensive the matrix of feature compatibility should be. In theory we could use the same format as in https://www.jaegertracing.io/docs/1.27/client-features/. It will involve more work to setup the rendering, but will result in easy to maintain source file and cleaner presentation.