### PR TITLE
Rename master to main

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   create:
-    branches: [ master ]
+    branches: [ main ]
     tags: ["release-*.*.*"]
 
 jobs:
@@ -33,6 +33,6 @@ jobs:
         export TAG=${GITHUB_REF##*/}
         git checkout -b gen-release-${TAG} # branch is need for GH CLI
         git push origin gen-release-${TAG} # branch has to be on remote  before PR is opened
-        gh pr create --base master --title "Release ${TAG}" --body "Release ${TAG}. This PR is created from CI and is part of the release process."
+        gh pr create --base main --title "Release ${TAG}" --body "Release ${TAG}. This PR is created from CI and is part of the release process."
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This will start up a local server on localhost port 1313. When you make changes 
 
 ## Publishing the site
 
-The site is published automatically by [Netlify](https://www.netlify.com/) whenever changes are merged to the `master` branch. The site cannot be published in an ad-hoc way (e.g. through a `make` command or script in the repo).
+The site is published automatically by [Netlify](https://www.netlify.com/) whenever changes are merged to the `main` branch. The site cannot be published in an ad-hoc way (e.g. through a `make` command or script in the repo).
 
 ## Contributing to the site
 
@@ -35,7 +35,7 @@ We strongly encourage you to contribute to this site! For more information, see 
 
 ## Diagrams
 
-Diagrams included in the documentation are created in the shared [Google Slides document][slides], which supports export to SVG. If you need to make changes to the diagrams as part of a PR, please copy the diagram into a new slide deck and include a shared link to it in the PR along with the exported SVG file. The maintainers will update the master deck with the new version upon merging the PR.
+Diagrams included in the documentation are created in the shared [Google Slides document][slides], which supports export to SVG. If you need to make changes to the diagrams as part of a PR, please copy the diagram into a new slide deck and include a shared link to it in the PR along with the exported SVG file. The maintainers will update the main deck with the new version upon merging the PR.
 
 ## Publishing new Jaeger version
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,7 +9,7 @@ Before creating a new release:
   - If there are new Jaeger binaries or new storage options added to the release, make sure the CLI docs config file `data/cli/next-release/config.json` is updated accordingly (see below).
   - Make sure you have git remote `upstream` pointing to the official repository, e.g.
     `git remote add upstream git@github.com:jaegertracing/documentation.git`
-  - Make sure you are on your `master` branch.
+  - Make sure you are on your `main` branch.
 
 Then create a release by pushing a tag corresponding to the jaegertracing/jaeger version `release-X.Y.Z`, e.g.
 

--- a/content/_client_libs/client-features.md
+++ b/content/_client_libs/client-features.md
@@ -12,7 +12,7 @@ Jaeger clients are being retired. Please refer to this [notice](../client-librar
 The table below provides a feature matrix for the existing client libraries. Cells marked with `?` indicate that it's not known if the given client supports the given feature and additional research & documentation update is required.
 
 {{< info >}}
-The table is auto-generated from [data/clients.yaml](https://github.com/jaegertracing/documentation/blob/master/data/clients.yaml)
+The table is auto-generated from [data/clients.yaml](https://github.com/jaegertracing/documentation/blob/main/data/clients.yaml)
 {{< /info >}}
 
 {{< featuresTable >}}

--- a/content/get-involved.md
+++ b/content/get-involved.md
@@ -2,7 +2,7 @@
 title: Get Involved
 ---
 
-Jaeger is an open source project with [open governance](https://github.com/jaegertracing/jaeger/blob/master/GOVERNANCE.md). We welcome contributions from the community, and we’d love your help to improve and extend the project. Here are some ideas for how to get involved with the project. Some of them don't even require any coding.
+Jaeger is an open source project with [open governance](https://github.com/jaegertracing/jaeger/blob/main/GOVERNANCE.md). We welcome contributions from the community, and we’d love your help to improve and extend the project. Here are some ideas for how to get involved with the project. Some of them don't even require any coding.
 
 ## No-coding involvement
 
@@ -31,4 +31,4 @@ Of course, there's also no shortage of opportunities to help with the actual dev
 
 Another label to look for is [help wanted](https://github.com/jaegertracing/jaeger/labels/help%20wanted), which we use to tag tickets that involve features that maintainers consider promising / useful, but which are not on the immediate roadmap (after all, we all have day jobs with different priorities).
 
-Please refer to the [Contributing Guidelines](https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md) on how to make code contributions. And make sure to follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+Please refer to the [Contributing Guidelines](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md) on how to make code contributions. And make sure to follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).

--- a/data/clients.yaml
+++ b/data/clients.yaml
@@ -2,11 +2,11 @@ featureGroups:
   - description: Data format and transport for reporting spans to Jaeger backend
     features:
     - name: report_jaeger_thrift_compact_udp
-      description: Report [`jaeger.thrift`](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift), [Compact](https://github.com/apache/thrift/blob/v0.13.0/doc/specs/thrift-compact-protocol.md) protocol, over UDP
+      description: Report [`jaeger.thrift`](https://github.com/jaegertracing/jaeger-idl/blob/main/thrift/jaeger.thrift), [Compact](https://github.com/apache/thrift/blob/v0.13.0/doc/specs/thrift-compact-protocol.md) protocol, over UDP
     - name: report_jaeger_thrift_binary_udp
-      description: Report [`jaeger.thrift`](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift), [Binary](https://github.com/apache/thrift/blob/v0.13.0/doc/specs/thrift-binary-protocol.md) protocol, over UDP
+      description: Report [`jaeger.thrift`](https://github.com/jaegertracing/jaeger-idl/blob/main/thrift/jaeger.thrift), [Binary](https://github.com/apache/thrift/blob/v0.13.0/doc/specs/thrift-binary-protocol.md) protocol, over UDP
     - name: report_jaeger_thrift_binary_http
-      description: Report [`jaeger.thrift`](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift), [Binary](https://github.com/apache/thrift/blob/v0.13.0/doc/specs/thrift-binary-protocol.md) protocol, over TCP (HTTP)
+      description: Report [`jaeger.thrift`](https://github.com/jaegertracing/jaeger-idl/blob/main/thrift/jaeger.thrift), [Binary](https://github.com/apache/thrift/blob/v0.13.0/doc/specs/thrift-binary-protocol.md) protocol, over TCP (HTTP)
     - name: report_zipkin_thrift_binary_http
       description: Report Zipkin Thrift, Binary protocol, over TCP (HTTP)
 

--- a/data/download.yaml
+++ b/data/download.yaml
@@ -14,7 +14,7 @@ docker:
   description: Designed for quick local testing. It launches the Jaeger UI, collector, query, and agent, with an in-memory storage component.
   since: 0.8
 - image: example-hotrod
-  description: Sample application "[HotROD](https://github.com/jaegertracing/jaeger/tree/master/examples/hotrod)" that demonstrates features of distributed tracing ([blog post](https://medium.com/@YuriShkuro/take-opentracing-for-a-hotrod-ride-f6e3141f7941)).
+  description: Sample application "[HotROD](https://github.com/jaegertracing/jaeger/tree/main/examples/hotrod)" that demonstrates features of distributed tracing ([blog post](https://medium.com/@YuriShkuro/take-opentracing-for-a-hotrod-ride-f6e3141f7941)).
   since: 1.6
 - image: jaeger-agent
   description: Receives spans from Jaeger clients and forwards to collector. Designed to run as a sidecar or a host agent.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,19 +2,19 @@
 
 set -x -o errexit -o pipefail
 
-checkoutBranch=master
+checkoutBranch=main
 
-safe_checkout_master() {
+safe_checkout_main() {
   # We need to be on a branch to be able to create commits,
-  # and we want that branch to be master, which has been checked before.
+  # and we want that branch to be main, which has been checked before.
   # But we also want to make sure that we build and release exactly the tagged version, so we verify that the remote
   # branch is where our tag is.
   git remote -v
   git checkout -B "${checkoutBranch}"
   git fetch origin "${checkoutBranch}":origin/"${checkoutBranch}"
-  commit_local_master="$(git rev-parse ${checkoutBranch})"
-  commit_remote_master="$(git rev-parse origin/${checkoutBranch})"
-  if [ "$commit_local_master" != "$commit_remote_master" ]; then
+  commit_local_main="$(git rev-parse ${checkoutBranch})"
+  commit_remote_main="$(git rev-parse origin/${checkoutBranch})"
+  if [ "$commit_local_main" != "$commit_remote_main" ]; then
     echo "${checkoutBranch} on remote 'origin' has commits since the version under release, aborting"
     exit 1
   fi
@@ -22,7 +22,7 @@ safe_checkout_master() {
 
 if [[ "$RELEASE_TAG" =~ ^release-[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+?$ ]]; then
     echo "We are on release-x.y.z tag: $RELEASE_TAG"
-    safe_checkout_master
+    safe_checkout_main
     version=$(echo "${RELEASE_TAG}" | sed 's/^release-//')
     versionMajorMinor=$(echo "${version}" | sed 's/\.[[:digit:]]$//')
     echo "Creating new documentation for ${version}"


### PR DESCRIPTION
## Short description of the changes
- Renames references from master to main in an attempt to fix the [failing release build job](https://github.com/jaegertracing/documentation/runs/4745349895?check_suite_focus=true) on the newly introduced `main` branch.
