### PR TITLE
Disable search on all docs except latest version

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 on:
-  create:
+  push:
     branches: [ main ]
     tags: ["release-*.*.*"]
 

--- a/themes/jaeger-docs/layouts/index.json
+++ b/themes/jaeger-docs/layouts/index.json
@@ -1,7 +1,9 @@
+{{ $latestVersion := site.Params.latest }}
 {{ $index := newScratch }}
 {{ $index.Add "index" slice }}
 {{ range where site.Pages "Section" "docs" }}
-{{ $version := index (split .File.Path "/") 1 }}
-{{ $index.Add "index" (dict "title" .Title "url" .Permalink "body" (.Content | plainify | jsonify) "summary" .Summary "version" $version) }}
-{{ end }}
+  {{ $version := index (split .File.Path "/") 1 }}
+  {{ if eq $version $latestVersion }}
+    {{ $index.Add "index" (dict "title" .Title "url" .Permalink "body" (.Content | plainify | jsonify) "summary" .Summary "version" $version) }}
+  {{ end }}{{ end }}
 {{ $index.Get "index" | jsonify }}

--- a/themes/jaeger-docs/layouts/partials/javascript.html
+++ b/themes/jaeger-docs/layouts/partials/javascript.html
@@ -1,7 +1,16 @@
+{{ $isDocsPage    := eq .Section "docs" }}
 <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
 <script defer src="https://use.fontawesome.com/releases/v5.0.7/js/all.js"></script>
-{{ $jsFiles := (slice "jquery-ui-1.9.1.custom.min.js" "anchor.min.js" "tocbot.min.js" "app.js" "lunr-2.3.6.min.js") }}
+{{ $jsFiles := (slice "jquery-ui-1.9.1.custom.min.js" "anchor.min.js" "tocbot.min.js" "app.js") }}
 {{ range $jsFiles }}
 {{ $js := resources.Get (printf "js/%s" .) | minify | fingerprint }}
 <script src="{{ $js.Permalink }}" integrity="{{ $js.Data.Integrity }}"></script>
+{{ end }}
+
+{{ if $isDocsPage }}
+    {{ $jsFiles := (slice "lunr-2.3.6.min.js") }}
+    {{ range $jsFiles }}
+    {{ $js := resources.Get (printf "js/%s" .) | minify | fingerprint }}
+    <script src="{{ $js.Permalink }}" integrity="{{ $js.Data.Integrity }}"></script>
+    {{ end }}
 {{ end }}

--- a/themes/jaeger-docs/layouts/partials/navbar.html
+++ b/themes/jaeger-docs/layouts/partials/navbar.html
@@ -8,7 +8,6 @@
 {{ $preview       := getenv "HUGO_PREVIEW" }}
 {{ $isPreview     := eq $preview "true" }}
 {{ $currentVersion := index (split .File.Path "/") 1 }}
-{{ $isDoc          := eq .Section "docs" }}
 <nav class="navbar is-fixed-top">
   <div class="container is-fluid">
     <div class="navbar-brand">
@@ -27,6 +26,7 @@
     <div id="topNav" class="navbar-menu">
       <div class="navbar-end">
         {{ if $isDocsPage }}
+        {{ if eq $latest $currentVersion }}
         <div class="navbar-item">
           <div class="dropdown" id="search-dropdown">
             <div class="dropdown-trigger">
@@ -47,10 +47,7 @@
           </div>
         </div>
         {{ end }}
-
-        <a class="navbar-item" href="/download">
-          Download
-        </a>
+        {{ end }}
 
         <div class="navbar-item has-dropdown is-hoverable">
           <a class="navbar-link">
@@ -66,7 +63,7 @@
 
             {{ with .Params.children }}
             {{ range . }}
-            {{ $url := cond $isDoc (printf "/docs/%s/%s" $currentVersion .url) (printf "/docs/%s/%s" $latest .url) }}
+            {{ $url := cond $isDocsPage (printf "/docs/%s/%s" $currentVersion .url) (printf "/docs/%s/%s" $latest .url) }}
             <a class="navbar-item is-small is-hidden-desktop" href="{{ $url }}">
               &cir; {{ if .navtitle }}{{ .navtitle }}{{ else }}{{ .title }}{{ end }}
             </a>
@@ -98,6 +95,10 @@
           </div>
         </div>
         {{ end }}
+
+        <a class="navbar-item" href="/download">
+          Download
+        </a>
 
         <a class="navbar-item" href="https://medium.com/jaegertracing/latest" target="_blank">
           Blog


### PR DESCRIPTION
Temporary workaround for #570:
  * do not include non-latest docs into the search index `index.json`
  * do not render the Search bar on non-latest docs
  * do not load lunr module on non-docs pages

cc @albertteoh 
