### PR TITLE
Adaptive update

### DIFF
--- a/content/docs/1.27/_index.md
+++ b/content/docs/1.27/_index.md
@@ -34,7 +34,7 @@ Uber published a blog post, [Evolving Distributed Tracing at Uber](https://eng.u
   * Uses consistent upfront sampling with individual per service/endpoint probabilities
   * Multiple storage backends: Cassandra, Elasticsearch, memory.
   * System topology graphs
-  * Adaptive sampling (coming soon)
+  * Adaptive sampling
   * Post-collection data processing pipeline (coming soon)
 
 See [Features](./features/) page for more details.

--- a/content/docs/1.28/_index.md
+++ b/content/docs/1.28/_index.md
@@ -34,7 +34,7 @@ Uber published a blog post, [Evolving Distributed Tracing at Uber](https://eng.u
   * Uses consistent upfront sampling with individual per service/endpoint probabilities
   * Multiple storage backends: Cassandra, Elasticsearch, memory.
   * System topology graphs
-  * Adaptive sampling (coming soon)
+  * Adaptive sampling
   * Post-collection data processing pipeline (coming soon)
 
 See [Features](./features/) page for more details.

--- a/content/docs/1.29/_index.md
+++ b/content/docs/1.29/_index.md
@@ -34,7 +34,7 @@ Uber published a blog post, [Evolving Distributed Tracing at Uber](https://eng.u
   * Uses consistent upfront sampling with individual per service/endpoint probabilities
   * Multiple storage backends: Cassandra, Elasticsearch, memory.
   * System topology graphs
-  * Adaptive sampling (coming soon)
+  * Adaptive sampling
   * Post-collection data processing pipeline (coming soon)
 
 See [Features](./features/) page for more details.

--- a/content/docs/1.30/_index.md
+++ b/content/docs/1.30/_index.md
@@ -34,7 +34,7 @@ Uber published a blog post, [Evolving Distributed Tracing at Uber](https://eng.u
   * Uses consistent upfront sampling with individual per service/endpoint probabilities
   * Multiple storage backends: Cassandra, Elasticsearch, memory.
   * System topology graphs
-  * Adaptive sampling (coming soon)
+  * Adaptive sampling
   * Post-collection data processing pipeline (coming soon)
 
 See [Features](./features/) page for more details.

--- a/content/docs/1.31/_index.md
+++ b/content/docs/1.31/_index.md
@@ -34,7 +34,7 @@ Uber published a blog post, [Evolving Distributed Tracing at Uber](https://eng.u
   * Uses consistent upfront sampling with individual per service/endpoint probabilities
   * Multiple storage backends: Cassandra, Elasticsearch, memory.
   * System topology graphs
-  * Adaptive sampling (coming soon)
+  * Adaptive sampling
   * Post-collection data processing pipeline (coming soon)
 
 See [Features](./features/) page for more details.

--- a/content/docs/1.32/_index.md
+++ b/content/docs/1.32/_index.md
@@ -34,7 +34,7 @@ Uber published a blog post, [Evolving Distributed Tracing at Uber](https://eng.u
   * Uses consistent upfront sampling with individual per service/endpoint probabilities
   * Multiple storage backends: Cassandra, Elasticsearch, memory.
   * System topology graphs
-  * Adaptive sampling (coming soon)
+  * Adaptive sampling
   * Post-collection data processing pipeline (coming soon)
 
 See [Features](./features/) page for more details.

--- a/content/docs/next-release/_index.md
+++ b/content/docs/next-release/_index.md
@@ -34,7 +34,7 @@ Uber published a blog post, [Evolving Distributed Tracing at Uber](https://eng.u
   * Uses consistent upfront sampling with individual per service/endpoint probabilities
   * Multiple storage backends: Cassandra, Elasticsearch, memory.
   * System topology graphs
-  * Adaptive sampling (coming soon)
+  * Adaptive sampling
   * Post-collection data processing pipeline (coming soon)
 
 See [Features](./features/) page for more details.

--- a/content/docs/next-release/sampling.md
+++ b/content/docs/next-release/sampling.md
@@ -87,4 +87,6 @@ Adaptive sampling works in the Jaeger collector by observing the spans received 
 
 Adaptive sampling requires a storage backend to store the observed traffic data and computed probabilities. At the moment `memory` (for all-in-one deployment) and `cassandra` are supported as sampling storage backends. We are seeking help in implementing support for other backends (https://github.com/jaegertracing/jaeger/issues/3305).
 
+By default adaptive sampling will attempt to use the backend specified by `SPAN_STORAGE_TYPE` to store data. However, a second type of backend can also be specified by using `SAMPLING_STORAGE_TYPE`. For instance, `SPAN_STORAGE_TYPE=elasticsearch SAMPLING_STORAGE_TYPE=cassandra ./jaeger-collector` will run the collector in a mode where it attempts to store its span data in the configured elasticsearch cluster and its adaptive sampling data in the configured cassandra cluster. Note that this feature can not be used to store span and adaptive sampling data in two different backends of the same type.
+
 Read [this blog post](https://medium.com/jaegertracing/adaptive-sampling-in-jaeger-50f336f4334) for more details on adaptive sampling engine.


### PR DESCRIPTION
## Which problem is this PR solving?
- Fixes #557 

## Short description of the changes
- Removes the adaptive sampling "coming soon" from the main page for all versions since 1.27.
- Adds a short paragraph about using `SAMPLING_STORAGE_TYPE` recently added
