### PR TITLE
Remove collector from ATM arch diag

### DIFF
--- a/content/docs/next-release/atm.md
+++ b/content/docs/next-release/atm.md
@@ -80,12 +80,9 @@ as such, is only relevant to the Jaeger Query component (and All In One).
 graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_PROC[Spanmetrics Processor]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
-    TRACE_EXPORTER --> |spans| JAEGER[Jaeger Collector]
     SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
     UI[Jaeger UI] --> QUERY
-    JAEGER --> SPAN_STORE[Span Storage]
     QUERY[Jaeger Query Service] --> METRICS_STORE[Metrics Storage]
-    QUERY --> SPAN_STORE
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE
     subgraph Opentelemetry Collector
         subgraph Pipeline
@@ -95,7 +92,6 @@ graph
             PROMETHEUS_EXPORTER
         end
     end
-    style JAEGER fill:#9AEBFE,color:black
     style UI fill:#9AEBFE,color:black
     style QUERY fill:#9AEBFE,color:black
 


### PR DESCRIPTION
Signed-off-by: albertteoh <see.kwang.teoh@gmail.com>

## Which problem is this PR solving?
Received feedback regarding the ATM architecture diagram that it may be confusing with the Jaeger Collector component for the following reasons:

- Span collection and storage are a related, but irrelevant concern for ATM; i.e. it should still be possible to monitor service health without storing spans, only the drill-down feature to search for relevant traces will not work.
- Users do not necessarily need a Jaeger Collector component in their deployment architecture and may, instead choose to export spans to another system/provider.

## Short description of the changes
- Proposes to remove the Jaeger Collector and span storage components from the ATM architecture to reduce confusion.
- Leads to a simpler, cleaner, and easier to comprehend diagram.
- Kept "Trace Exporter" component in the OTEL pipeline to still emphasize that spans can be forked and exported to a trace storage backend, while still aggregating metrics on spans.

Renders to the following:

<img width="857" alt="Screen Shot 2022-03-24 at 10 20 23 pm" src="https://user-images.githubusercontent.com/26584478/159907650-b5bf8ab7-dcbd-4f8a-b6cc-9ba9ec262f1f.png">

