### PR TITLE
Add Aggregated Trace Metrics documentation

### DIFF
--- a/content/docs/next-release/_index.md
+++ b/content/docs/next-release/_index.md
@@ -36,6 +36,7 @@ Uber published a blog post, [Evolving Distributed Tracing at Uber](https://eng.u
   * System topology graphs
   * Adaptive sampling (coming soon)
   * Post-collection data processing pipeline (coming soon)
+  * Aggregated Trace Metrics (ATM)
 
 See [Features](./features/) page for more details.
 

--- a/content/docs/next-release/apis.md
+++ b/content/docs/next-release/apis.md
@@ -77,6 +77,10 @@ The returned JSON is a list of edges represented as tuples `(caller, callee, cou
 
 For programmatic access to service graph, the recommended API is gRPC/Protobuf described above.
 
+## Aggregated Trace Metrics (internal)
+
+Please refer to the [ATM Documentation](../atm#API)
+
 [jaeger-idl]: https://github.com/jaegertracing/jaeger-idl/
 [jaeger.thrift]: https://github.com/jaegertracing/jaeger-idl/blob/main/thrift/jaeger.thrift
 [agent.thrift]: https://github.com/jaegertracing/jaeger-idl/blob/main/thrift/agent.thrift

--- a/content/docs/next-release/atm.md
+++ b/content/docs/next-release/atm.md
@@ -105,7 +105,7 @@ graph
     style PROMETHEUS_EXPORTER fill:#404ca8,color:white
 {{< /mermaid >}}
 
-## Metrics Created
+## Derived Time Series
 
 Though more in scope of the [OpenTelemetry Collector][opentelemetry-collector],
 it is worth understanding the additional metrics and time series that the
@@ -133,14 +133,13 @@ Two metric names will be created:
       or equal to) label. The `latency_bucket` counter with lowest `le` and
       `le >= span latency` will be incremented for each span.
 
-The following formula aims to provide some guidance on the number new time series created:
+The following formula aims to provide some guidance on the number of new time series created:
 ```
-num_status_codes * num_span_kinds * (num_calls_metrics + num_latency_buckets) * num_operations
+num_status_codes * num_span_kinds * (1 + num_latency_buckets) * num_operations
 
 Where:
   num_status_codes = 3 max (typically 2: ok/error)
   num_span_kinds = 6 max (typically 2: client/server)
-  num_calls_metrics = 1
   num_latency_buckets = 17 default
 ```
 

--- a/content/docs/next-release/atm.md
+++ b/content/docs/next-release/atm.md
@@ -143,12 +143,16 @@ Where:
   num_latency_buckets = 17 default
 ```
 
-Plugging those numbers in, assuming default configuration (no custom dimensions/labels
-or latency buckets):
+Plugging those numbers in, assuming default configuration:
 ```
 max = 324 * num_operations
 typical = 72 * num_operations
 ```
+
+Note:
+- Custom [latency buckets][spanmetrics-config-latency] or [dimensions][spanmetrics-config-dimensions]
+  configured in the spanmetrics processor will alter the calculation above.
+- Querying custom dimensions are not supported by ATM and will be aggregated over.
 
 ## Configuration
 
@@ -197,3 +201,5 @@ both ingress and egress spans in the `server` and `client` span kinds, respectiv
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
 [http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L46
+[spanmetrics-config-latency]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L38

--- a/content/docs/next-release/atm.md
+++ b/content/docs/next-release/atm.md
@@ -1,0 +1,304 @@
+---
+title: Aggregated Trace Metrics (ATM) - Experimental
+hasparent: true
+---
+
+{{< info >}}
+As the Aggregated Trace Metrics feature is in its infancy, it is being marked
+as experimental to signal that this feature will be in flux while bugs and
+enhancements are added in response to community feedback.
+{{< /info >}}
+
+Surfaced in Jaeger UI as the "Monitor" tab, the motivation for this feature is
+to help identify interesting traces (e.g. high QPS, slow or erroneous requests)
+without needing to know the service or operation names up-front.
+
+It is essentially achieved through aggregating span data to produce R.E.D
+(Request, Error, Duration) metrics.
+
+As such, technically speaking, the term "Trace" used in the ATM acronym is a
+slight misnomer, while the term "Span" would be more appropriate because these
+metrics are trace unaware. ATM remains the name for this feature for historical
+reasons, to avoid confusion.
+
+Potential use cases include:
+
+- Post deployment sanity checks across the org, or on known dependent services
+  in the request chain.
+- Monitoring and root-causing when alerted of an issue.
+- Better onboarding experience for new users of Jaeger UI.
+- Long-term trend analysis of QPS, errors and latencies.
+- Capacity planning.
+
+## UI Feature Overview
+
+The "Monitor" tab provides a service-level aggregation, as well as an operation-level
+aggregation within the service, of Request rates, Error rates and Durations
+(P95, P75 and P50), also known as R.E.D metrics.
+
+Within the operation-level aggregations, an "Impact" metric, computed as the
+product of latency and request rate, is another signal that can be used to
+rule-out operations that may naturally have a high latency profile such as daily
+batch jobs, or conversely highlight operations that are lower in the latency
+rankings but with a high RPS (request per second).
+
+From these aggregations, Jaeger UI is able to pre-populate a Trace search with
+the relevant service, operation and lookback period, narrowing down the search
+space for these more interesting traces.
+
+## Getting Started
+
+{{< info >}}
+This is for demonstration purposes only and does not reflect deployment best practices.
+{{< /info >}}
+
+A locally runnable setup is available in the [Jaeger repository][atm-demo] along
+with instructions on how to run it.
+
+The feature can be accessed from the "Monitor" tab along the top menu.
+
+This demo includes [Microsim](https://github.com/yurishkuro/microsim); a microservices
+simulator to generate trace data.
+
+If generating traces manually is preferred, the [Sample App: HotROD](#Sample-App-HotROD)
+can be started via docker. Be sure to include `--net monitor_backend` in the `docker run` command.
+
+## Architecture
+
+The R.E.D metrics queried by Jaeger for the Monitor tab are the result of span
+data collected by the [OpenTelemetry Collector][opentelemetry-collector] which
+is then aggregated by the [SpanMetrics Processor][spanmetrics] component configured
+within its pipeline.
+
+These metrics are finally exported by the OpenTelemetry Collector (via prometheus
+exporters) to a Prometheus-compatible metrics store.
+
+It is worth emphasizing that this is a "read-only" feature and,
+as such, is only relevant to the Jaeger Query component (and All In One).
+
+{{<mermaid align="center">}}
+graph
+    TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_PROC[Spanmetrics Processor]
+    TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
+    TRACE_EXPORTER --> |spans| JAEGER[Jaeger Collector]
+    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    UI[Jaeger UI] --> QUERY
+    JAEGER --> SPAN_STORE[Span Storage]
+    QUERY[Jaeger Query Service] --> METRICS_STORE[Metrics Storage]
+    QUERY --> SPAN_STORE
+    PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE
+    subgraph Opentelemetry Collector
+        subgraph Pipeline
+            TRACE_RECEIVER
+            SPANMETRICS_PROC
+            TRACE_EXPORTER
+            PROMETHEUS_EXPORTER
+        end
+    end
+    style JAEGER fill:#9AEBFE,color:black
+    style UI fill:#9AEBFE,color:black
+    style QUERY fill:#9AEBFE,color:black
+
+    style TRACE_RECEIVER fill:#404ca8,color:white
+    style TRACE_EXPORTER fill:#404ca8,color:white
+    style SPANMETRICS_PROC fill:#404ca8,color:white
+    style PROMETHEUS_EXPORTER fill:#404ca8,color:white
+{{< /mermaid >}}
+
+## Metrics Created
+
+Though more in scope of the [OpenTelemetry Collector][opentelemetry-collector],
+it is worth understanding the additional metrics and time series that the
+[SpanMetrics Processor][spanmetrics] will generate in metrics storage to help
+with capacity planning when deploying ATM.
+
+Please refer to [Prometheus documentation][prom-metric-labels] covering the
+concepts of metric names, types, labels and time series; terms that will be used
+in the remainder of this section.
+
+Two metric names will be created:
+- `calls_total`
+  - **Type**: counter
+  - **Description**: counts the total number of spans, including error spans.
+    Call counts are differentiated from errors via the `status_code` label. Errors
+    are identified as any time series with the label `status_code = "STATUS_CODE_ERROR"`.
+- `latency`
+  - **Type**: histogram
+  - **Description**: a histogram of span latencies. Under the hood, Prometheus histograms
+    will create a number of time series:
+    - `latency_count`: The total number of data points across all buckets in the histogram.
+    - `latency_sum`: The sum of all data point values.
+    - `latency_bucket`: A collection of `n` time series (where `n` is the number of
+      latency buckets) for each latency bucket identified by an `le` (less than
+      or equal to) label. The `latency_bucket` counter with lowest `le` and
+      `le >= span latency` will be incremented for each span.
+
+The following formula aims to provide some guidance on the number new time series created:
+```
+num_status_codes * num_span_kinds * (num_calls_metrics + num_latency_buckets) * num_operations
+
+Where:
+  num_status_codes = 3 max (typically 2: ok/error)
+  num_span_kinds = 6 max (typically 2: client/server)
+  num_calls_metrics = 1
+  num_latency_buckets = 17 default
+```
+
+Plugging those numbers in, assuming default configuration (no custom dimensions
+or latency buckets):
+```
+max = 324 * num_operations
+typical = 72 * num_operations
+```
+
+## Configuration
+
+### Enabling ATM
+
+The following configuration is required to enable the ATM feature:
+
+- [Jaeger UI](../frontend-ui#monitor-experimental)
+- [Jaeger Query](../cli#jaeger-query-prometheus)
+  - Set the `METRICS_STORAGE_TYPE` environment variable to `prometheus`.
+  - Optional: Set `--prometheus.server-url` (or `PROMETHEUS_SERVER_URL` environment variable)
+    to the URL of the prometheus server. Default: http://localhost:9090.
+
+## API
+
+Used by the Monitor tab of Jaeger UI to populate the metrics for its visualizations.
+
+### gRPC/Protobuf
+
+The recommended way to programmatically retrieve traces and other data is via `jaeger.api_v2.metrics.MetricsQueryService` gRPC endpoint defined in the [metricsquery.proto][metricsquery.proto] IDL file.
+
+### HTTP JSON
+
+#### R.E.D. Metrics Queries
+
+`/api/metrics/{metric_type}?{query}`
+
+Where (in Backus-Naur form):
+```
+metric_type = 'latencies' | 'calls' | 'errors'
+
+query = services , [ '&' optionalParams ]
+
+optionalParams = param | param '&' optionalParams
+
+param =  groupByOperation | quantile | endTs | lookback | step | ratePer | spanKinds
+
+services = service | service '&' services
+service = 'service=' strValue
+  - The list of services to include in the metrics selection filter, which are logically 'OR'ed.
+  - Mandatory.
+
+quantile = 'quantile=' floatValue
+  - The quantile to compute the latency 'P' value. Valid range (0,1].
+  - Mandatory for 'latencies' type.
+
+groupByOperation = 'groupByOperation=' boolValue
+boolValue = '1' | 't' | 'T' | 'true' | 'TRUE' | 'True' | 0 | 'f' | 'F' | 'false' | 'FALSE' | 'False'
+  - A boolean value which will determine if the metrics query will also group by operation.
+  - Optional with default: false
+
+endTs = 'endTs=' intValue
+  - The posix milliseconds timestamp of the end time range of the metrics query.
+  - Optional with default: now
+
+lookback = 'lookback=' intValue
+  - The duration, in milliseconds, from endTs to look back on for metrics data points.
+  - For example, if set to `3600000` (1 hour), the query would span from `endTs - 1 hour` to `endTs`.
+  - Optional with default: 3600000 (1 hour).
+
+step = 'step=' intValue
+  - The duration, in milliseconds, between data points of the query results.
+  - For example, if set to 5s, the results would produce a data point every 5 seconds from the `endTs - lookback` to `endTs`.
+  - Optional with default: 5000 (5 seconds).
+
+ratePer = 'ratePer=' intValue
+  - The duration, in milliseconds, in which the per-second rate of change is calculated for a cumulative counter metric.
+  - Optional with default: 600000 (10 minutes).
+
+spanKinds = spanKind | spanKind '&' spanKinds
+spanKind = 'spanKind=' spanKindType
+spanKindType = 'unspecified' | 'internal' | 'server' | 'client' | 'producer' | 'consumer'
+  - The list of spanKinds to include in the metrics selection filter, which are logically 'OR'ed.
+  - Optional with default: 'server'
+```
+
+##### Responses
+
+The response data model is based on [OpenMetrics' `MetricFamily`][openmetrics.proto]
+
+For example:
+```
+{
+  "name": "service_call_rate",
+  "type": "GAUGE",
+  "help": "calls/sec, grouped by service",
+  "metrics": [
+    {
+      "labels": [
+        {
+          "name": "service_name",
+          "value": "driver"
+        }
+      ],
+      "metricPoints": [
+        {
+          "gaugeValue": {
+            "doubleValue": 0.005846808321083344
+          },
+          "timestamp": "2021-06-03T09:12:06Z"
+        },
+        {
+          "gaugeValue": {
+            "doubleValue": 0.006960443672323934
+          },
+          "timestamp": "2021-06-03T09:12:11Z"
+        },
+...
+  ```
+
+If the `groupByOperation=true` parameter is set, the response will include the operation name in the labels like so:
+```
+      "labels": [
+        {
+          "name": "operation",
+          "value": "/FindNearest"
+        },
+        {
+          "name": "service_name",
+          "value": "driver"
+        }
+      ],
+```
+
+#### Min Step Query
+
+`/api/metrics/minstep`
+
+Gets the min time resolution supported by the backing metrics store, in milliseconds, that can be used in the `step` parameter.
+e.g. a min step of 1 means the backend can only return data points that are at least 1ms apart, not closer.
+
+## Troubleshooting
+
+### Service/Operation missing in Monitor Tab
+
+If the service/operation is missing in the Monitor Tab, but visible in the Jaeger
+Trace search service and operation drop-downs menus, a common cause of this is
+the default `server` span kind used in metrics queries.
+
+The service/operations you are not seeing could be from spans that are non-server
+span kinds such as client or worse, `unspecified`. Hence, this is an instrumentation
+data quality issue, and the instrumentation should set the span kind.
+
+The reason for defaulting to `server` span kinds is to avoid double-counting
+both ingress and egress spans in the `server` and `client` span kinds, respectively.
+
+[atm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
+[openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
+[opentelemetry-collector]: https://opentelemetry.io/docs/collector/
+[spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
+[prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels

--- a/content/docs/next-release/atm.md
+++ b/content/docs/next-release/atm.md
@@ -73,7 +73,7 @@ within its pipeline.
 These metrics are finally exported by the OpenTelemetry Collector (via prometheus
 exporters) to a Prometheus-compatible metrics store.
 
-It is worth emphasizing that this is a "read-only" feature and,
+It is important emphasize that this is a "read-only" feature and,
 as such, is only relevant to the Jaeger Query component (and All In One).
 
 {{<mermaid align="center">}}
@@ -144,7 +144,7 @@ Where:
   num_latency_buckets = 17 default
 ```
 
-Plugging those numbers in, assuming default configuration (no custom dimensions
+Plugging those numbers in, assuming default configuration (no custom dimensions/labels
 or latency buckets):
 ```
 max = 324 * num_operations

--- a/content/docs/next-release/atm.md
+++ b/content/docs/next-release/atm.md
@@ -164,121 +164,16 @@ The following configuration is required to enable the ATM feature:
 
 ## API
 
-Used by the Monitor tab of Jaeger UI to populate the metrics for its visualizations.
-
 ### gRPC/Protobuf
 
-The recommended way to programmatically retrieve traces and other data is via `jaeger.api_v2.metrics.MetricsQueryService` gRPC endpoint defined in the [metricsquery.proto][metricsquery.proto] IDL file.
+The recommended way to programmatically retrieve RED metrics is via `jaeger.api_v2.metrics.MetricsQueryService` gRPC endpoint defined in the [metricsquery.proto][metricsquery.proto] IDL file.
 
 ### HTTP JSON
 
-#### R.E.D. Metrics Queries
+Used internally by the Monitor tab of Jaeger UI to populate the metrics for its visualizations.
 
-`/api/metrics/{metric_type}?{query}`
-
-Where (in Backus-Naur form):
-```
-metric_type = 'latencies' | 'calls' | 'errors'
-
-query = services , [ '&' optionalParams ]
-
-optionalParams = param | param '&' optionalParams
-
-param =  groupByOperation | quantile | endTs | lookback | step | ratePer | spanKinds
-
-services = service | service '&' services
-service = 'service=' strValue
-  - The list of services to include in the metrics selection filter, which are logically 'OR'ed.
-  - Mandatory.
-
-quantile = 'quantile=' floatValue
-  - The quantile to compute the latency 'P' value. Valid range (0,1].
-  - Mandatory for 'latencies' type.
-
-groupByOperation = 'groupByOperation=' boolValue
-boolValue = '1' | 't' | 'T' | 'true' | 'TRUE' | 'True' | 0 | 'f' | 'F' | 'false' | 'FALSE' | 'False'
-  - A boolean value which will determine if the metrics query will also group by operation.
-  - Optional with default: false
-
-endTs = 'endTs=' intValue
-  - The posix milliseconds timestamp of the end time range of the metrics query.
-  - Optional with default: now
-
-lookback = 'lookback=' intValue
-  - The duration, in milliseconds, from endTs to look back on for metrics data points.
-  - For example, if set to `3600000` (1 hour), the query would span from `endTs - 1 hour` to `endTs`.
-  - Optional with default: 3600000 (1 hour).
-
-step = 'step=' intValue
-  - The duration, in milliseconds, between data points of the query results.
-  - For example, if set to 5s, the results would produce a data point every 5 seconds from the `endTs - lookback` to `endTs`.
-  - Optional with default: 5000 (5 seconds).
-
-ratePer = 'ratePer=' intValue
-  - The duration, in milliseconds, in which the per-second rate of change is calculated for a cumulative counter metric.
-  - Optional with default: 600000 (10 minutes).
-
-spanKinds = spanKind | spanKind '&' spanKinds
-spanKind = 'spanKind=' spanKindType
-spanKindType = 'unspecified' | 'internal' | 'server' | 'client' | 'producer' | 'consumer'
-  - The list of spanKinds to include in the metrics selection filter, which are logically 'OR'ed.
-  - Optional with default: 'server'
-```
-
-##### Responses
-
-The response data model is based on [OpenMetrics' `MetricFamily`][openmetrics.proto]
-
-For example:
-```
-{
-  "name": "service_call_rate",
-  "type": "GAUGE",
-  "help": "calls/sec, grouped by service",
-  "metrics": [
-    {
-      "labels": [
-        {
-          "name": "service_name",
-          "value": "driver"
-        }
-      ],
-      "metricPoints": [
-        {
-          "gaugeValue": {
-            "doubleValue": 0.005846808321083344
-          },
-          "timestamp": "2021-06-03T09:12:06Z"
-        },
-        {
-          "gaugeValue": {
-            "doubleValue": 0.006960443672323934
-          },
-          "timestamp": "2021-06-03T09:12:11Z"
-        },
-...
-  ```
-
-If the `groupByOperation=true` parameter is set, the response will include the operation name in the labels like so:
-```
-      "labels": [
-        {
-          "name": "operation",
-          "value": "/FindNearest"
-        },
-        {
-          "name": "service_name",
-          "value": "driver"
-        }
-      ],
-```
-
-#### Min Step Query
-
-`/api/metrics/minstep`
-
-Gets the min time resolution supported by the backing metrics store, in milliseconds, that can be used in the `step` parameter.
-e.g. a min step of 1 means the backend can only return data points that are at least 1ms apart, not closer.
+Refer to [this README file][http-api-readme] for a detailed specification of
+the HTTP API.
 
 ## Troubleshooting
 
@@ -301,3 +196,4 @@ both ingress and egress spans in the `server` and `client` span kinds, respectiv
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api

--- a/content/docs/next-release/deployment.md
+++ b/content/docs/next-release/deployment.md
@@ -13,6 +13,9 @@ children:
   url: security
 - title: On Windows
   url: windows
+- title: Aggregated Trace Metrics (ATM)
+  navtitle: ATM
+  url: atm
 ---
 
 The main Jaeger backend components are released as Docker images on [Docker Hub](https://hub.docker.com/r/jaegertracing) and [Quay](https://quay.io/organization/jaegertracing):
@@ -56,7 +59,7 @@ Command line option                | Environment variable
 
 ## All-in-one
 
-Jaeger all-in-one is a special distribution that combines three Jaeger components, [agent](#agent), [collector](#collector), and [query service/UI](#query-service--ui), in a single binary or container image. It is useful for single-node deployments where your trace volume is light enough to be handled by a single instance. By default, all-in-one starts with `memory` storage, meaning it will lose all data upon restart. All other [storage backends](#storage-backends) can also be used with all-in-one, but `memory` and `badger` are exclusive to all-in-one because they cannot be shared between instances.
+Jaeger all-in-one is a special distribution that combines three Jaeger components, [agent](#agent), [collector](#collector), and [query service/UI](#query-service--ui), in a single binary or container image. It is useful for single-node deployments where your trace volume is light enough to be handled by a single instance. By default, all-in-one starts with `memory` storage, meaning it will lose all data upon restart. All other [span storage backends](#span-storage-backends) can also be used with all-in-one, but `memory` and `badger` are exclusive to all-in-one because they cannot be shared between instances.
 
 All-in-one listens to the same ports as the components it contains (described below), with the exception of the admin port.
 
@@ -155,7 +158,7 @@ Port  | Protocol | Function
 14269 | HTTP     | admin port: health check at `/` and metrics at `/metrics`
 
 
-## Storage Backends
+## Span Storage Backends
 
 Collectors require a persistent storage backend. Cassandra and Elasticsearch are the primary supported distributed storage backends. Additional backends are [discussed here](https://github.com/jaegertracing/jaeger/issues/638).
 
@@ -662,6 +665,54 @@ docker run \
   -e GRPC_STORAGE_PLUGIN_BINARY=<...> \
   -e GRPC_STORAGE_PLUGIN_CONFIGURATION_FILE=<...> \
   jaegertracing/all-in-one:{{< currentVersion >}}
+```
+
+## Metrics Storage Backends
+
+Jaeger Query is capable of querying aggregated R.E.D metrics from a storage backend,
+visualizing them on the [Monitor tab](../atm). It should be emphasized that the
+configured metrics storage type is for reading _only_ and therefore, only applies
+to the Jaeger Query component (and All In One, which contains Jaeger Query).
+
+The storage type can be passed via `METRICS_STORAGE_TYPE` environment variable.
+Valid values are: `prometheus`.
+
+### Prometheus
+
+Any PromQL-compatible backend is supported by Jaeger Query. A list of these have
+been compiled by Julius Volz in:
+https://promlabs.com/blog/2020/11/26/an-update-on-promql-compatibility-across-vendors
+
+#### Configuration
+
+##### Minimal
+```sh
+docker run \
+  -e METRICS_STORAGE_TYPE=prometheus \
+  jaegertracing/jaeger-query:{{< currentVersion >}}
+```
+
+##### All options
+To view the full list of configuration options, you can run the following command:
+```sh
+docker run \
+  -e METRICS_STORAGE_TYPE=prometheus \
+  jaegertracing/jaeger-query:{{< currentVersion >}} \
+  --help
+```
+#### TLS support
+
+Jaeger supports TLS client to Prometheus server connections as long as you've [configured
+your Prometheus server](https://prometheus.io/docs/guides/tls-encryption/) correctly. You can
+configure Jaeger Query like so:
+
+```sh
+docker run \
+  -e METRICS_STORAGE_TYPE=prometheus \
+  -e PROMETHEUS_SERVER_URL=<...> \
+  -e PROMETHEUS_TLS_ENABLED=true \
+  -e PROMETHEUS_TLS_CA=<path to your CA cert file> \
+  jaegertracing/jaeger-query:{{< currentVersion >}}
 ```
 
 ## Ingester

--- a/content/docs/next-release/features.md
+++ b/content/docs/next-release/features.md
@@ -75,3 +75,7 @@ Also known as "Transitive Dependency Graph", where a chain `A -> B -> C` means t
 The node granularity of this graph can be changed between services and service endpoints. In the latter mode, different endpoints in the same service will be displayed as separate nodes, e.g. `A::op1` and `A::op2`.
 
 At this time the transitive graph can only be constructed from traces in the search results. In the future there will be a Flink job that will compute the graphs by aggregating all traces.
+
+## Aggregated Trace Metrics (ATM)
+
+Please refer to [Aggregated Trace Metrics (ATM)](../atm).

--- a/content/docs/next-release/features.md
+++ b/content/docs/next-release/features.md
@@ -78,4 +78,9 @@ At this time the transitive graph can only be constructed from traces in the sea
 
 ## Aggregated Trace Metrics (ATM)
 
-Please refer to [Aggregated Trace Metrics (ATM)](../atm).
+Visualizes aggregated span data in the form of RED (Requests, Errors, Duration) metrics
+to highlight services and/or operations with statistically significant request/error rates or
+latencies, then leveraging Jaeger's Trace Search capabilities to pinpoint specific
+traces belonging to these services/operations.
+
+See [Aggregated Trace Metrics (ATM)](../atm) for more details.

--- a/content/docs/next-release/frontend-ui.md
+++ b/content/docs/next-release/frontend-ui.md
@@ -10,6 +10,7 @@ weight: 7
 Several aspects of the UI can be configured:
 
   * The Dependencies section can be enabled / configured
+  * The [Monitor tab (aka: Aggregated Trace Metrics)](../atm) can be enabled / configured
   * App analytics tracking can be enabled / configured (via Google Analytics or custom plugin)
   * Additional menu options can be added to the global nav
   * Search input limits can be configured
@@ -22,6 +23,9 @@ An example configuration file:
 {
   "dependencies": {
     "dagMaxNumServices": 200,
+    "menuEnabled": true
+  },
+  "monitor": {
     "menuEnabled": true
   },
   "archiveEnabled": true,
@@ -65,6 +69,10 @@ An example configuration file:
 `dependencies.dagMaxNumServices` defines the maximum number of services allowed before the DAG dependency view is disabled. Default: `200`.
 
 `dependencies.menuEnabled` enables (`true`) or disables (`false`) the dependencies menu button. Default: `true`.
+
+### Monitor (Experimental)
+
+`monitor.menuEnabled` enables (`true`) or disables (`false`) the Monitor menu button. Default: `false`.
 
 ### Archive Support
 

--- a/content/docs/next-release/getting-started.md
+++ b/content/docs/next-release/getting-started.md
@@ -52,6 +52,9 @@ Port  | Protocol | Component | Function
 14250 | HTTP     | collector | accept `model.proto`
 9411  | HTTP     | collector | Zipkin compatible endpoint (optional)
 
+### With Aggregated Trace Metrics (ATM)
+
+Please refer to [Aggregated Trace Metrics (ATM)](../atm#getting-started).
 
 ## Kubernetes and OpenShift
 

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -427,7 +427,7 @@ Spark dependencies
 
 You can use the simplest example (shown above) and create a Jaeger instance using the defaults, or you can create your own custom resource file.
 
-## Storage options
+## Span storage options
 
 ### Cassandra storage
 
@@ -695,6 +695,51 @@ spec:
 <3> Configuration options for the `grpc-plugin`.
 
 <4> User created config map with the plugin configuration.
+
+## Metrics storage options
+
+### Prometheus
+
+Setting `spec.metricsStorage.type` to `prometheus` enables using Jaeger with
+PromQL-compatible storage implementations to query R.E.D metrics for the
+[Aggregated Trace Metrics](../atm) feature.
+
+The following is an example of a Jaeger CR using the `allInOne` deployment strategy,
+an in-memory span storage and prometheus metrics storage.
+
+```yaml
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: jaeger-atm
+spec:
+  strategy: allInOne
+  allInOne:
+    image: jaegertracing/all-in-one:latest
+    options:
+      log-level: debug
+      query:
+        base-path: /jaeger
+      prometheus: # <1>
+        server-url: "http://prometheus:9090" # <2>
+    metricsStorage: # <3>
+      type: prometheus # <4>
+  storage:
+    options:
+      memory:
+        max-traces: 100000
+```
+
+<1> Beginning of `prometheus`-namespaced configuration, defined as a simple `key: value` map.
+    All available options are documented in the
+    [Jaeger All-In-One with Prometheus CLI section](../cli#jaeger-all-in-one-prometheus)
+
+<2> Overrides the default `http://localhost:9090` prometheus server URL with `http://prometheus:9090`.
+
+<3> Section to enable metrics querying capabilities.
+
+<4> Selects `prometheus` as the metrics storage backend.
+
 
 ## Deriving dependencies
 

--- a/themes/jaeger-docs/layouts/shortcodes/mermaid.html
+++ b/themes/jaeger-docs/layouts/shortcodes/mermaid.html
@@ -1,0 +1,18 @@
+<script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+<script>
+  var config = {
+    startOnLoad: true,
+
+    // useMaxWidth:true ensures the SVG scales with the main panel as it's resized
+    // and prevents the image from overlapping with menu panels.
+    flowchart: { useMaxWidth: true, htmlLabels: false },
+
+    // See: https://github.com/mermaid-js/mermaid/issues/790#issuecomment-478860052
+    // Prevents text in labels from getting cut off at the end.
+    themeCSS: ".label foreignObject { font-size: 90%; overflow: visible; }"
+  };
+  mermaid.initialize(config);
+</script>
+<div class="mermaid">
+  {{ .Inner }}
+</div>


### PR DESCRIPTION
Signed-off-by: albertteoh <see.kwang.teoh@gmail.com>

## Which problem is this PR solving?
- Resolves #553

## Short description of the changes
- Adds the Aggregated Trace Metrics documentation, marking it as experimental.
- As [suggested](https://github.com/jaegertracing/documentation/issues/553#issuecomment-1058206739), I have put the majority of content in a single feature-oriented document.
- Updated k8s operator and Jaeger UI config documents with relevant details along with references to the main ATM feature document.
- Architecture diagram implemented with mermaid to allow for easy editing in anticipation of up-coming changes, particularly to the OTEL pipeline configuration.
  - The rendered architecture diagram:
<img width="1034" alt="Screen Shot 2022-03-14 at 9 55 33 pm" src="https://user-images.githubusercontent.com/26584478/158158523-a6ac7141-768c-4988-924c-b8f53e2087a1.png">

