### PR TITLE
Fixing ILM documentation 

### DIFF
--- a/content/docs/1.22/deployment.md
+++ b/content/docs/1.22/deployment.md
@@ -406,7 +406,7 @@ For example:
   "ILM policy jaeger-ilm-policy doesn't exist in Elasticsearch. Please create it and rerun init"
   {{< /info >}}
 
-  After the initialization, deploy Jaeger with `--es.use-ilm=true` and `--es.use-aliases=true`.
+  After the initialization, deploy Jaeger with `--es.use-ilm=true`, `--es.use-aliases=true` and `--es.create-index-templates=false`.
 
 
 #### Upgrade Elasticsearch version

--- a/content/docs/1.23/deployment.md
+++ b/content/docs/1.23/deployment.md
@@ -406,7 +406,7 @@ For example:
   "ILM policy jaeger-ilm-policy doesn't exist in Elasticsearch. Please create it and rerun init"
   {{< /info >}}
 
-  After the initialization, deploy Jaeger with `--es.use-ilm=true` and `--es.use-aliases=true`.
+  After the initialization, deploy Jaeger with `--es.use-ilm=true`, `--es.use-aliases=true` and `--es.create-index-templates=false`.
 
 
 #### Upgrade Elasticsearch version

--- a/content/docs/1.24/deployment.md
+++ b/content/docs/1.24/deployment.md
@@ -517,7 +517,7 @@ For example:
   "ILM policy jaeger-ilm-policy doesn't exist in Elasticsearch. Please create it and rerun init"
   {{< /info >}}
 
-  After the initialization, deploy Jaeger with `--es.use-ilm=true` and `--es.use-aliases=true`.
+  After the initialization, deploy Jaeger with `--es.use-ilm=true`, `--es.use-aliases=true` and `--es.create-index-templates=false`.
 
 
 #### Upgrade Elasticsearch version

--- a/content/docs/1.25/deployment.md
+++ b/content/docs/1.25/deployment.md
@@ -517,7 +517,7 @@ For example:
   "ILM policy jaeger-ilm-policy doesn't exist in Elasticsearch. Please create it and rerun init"
   {{< /info >}}
 
-  After the initialization, deploy Jaeger with `--es.use-ilm=true` and `--es.use-aliases=true`.
+  After the initialization, deploy Jaeger with `--es.use-ilm=true`, `--es.use-aliases=true` and `--es.create-index-templates=false`.
 
 
 #### Upgrade Elasticsearch version

--- a/content/docs/1.26/deployment.md
+++ b/content/docs/1.26/deployment.md
@@ -517,7 +517,7 @@ For example:
   "ILM policy jaeger-ilm-policy doesn't exist in Elasticsearch. Please create it and rerun init"
   {{< /info >}}
 
-  After the initialization, deploy Jaeger with `--es.use-ilm=true` and `--es.use-aliases=true`.
+  After the initialization, deploy Jaeger with `--es.use-ilm=true`, `--es.use-aliases=true` and `--es.create-index-templates=false`.
 
 
 #### Upgrade Elasticsearch version

--- a/content/docs/1.27/deployment.md
+++ b/content/docs/1.27/deployment.md
@@ -517,7 +517,7 @@ For example:
   "ILM policy jaeger-ilm-policy doesn't exist in Elasticsearch. Please create it and rerun init"
   {{< /info >}}
 
-  After the initialization, deploy Jaeger with `--es.use-ilm=true` and `--es.use-aliases=true`.
+  After the initialization, deploy Jaeger with `--es.use-ilm=true`, `--es.use-aliases=true` and `--es.create-index-templates=false`.
 
 
 #### Upgrade Elasticsearch version

--- a/content/docs/1.28/deployment.md
+++ b/content/docs/1.28/deployment.md
@@ -519,7 +519,7 @@ For example:
   "ILM policy jaeger-ilm-policy doesn't exist in Elasticsearch. Please create it and rerun init"
   {{< /info >}}
 
-  After the initialization, deploy Jaeger with `--es.use-ilm=true` and `--es.use-aliases=true`.
+  After the initialization, deploy Jaeger with `--es.use-ilm=true`, `--es.use-aliases=true` and `--es.create-index-templates=false`.
 
 
 #### Upgrade Elasticsearch version

--- a/content/docs/1.29/deployment.md
+++ b/content/docs/1.29/deployment.md
@@ -539,7 +539,7 @@ For example:
   "ILM policy jaeger-ilm-policy doesn't exist in Elasticsearch. Please create it and rerun init"
   {{< /info >}}
 
-  After the initialization, deploy Jaeger with `--es.use-ilm=true` and `--es.use-aliases=true`.
+  After the initialization, deploy Jaeger with `--es.use-ilm=true`, `--es.use-aliases=true` and `--es.create-index-templates=false`..
 
 
 #### Upgrade Elasticsearch version

--- a/content/docs/1.30/deployment.md
+++ b/content/docs/1.30/deployment.md
@@ -539,7 +539,7 @@ For example:
   "ILM policy jaeger-ilm-policy doesn't exist in Elasticsearch. Please create it and rerun init"
   {{< /info >}}
 
-  After the initialization, deploy Jaeger with `--es.use-ilm=true` and `--es.use-aliases=true`.
+  After the initialization, deploy Jaeger with `--es.use-ilm=true`, `--es.use-aliases=true` and `--es.create-index-templates=false`.
 
 
 #### Upgrade Elasticsearch version

--- a/content/docs/1.31/deployment.md
+++ b/content/docs/1.31/deployment.md
@@ -539,7 +539,7 @@ For example:
   "ILM policy jaeger-ilm-policy doesn't exist in Elasticsearch. Please create it and rerun init"
   {{< /info >}}
 
-  After the initialization, deploy Jaeger with `--es.use-ilm=true` and `--es.use-aliases=true`.
+  After the initialization, deploy Jaeger with `--es.use-ilm=true`, `--es.use-aliases=true` and `--es.create-index-templates=false`.
 
 
 #### Upgrade Elasticsearch version

--- a/content/docs/1.32/deployment.md
+++ b/content/docs/1.32/deployment.md
@@ -539,7 +539,7 @@ For example:
   "ILM policy jaeger-ilm-policy doesn't exist in Elasticsearch. Please create it and rerun init"
   {{< /info >}}
 
-  After the initialization, deploy Jaeger with `--es.use-ilm=true` and `--es.use-aliases=true`.
+  After the initialization, deploy Jaeger with `--es.use-ilm=true`, `--es.use-aliases=true` and `--es.create-index-templates=false`.
 
 
 #### Upgrade Elasticsearch version


### PR DESCRIPTION
**Problem**

By following the documentation, the elasticsearch index template would be overridden by the collector. The template create by the collector would not have the ILM policy setup thus stopping the rollover to work.

**Proposal** 
Adding create-index-templates=false will prevent this issue. Having this mentioned in the doc will help people setup ILM without having to debug why the rollover would stop working.


