### PR TITLE
Add metrics storage support to auto-generated CLI documentation

### DIFF
--- a/data/cli/1.28/config.json
+++ b/data/cli/1.28/config.json
@@ -14,10 +14,7 @@
             "badger",
             "grpc-plugin"
         ],
-        "sampling": [],
-        "metrics-storage": [
-          "prometheus"
-        ]
+        "sampling": []
     },
     "jaeger-collector": {
         "storage": [
@@ -29,8 +26,7 @@
         "sampling": [
             "adaptive",
             "file"
-        ],
-        "metrics-storage": []
+        ]
     },
     "jaeger-ingester": {
         "storage": [
@@ -38,8 +34,7 @@
             "elasticsearch",
             "grpc-plugin"
         ],
-        "sampling": [],
-        "metrics-storage": []
+        "sampling": []
     },
     "jaeger-query": {
         "storage": [
@@ -47,14 +42,10 @@
             "elasticsearch",
             "grpc-plugin"
         ],
-        "sampling": [],
-        "metrics-storage": [
-            "prometheus"
-        ]
+        "sampling": []
     },
     "jaeger-agent": {
         "storage": [],
-        "sampling": [],
-        "metrics-storage": []
+        "sampling": []
     }
 }

--- a/data/cli/1.28/config.json
+++ b/data/cli/1.28/config.json
@@ -14,7 +14,10 @@
             "badger",
             "grpc-plugin"
         ],
-        "sampling": []
+        "sampling": [],
+        "metrics-storage": [
+          "prometheus"
+        ]
     },
     "jaeger-collector": {
         "storage": [
@@ -26,7 +29,8 @@
         "sampling": [
             "adaptive",
             "file"
-        ]
+        ],
+        "metrics-storage": []
     },
     "jaeger-ingester": {
         "storage": [
@@ -34,7 +38,8 @@
             "elasticsearch",
             "grpc-plugin"
         ],
-        "sampling": []
+        "sampling": [],
+        "metrics-storage": []
     },
     "jaeger-query": {
         "storage": [
@@ -42,10 +47,14 @@
             "elasticsearch",
             "grpc-plugin"
         ],
-        "sampling": []
+        "sampling": [],
+        "metrics-storage": [
+            "prometheus"
+        ]
     },
     "jaeger-agent": {
         "storage": [],
-        "sampling": []
+        "sampling": [],
+        "metrics-storage": []
     }
 }

--- a/data/cli/next-release/config.json
+++ b/data/cli/next-release/config.json
@@ -14,7 +14,10 @@
             "badger",
             "grpc-plugin"
         ],
-        "sampling": []
+        "sampling": [],
+        "metrics-storage": [
+          "prometheus"
+        ]
     },
     "jaeger-collector": {
         "storage": [
@@ -26,7 +29,8 @@
         "sampling": [
             "adaptive",
             "file"
-        ]
+        ],
+        "metrics-storage": []
     },
     "jaeger-ingester": {
         "storage": [
@@ -34,7 +38,8 @@
             "elasticsearch",
             "grpc-plugin"
         ],
-        "sampling": []
+        "sampling": [],
+        "metrics-storage": []
     },
     "jaeger-query": {
         "storage": [
@@ -42,10 +47,14 @@
             "elasticsearch",
             "grpc-plugin"
         ],
-        "sampling": []
+        "sampling": [],
+        "metrics-storage": [
+            "prometheus"
+        ]
     },
     "jaeger-agent": {
         "storage": [],
-        "sampling": []
+        "sampling": [],
+        "metrics-storage": []
     }
 }

--- a/scripts/gen-cli-data.py
+++ b/scripts/gen-cli-data.py
@@ -14,12 +14,19 @@ with open(f"{output_path}/data/cli/{jaeger_ver}/config.json", 'r') as f:
     cfg = json.load(f)
 
 
+# generate generates the CLI documentation for a given "tool" (e.g.
+# jaeger-collector, jaeger-query, etc.) and feature (e.g. storage=elasticsearch,
+# sampling=adaptive, metrics-storage=prometheus).
 def generate(tool, **kwargs):
     if len(kwargs) > 1:
