### PR TITLE
fix: Strips HTML in title

### DIFF
--- a/themes/jaeger-docs/layouts/partials/home/articles.html
+++ b/themes/jaeger-docs/layouts/partials/home/articles.html
@@ -7,7 +7,7 @@
         {{ range .posts }}
         {{ $link    := .link }}
         {{ $img     := .thumbnail }}
-        {{ $title   := .title }}
+        {{ $title   := .title | plainify }}
         {{ $author  := .author }}
         {{ $dateRaw := .pubDate }}
         {{ $date    := dateFormat "January 2, 2006" $dateRaw }}


### PR DESCRIPTION
## Which problem is this PR solving?
- Currently, the below blog displays `&amp;` in the article 
https://medium.com/jaegertracing/jaeger-persistent-storage-with-elasticsearch-cassandra-kafka-f3c6c680a58c?source=rss----99735986d50---4

## Short description of the changes
- Strips HTML and returns the plain text version of the provided title string
