### PR TITLE
Give more emphasis to OpenTelemetry

### DIFF
--- a/content/_client_libs/client-libraries.md
+++ b/content/_client_libs/client-libraries.md
@@ -14,7 +14,9 @@ Jaeger clients are being retired.
 
 The Jaeger clients have faithfully served our community for several years. We pioneered many new features, such as remotely controlled samplers and per-operation / adaptive sampling, which were critical to the success of distributed tracing deployments at large organizations. However, now that the larger community in OpenTelemetry has caught up with the Jaeger clients in terms of feature parity and there is full support for exporting data to Jaeger, we believe it is time to **decommission Jaeger's native clients and refocus the efforts on the OpenTelemetry SDKs**.
 
-For new applications, we recommend using the [OpenTelemetry](https://opentelemetry.io/) APIs and SDKs. For existing applications that are already instrumented with the OpenTracing API, we recommend replacing the Jaeger clients with the corresponding OpenTelemetry SDKs and the OpenTracing shim/bridge available in most languages supported by Jaeger.
+For new applications, we recommend using the [OpenTelemetry](https://opentelemetry.io/) APIs, SDKs, and instrumentation. Since v1.35, the Jaeger backend can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp].
+
+For existing applications that are already instrumented with the OpenTracing API, we recommend replacing the Jaeger clients with the corresponding OpenTelemetry SDKs and the OpenTracing shim/bridge available in most languages supported by Jaeger.
 
 ### Timeline
 
@@ -236,3 +238,4 @@ uberctx-key1: value%201%20%2F%20blah
 [HttpSender]: https://github.com/jaegertracing/jaeger-client-java/blob/master/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/senders/HttpSender.java
 [http-latency-medium]: https://medium.com/@YuriShkuro/tracing-http-request-latency-in-go-with-opentracing-7cc1282a100a
 [blog-otel-java]: https://medium.com/jaegertracing/migrating-from-jaeger-client-to-opentelemetry-sdk-bd337d796759
+[otlp]: https://opentelemetry.io/docs/reference/specification/protocol/

--- a/content/docs/next-release/_index.md
+++ b/content/docs/next-release/_index.md
@@ -28,9 +28,7 @@ Uber published a blog post, [Evolving Distributed Tracing at Uber](https://eng.u
 
 ## Features
 
-  * [OpenTracing](http://opentracing.io/) compatible data model and instrumentation libraries
-    * in [Go](https://github.com/jaegertracing/jaeger-client-go), [Java](https://github.com/jaegertracing/jaeger-client-java), [Node](https://github.com/jaegertracing/jaeger-client-node), [Python](https://github.com/jaegertracing/jaeger-client-python),
-   [C++](https://github.com/jaegertracing/cpp-client) and [C#](https://github.com/jaegertracing/jaeger-client-csharp)
+  * [OpenTracing](http://opentracing.io/)-inspired data model
   * Uses consistent upfront sampling with individual per service/endpoint probabilities
   * Multiple storage backends: Cassandra, Elasticsearch, memory.
   * System topology graphs

--- a/content/docs/next-release/apis.md
+++ b/content/docs/next-release/apis.md
@@ -19,7 +19,7 @@ Agent and Collector are the two components of the Jaeger backend that can receiv
 
 ### OpenTelemetry Protocol (stable)
 
-Since v1.35, the Jaeger backend can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. That means that the OpenTelemetry SDKs no longer need to be configured with Jaeger exporters, nor the OpenTelemetry Collectors need to be deployed between the OTel SDKs and the Jaeger backend.
+Since v1.35, the Jaeger backend can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. That means that the OpenTelemetry SDKs no longer need to be configured with Jaeger exporters, nor the OpenTelemetry Collectors need to be deployed between the OpenTelemetry SDKs and the Jaeger backend.
 
 ### Thrift over UDP (stable)
 

--- a/content/docs/next-release/apis.md
+++ b/content/docs/next-release/apis.md
@@ -17,6 +17,10 @@ Since Jaeger v1.32, the Collector and Query Service ports that serve gRPC endpoi
 
 Agent and Collector are the two components of the Jaeger backend that can receive spans. At this time they support two sets of non-overlapping APIs.
 
+### OpenTelemetry Protocol (stable)
+
+Since v1.35, the Jaeger backend can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. That means that the OpenTelemetry SDKs no longer need to be configured with Jaeger exporters, nor the OpenTelemetry Collectors need to be deployed between the OTel SDKs and the Jaeger backend.
+
 ### Thrift over UDP (stable)
 
 The Agent can only receive spans over UDP in Thrift format. The primary API is a UDP packet that contains a Thrift-encoded `Batch` struct defined in [jaeger.thrift][jaeger.thrift] IDL file, located in the [jaeger-idl][jaeger-idl] repository. Most Jaeger Clients use Thrift's `compact` encoding, however some client libraries do not support it (notably, Node.js) and use Thrift's `binary` encoding (sent to  a different UDP port). The Agent's API is defined by [agent.thrift][agent.thrift] IDL file.
@@ -90,3 +94,4 @@ Please refer to the [SPM Documentation](../spm#API)
 [sampling.proto]: https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v2/sampling.proto
 [grpc-reflection]: https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md#enable-server-reflection
 [gogo-reflection]: https://jbrandhorst.com/post/gogoproto/#reflection
+[otlp]: https://opentelemetry.io/docs/reference/specification/protocol/

--- a/content/docs/next-release/architecture.md
+++ b/content/docs/next-release/architecture.md
@@ -24,7 +24,7 @@ A **trace** represents the data or execution path through the system. It can be 
 
 ### Baggage
 
-**Baggage** is arbitrary user-defined metadata (key-value pairs) that can be attached to distributed context propagated by the tracing SDKs. See [W3C Baggage](https://www.w3.org/TR/baggage/) for more information.
+**Baggage** is arbitrary user-defined metadata (key-value pairs) that can be attached to distributed context and propagated by the tracing SDKs. See [W3C Baggage](https://www.w3.org/TR/baggage/) for more information.
 
 ## Components
 
@@ -61,7 +61,7 @@ The instrumentation is designed to be always on in production. To minimize the o
 
 ### Agent
 
-The Jaeger **agent** is a network daemon that listens for spans sent over UDP, which it batches and sends to the collector. It is designed to be deployed to all hosts as an infrastructure component. The agent abstracts the routing and discovery of the collectors away from the client.
+The Jaeger **agent** is a network daemon that listens for spans sent over UDP, which are batched and sent to the collector. It is designed to be deployed to all hosts as an infrastructure component. The agent abstracts the routing and discovery of the collectors away from the client.
 
 The agent is **not** a required component. For example, when your applications are instrumented with OpenTelemetry, the SDKs can be configured to forward the trace data directly to Jaeger collectors.
 
@@ -77,4 +77,4 @@ The Jaeger **query** is a service that exposes the [APIs](../apis) for retrievin
 
 ### Ingester
 
-**Ingester** is a service that reads traces from Kafka and writes them to a storage backend. Effectively, it is a stripped down version of the Jaeger collector that supports Kafka sa the only input protocol.
+The Jaeger **ingester** is a service that reads traces from Kafka and writes them to a storage backend. Effectively, it is a stripped-down version of the Jaeger collector that supports Kafka as the only input protocol.

--- a/content/docs/next-release/architecture.md
+++ b/content/docs/next-release/architecture.md
@@ -8,25 +8,27 @@ children:
   url: sampling
 ---
 
-Jaeger's clients adhere to the data model described in the OpenTracing standard. Reading the [specification](https://github.com/opentracing/specification/blob/master/specification.md) will help you understand this section better.
-
 ## Terminology
 
-Let's start with a quick refresher on the terminology defined by the [OpenTracing Specification](https://github.com/opentracing/specification/blob/master/specification.md).
+Jaeger represents tracing data in a data model inspired by the [OpenTracing Specification](https://github.com/opentracing/specification/blob/master/specification.md).
 
 ### Span
 
-{{< definition "span" >}}
+A **span** represents a logical unit of work that has an operation name, the start time of the operation, and the duration. Spans may be nested and ordered to model causal relationships.
 
 ![Traces And Spans](/img/spans-traces.png)
 
 ### Trace
 
-{{< definition "trace" >}}
+A **trace** represents the data or execution path through the system. It can be thought of as a directed acyclic graph of spans.
+
+### Baggage
+
+**Baggage** is arbitrary user-defined metadata (key-value pairs) that can be attached to distributed context propagated by the tracing SDKs. See [W3C Baggage](https://www.w3.org/TR/baggage/) for more information.
 
 ## Components
 
-Jaeger can be deployed either as all-in-one binary, where all Jaeger backend components
+Jaeger can be deployed either as an **all-in-one** binary, where all Jaeger backend components
 run in a single process, or as a scalable distributed system, discussed below.
 There are two main deployment options:
 
@@ -41,11 +43,16 @@ There are two main deployment options:
 
 This section details the constituent parts of Jaeger and how they relate to each other. It is arranged by the order in which spans from your application interact with them.
 
-### Jaeger client libraries
+### Jaeger client libraries (deprecated)
+
+{{< warning >}}
+Jaeger clients are [being retired](../client-libraries). Please use OpenTelemetry.
+{{< /warning >}}
+
 
 Jaeger clients are language specific implementations of the [OpenTracing API](https://opentracing.io). They can be used to instrument applications for distributed tracing either manually or with a variety of existing open source frameworks, such as Flask, Dropwizard, gRPC, and many more, that are already integrated with OpenTracing.
 
-An instrumented service creates {{< tip "spans" "span" >}} when receiving new requests and attaches context information ({{< tip "trace" >}} id, {{< tip "span" "span" >}} id, and {{< tip "baggage" "baggage" >}}) to outgoing requests. Only the ids and baggage are propagated with requests; all other profiling data, like operation name, timing, tags and logs, is not propagated. Instead, it is transmitted out of process to the Jaeger backend asynchronously, in the background.
+An instrumented service creates spans when receiving new requests and attaches context information (trace id, span id, and baggage) to outgoing requests. Only the ids and baggage are propagated with requests; all other profiling data, like operation name, timing, tags and logs, is not propagated. Instead, it is transmitted out of process to the Jaeger backend asynchronously, in the background.
 
 The instrumentation is designed to be always on in production. To minimize the overhead, Jaeger clients employ various sampling strategies. When a trace is sampled, the profiling span data is captured and transmitted to the Jaeger backend. When a trace is not sampled, no profiling data is collected at all, and the calls to the OpenTracing APIs are short-circuited to incur the minimal amount of overhead. By default, Jaeger clients sample 0.1% of traces (1 in 1000), and have the ability to retrieve sampling strategies from the Jaeger backend. For more information, please refer to [Sampling](../sampling/).
 
@@ -54,16 +61,20 @@ The instrumentation is designed to be always on in production. To minimize the o
 
 ### Agent
 
-{{< definition "agent" >}}
+The Jaeger **agent** is a network daemon that listens for spans sent over UDP, which it batches and sends to the collector. It is designed to be deployed to all hosts as an infrastructure component. The agent abstracts the routing and discovery of the collectors away from the client.
+
+The agent is **not** a required component. For example, when your applications are instrumented with OpenTelemetry, the SDKs can be configured to forward the trace data directly to Jaeger collectors.
 
 ### Collector
 
-{{< definition "collector" >}}
+The Jaeger **collector** receives traces from the SDKs or Jaeger [agents](../architecture#agent), runs them through a processing pipeline for validation and clean-up/enrichment, and stores them in a storage backend.
+
+Jaeger comes with built-in support for several storage backends (see [Deployment](../deployment)), as well as extensible plugin framework for implementing custom storage plugins.
 
 ### Query
 
-{{< definition "query" >}}
+The Jaeger **query** is a service that exposes the [APIs](../apis) for retrieving traces from storage and hosts a Web UI for searching and analyzing traces.
 
 ### Ingester
 
-{{< definition "ingester" >}}
+**Ingester** is a service that reads traces from Kafka and writes them to a storage backend. Effectively, it is a stripped down version of the Jaeger collector that supports Kafka sa the only input protocol.

--- a/content/docs/next-release/features.md
+++ b/content/docs/next-release/features.md
@@ -14,15 +14,17 @@ Jaeger is used for monitoring and troubleshooting microservices-based distribute
 ## High Scalability
 
 Jaeger backend is designed to have no single points of failure and to scale with the business needs.
-For example, any given Jaeger installation at Uber is typically processing several billion {{< tip "spans" "span" >}} per day.
+For example, any given Jaeger installation at Uber is typically processing several billion spans per day.
 
-## Native support for OpenTracing
+## Native support for OpenTracing and OpenTelemetry
 
 Jaeger backend, Web UI, and instrumentation libraries have been designed from ground up to support the OpenTracing standard.
 
-* Represent {{< tip "traces" "trace" >}} as {{< tip "directed acyclic graphs" "directed acyclic graph" >}} (not just trees) via [span references](https://github.com/opentracing/specification/blob/master/specification.md#references-between-spans)
+* Represent traces as directed acyclic graphs (not just trees) via [span references](https://github.com/opentracing/specification/blob/master/specification.md#references-between-spans)
 * Support strongly typed span _tags_ and _structured logs_
 * Support general distributed context propagation mechanism via _baggage_
+
+Since v1.35, the Jaeger backend can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. However, the internal data representation and the UI still follow the OpenTracing specification's model.
 
 ## Multiple storage backends
 
@@ -32,9 +34,7 @@ with a simple in-memory storage for testing setups.
 
 ## Modern Web UI
 
-Jaeger Web UI is implemented in Javascript using popular open source frameworks like React. Several performance
-improvements have been released in v1.0 to allow the UI to efficiently deal with large volumes of data, and to display
-{{< tip "traces" "trace" >}} with tens of thousands of {{< tip "spans" "span" >}} (e.g. we tried a trace with 80,000 spans).
+Jaeger Web UI is implemented in Javascript using popular open source frameworks like React. Several performance improvements have been released in v1.0 to allow the UI to efficiently deal with large volumes of data, and to display traces with tens of thousands of spans (e.g. we tried a trace with 80,000 spans).
 
 ## Cloud Native Deployment
 
@@ -46,15 +46,11 @@ and a [Helm chart](https://github.com/kubernetes/charts/tree/master/incubator/ja
 ## Observability
 
 All Jaeger backend components expose [Prometheus](https://prometheus.io/) metrics by default (other metrics backends are
-also supported). Logs are written to standard out using the structured logging library [zap](https://github.com/uber-go/zap).
+also supported). Logs are written to stdout using the structured logging library [zap](https://github.com/uber-go/zap).
 
 ## Backwards compatibility with Zipkin
 
-Although we recommend instrumenting applications with OpenTracing API and binding to Jaeger client libraries to benefit
-from advanced features not available elsewhere, if your organization has already invested in the instrumentation
-using Zipkin libraries, you do not have to rewrite all that code. Jaeger provides backwards compatibility with Zipkin
-by accepting spans in Zipkin formats (Thrift, JSON v1/v2 and Protobuf) over HTTP. Switching from Zipkin backend is just a matter
-of routing the traffic from Zipkin libraries to the Jaeger backend.
+Although we recommend instrumenting applications with OpenTelemetry, if your organization has already invested in the instrumentation using Zipkin libraries, you do not have to rewrite all that code. Jaeger provides backwards compatibility with Zipkin by accepting spans in Zipkin formats (Thrift, JSON v1/v2 and Protobuf) over HTTP. Switching from Zipkin backend is just a matter of routing the traffic from Zipkin libraries to the Jaeger backend.
 
 ## Topology Graphs
 
@@ -84,3 +80,5 @@ latencies, then leveraging Jaeger's Trace Search capabilities to pinpoint specif
 traces belonging to these services/operations.
 
 See [Service Performance Monitoring (SPM)](../spm) for more details.
+
+[otlp]: https://opentelemetry.io/docs/reference/specification/protocol/

--- a/content/docs/next-release/features.md
+++ b/content/docs/next-release/features.md
@@ -34,7 +34,7 @@ with a simple in-memory storage for testing setups.
 
 ## Modern Web UI
 
-Jaeger Web UI is implemented in Javascript using popular open source frameworks like React. Several performance improvements have been released in v1.0 to allow the UI to efficiently deal with large volumes of data, and to display traces with tens of thousands of spans (e.g. we tried a trace with 80,000 spans).
+Jaeger Web UI is implemented in Javascript using popular open source frameworks like React. Several performance improvements have been released in v1.0 to allow the UI to efficiently deal with large volumes of data and display traces with tens of thousands of spans (e.g. we tried a trace with 80,000 spans).
 
 ## Cloud Native Deployment
 
@@ -50,7 +50,7 @@ also supported). Logs are written to stdout using the structured logging library
 
 ## Backwards compatibility with Zipkin
 
-Although we recommend instrumenting applications with OpenTelemetry, if your organization has already invested in the instrumentation using Zipkin libraries, you do not have to rewrite all that code. Jaeger provides backwards compatibility with Zipkin by accepting spans in Zipkin formats (Thrift, JSON v1/v2 and Protobuf) over HTTP. Switching from Zipkin backend is just a matter of routing the traffic from Zipkin libraries to the Jaeger backend.
+Although we recommend instrumenting applications with OpenTelemetry, if your organization has already invested in the instrumentation using Zipkin libraries, you do not have to rewrite all that code. Jaeger provides backwards compatibility with Zipkin by accepting spans in Zipkin formats (Thrift, JSON v1/v2 and Protobuf) over HTTP. Switching from a Zipkin backend is just a matter of routing the traffic from Zipkin libraries to the Jaeger backend.
 
 ## Topology Graphs
 

--- a/content/docs/next-release/getting-started.md
+++ b/content/docs/next-release/getting-started.md
@@ -10,7 +10,7 @@ If you are new to distributed tracing, please check the [Introduction](../) page
 
 Your applications must be instrumented before they can send tracing data to Jaeger. We recommend using the [OpenTelemetry](https://opentelemetry.io) instrumentation and SDKs.
 
-Historically, the Jaeger project supported our own SDKs (aka tracers, client libraries) that implemented the OpenTracing API. The [Client Libraries](../client-libraries) section provides information about how to use the OpenTracing API and how to initialize and configure Jaeger tracers. As of 2022, the Jaeger SDKs are no longer supported, and all users are advised to migrate to OpenTelemetry.
+Historically, the Jaeger project supported its own SDKs (aka tracers, client libraries) that implemented the OpenTracing API. The [Client Libraries](../client-libraries) section provides information about how to use the OpenTracing API and how to initialize and configure Jaeger tracers. As of 2022, the Jaeger SDKs are no longer supported, and all users are advised to migrate to OpenTelemetry.
 
 ## All in One
 

--- a/content/docs/next-release/getting-started.md
+++ b/content/docs/next-release/getting-started.md
@@ -8,7 +8,9 @@ If you are new to distributed tracing, please check the [Introduction](../) page
 
 ## Instrumentation
 
-Your applications must be instrumented before they can send tracing data to Jaeger backend. Check the [Client Libraries](../client-libraries) section for information about how to use the OpenTracing API and how to initialize and configure Jaeger tracers.
+Your applications must be instrumented before they can send tracing data to Jaeger. We recommend using the [OpenTelemetry](https://opentelemetry.io) instrumentation and SDKs.
+
+Historically, the Jaeger project supported our own SDKs (aka tracers, client libraries) that implemented the OpenTracing API. The [Client Libraries](../client-libraries) section provides information about how to use the OpenTracing API and how to initialize and configure Jaeger tracers. As of 2022, the Jaeger SDKs are no longer supported, and all users are advised to migrate to OpenTelemetry.
 
 ## All in One
 

--- a/content/docs/next-release/sampling.md
+++ b/content/docs/next-release/sampling.md
@@ -3,7 +3,7 @@ title: Sampling
 hasparent: true
 ---
 
-Jaeger libraries implement consistent upfront (or head-based) sampling. For example, assume we have a simple call graph where service A calls service B, and B calls service C: `A -> B -> C`. When service A receives a request that contains no tracing information, Jaeger tracer will start a new {{< tip "trace" >}}, assign it a random trace ID, and make a sampling decision based on the currently installed sampling strategy. The sampling decision will be propagated with the requests to B and to C, so those services will not be making the sampling decision again but instead will respect the decision made by the top service A. This approach guarantees that if a trace is sampled, all its {{< tip "spans" "span" >}} will be recorded in the backend. If each service was making its own sampling decision we would rarely get complete traces in the backend.
+Jaeger libraries implement consistent upfront (or head-based) sampling. For example, assume we have a simple call graph where service A calls service B, and B calls service C: `A -> B -> C`. When service A receives a request that contains no tracing information, Jaeger tracer will start a new trace, assign it a random trace ID, and make a sampling decision based on the currently installed sampling strategy. The sampling decision will be propagated with the requests to B and to C, so those services will not be making the sampling decision again but instead will respect the decision made by the top service A. This approach guarantees that if a trace is sampled, all its spans will be recorded in the backend. If each service was making its own sampling decision we would rarely get complete traces in the backend.
 
 ## Client Sampling Configuration
 

--- a/content/docs/next-release/spm.md
+++ b/content/docs/next-release/spm.md
@@ -4,9 +4,7 @@ hasparent: true
 ---
 
 {{< info >}}
-As the Service Performance Monitoring feature is in its infancy, it is being marked
-as experimental to signal that this feature will be in flux while bugs are fixed and
-enhancements are added in response to community feedback.
+The Service Performance Monitoring feature is currently considered **experimental**.
 {{< /info >}}
 
 ![Service Performance Monitoring](/img/frontend-ui/spm.png)


### PR DESCRIPTION
A spring clean-up of the docs to put more emphasis on OpenTelemetry and tone down references to OpenTracing. Mention the OTLP support coming in v1.35 via https://github.com/jaegertracing/jaeger/pull/3701.

I've also simplified the docs by removing the definition/tip short-cuts, which were only used for the words traces/spans, which is largely superfluous. Unfortunately, cannot remove the file `data/definitions.yaml` because older docs versions still refer to them.