-        print(f"Expected 1 feature, got {len(kwargs)}.")
+        print(f"Expected at most 1 feature, got {len(kwargs)}.")
         sys.exit(1)
 
     feature_name = ""
+
+    # Get the first feature value (e.g. elasticsearch, adaptive, prometheus,
+    # etc.) in kwargs if it exists. The feature name (e.g. storage,
+    # sampling, metrics-storage) is not used, and hence ignored.
     for _, feature_name in kwargs.items():
         break
 

--- a/scripts/gen-cli-data.py
+++ b/scripts/gen-cli-data.py
@@ -24,8 +24,8 @@ def generate(tool, **kwargs):
 
     feature_name = ""
 
-    # Get the first feature value (e.g. elasticsearch, adaptive, prometheus,
-    # etc.) in kwargs if it exists. The feature name (e.g. storage,
+    # Get the first feature name (e.g. elasticsearch, adaptive, prometheus,
+    # etc.) in kwargs if it exists. The feature type (e.g. storage,
     # sampling, metrics-storage) is not used, and hence ignored.
     for _, feature_name in kwargs.items():
         break

--- a/themes/jaeger-docs/layouts/shortcodes/cli/tools-list.html
+++ b/themes/jaeger-docs/layouts/shortcodes/cli/tools-list.html
@@ -22,6 +22,7 @@
   {{ $cli := index $data $tool }}
   {{ $storage_types := index (index $config $tool) "storage" }}
   {{ $sampling_types := index (index $config $tool) "sampling" }}
+  {{ $metrics_storage_types := index (index $config $tool) "metrics-storage" }}
 
   <h2 id="{{ $tool }}">
     {{ $tool }}
@@ -49,13 +50,28 @@
       <p>{{ $tool }} can be used with these sampling types:</p>
       <ul>
         {{ range $sampling_types }}
-          {{ $storage := . }}
-          {{ $file    := printf "%s-%s" $tool $storage }}
+          {{ $sampling := . }}
+          {{ $file    := printf "%s-%s" $tool $sampling }}
           <li>
               <a href="#{{ $file }}">
-                  {{ $tool }} with <code>{{ $storage }}</code>
+                  {{ $tool }} with <code>{{ $sampling }}</code> sampling
               </a>
           </li>
+        {{ end }}
+      </ul>
+    {{ end }}
+
+    {{ if $metrics_storage_types }}
+      <p>(Experimental) {{ $tool }} can be used with these metrics storage types:</p>
+      <ul>
+        {{ range $metrics_storage_types }}
+        {{ $metrics_storage := . }}
+        {{ $file    := printf "%s-%s" $tool $metrics_storage }}
+        <li>
+          <a href="#{{ $file }}">
+            {{ $tool }} with <code>{{ $metrics_storage }}</code> metrics storage
+          </a>
+        </li>
         {{ end }}
       </ul>
     {{ end }}
@@ -80,11 +96,25 @@
 
       <!-- TODO right sidebar gets too long, we should use tabs here -->
       <h3 id="{{ $file }}">
-        {{ $tool }} with <code>{{ $sampling }}</code> sampling type
+        {{ $tool }} with <code>{{ $sampling }}</code> sampling
       </h3>
 
       {{ partial "options-table.html" $cli.options }}
     {{ end }}
+
+    {{ range $metrics_storage_types }}
+      {{ $metrics_storage := . }}
+      {{ $file    := printf "%s-%s" $tool $metrics_storage }}
+      {{ $cli     := index $data $file }}
+
+      <!-- TODO right sidebar gets too long, we should use tabs here -->
+      <h3 id="{{ $file }}">
+        {{ $tool }} with <code>{{ $metrics_storage }}</code> metrics storage
+      </h3>
+
+      {{ partial "options-table.html" $cli.options }}
+    {{ end }}
+
   {{ else }}
     {{ partial "options-table.html" $cli.options }}
   {{ end }}


### PR DESCRIPTION
Signed-off-by: albertteoh <see.kwang.teoh@gmail.com>

