### PR TITLE
Removal of a comment of the ES client for Jaeger ES

### DIFF
--- a/data/cli/1.32/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.32/jaeger-ingester-elasticsearch.yaml
@@ -24,7 +24,7 @@ options:
 - name: es-archive.bulk.flush-interval
   default_value: 200ms
   usage: |
-    A time.Duration after which bulk requests are committed, regardless of other thresholds. Set to zero to disable. By default, this is disabled.
+    A time.Duration after which bulk requests are committed, regardless of other thresholds. Set to zero to disable.
 - name: es-archive.bulk.size
   default_value: "5000000"
   usage: |
@@ -149,7 +149,7 @@ options:
 - name: es.bulk.flush-interval
   default_value: 200ms
   usage: |
-    A time.Duration after which bulk requests are committed, regardless of other thresholds. Set to zero to disable. By default, this is disabled.
+    A time.Duration after which bulk requests are committed, regardless of other thresholds. Set to zero to disable.
 - name: es.bulk.size
   default_value: "5000000"
   usage: |


### PR DESCRIPTION
Signed-off-by: Phoebe Zhou <phoebe@canva.com>

## Context
- Bulk.flush-interval is by default set to a value of 200ms
- This setting is only disabled if it it set to 0 but the last line of the documentation: "By default, this is disabled", is very misleading because by default, it is enabled with a value of 200ms

## Which problem is this PR solving?
- Reduces confusion since there is a default value (but the comment says that it this setting is disabled)

## Short description of the changes
- Removed the line "By default, this is disabled." to reduce confusion for users