## Which problem is this PR solving?
- Relates to https://github.com/jaegertracing/jaeger/issues/2954

## Short description of the changes
- Adds support for metrics-storage to the auto-generated documentation.
- Minor improvements:
  - Taking advantage of python 3 features such as f-strings along with some simplifications.
  - Fix variable names and titles in template.

## Testing

Generated CLI docs against version 1.28 to allow output comparison.

```
# Only prometheus-related files were added.
$ diff -q /home/go/src/github.com/albertteoh/documentation/data/cli/1.28/ /tmp/docs/data/cli/1.28
Files /home/go/src/github.com/albertteoh/documentation/data/cli/1.28/config.json and /tmp/docs/data/cli/1.28/config.json differ
Only in /tmp/docs/data/cli/1.28: jaeger-all-in-one-prometheus.yaml
Only in /tmp/docs/data/cli/1.28: jaeger-query-prometheus.yaml

# Only prometheus flags added to these files.
$ diff /home/go/src/github.com/albertteoh/documentation/data/cli/1.28/jaeger-all-in-one.yaml /tmp/docs/data/cli/1.28/jaeger-all-in-one-prometheus.yaml
150a151,177
> - name: prometheus.connect-timeout
>   default_value: 30s
>   usage: |
>     The period to wait for a connection to Prometheus when executing queries.
> - name: prometheus.server-url
>   default_value: http://localhost:9090
>   usage: |
>     The Prometheus server's URL, must include the protocol scheme e.g. http://localhost:9090
> - name: prometheus.tls.ca
>   usage: |
>     Path to a TLS CA (Certification Authority) file used to verify the remote server(s) (by default will use the system truststore)
> - name: prometheus.tls.cert
>   usage: |
>     Path to a TLS Certificate file, used to identify this process to the remote server(s)
> - name: prometheus.tls.enabled
>   default_value: "false"
>   usage: Enable TLS when talking to the remote server(s)
> - name: prometheus.tls.key
>   usage: |
>     Path to a TLS Private Key file, used to identify this process to the remote server(s)
> - name: prometheus.tls.server-name
>   usage: |
>     Override the TLS server name we expect in the certificate of the remote server(s)
> - name: prometheus.tls.skip-host-verify
>   default_value: "false"
>   usage: |
>     (insecure) Skip server's certificate chain and host name verification
```

Copied generated doc files to `documentation/data/cli/1.28/` and ran `make develop`. The following are relevant screenshots of the rendered changes made in this PR:

<img width="698" alt="Screen Shot 2021-11-30 at 10 31 50 pm" src="https://user-images.githubusercontent.com/26584478/144040199-44a9e4e4-366a-4ecc-aab3-2de0c41407f4.png">

<img width="659" alt="Screen Shot 2021-11-30 at 10 31 28 pm" src="https://user-images.githubusercontent.com/26584478/144040204-76076864-97df-4257-910e-1c2c663711f4.png">


<img width="533" alt="Screen Shot 2021-11-30 at 10 32 38 pm" src="https://user-images.githubusercontent.com/26584478/144040161-c0986663-42cd-4193-9cbd-6a82d1952355.png">
<img width="479" alt="Screen Shot 2021-11-30 at 10 32 33 pm" src="https://user-images.githubusercontent.com/26584478/144040171-8f268425-1a8b-4f42-9ca8-7375a743de24.png">
<img width="606" alt="Screen Shot 2021-11-30 at 10 32 19 pm" src="https://user-images.githubusercontent.com/26584478/144040176-f2812ebe-3adc-4720-95e2-0a191ff4d625.png">
<img width="624" alt="Screen Shot 2021-11-30 at 10 32 15 pm" src="https://user-images.githubusercontent.com/26584478/144040178-fef209f6-f0dc-4456-a0b0-911d5b3d3e0a.png">
<img width="1154" alt="Screen Shot 2021-11-30 at 10 32 04 pm" src="https://user-images.githubusercontent.com/26584478/144040183-aac3700a-8893-4342-8c94-857baa7e8460.png">


