### PR TITLE
Add description of remote-storage component

### DIFF
--- a/content/docs/next-release/apis.md
+++ b/content/docs/next-release/apis.md
@@ -64,6 +64,10 @@ The recommended way for programmatically retrieving traces and other data is via
 
 Jaeger UI communicates with Jaeger Query Service via JSON API. For example, a trace can be retrieved via GET request to `https://jaeger-query:16686/api/traces/{trace-id-hex-string}`. This JSON API is intentionally undocumented and subject to change.
 
+## Remote Storage API (stable)
+
+When using the `grpc-plugin` storage type (a.k.a. [storage plugin](../deployment/#storage-plugin)), Jaeger components can use custom storage backends as long as those backends implement the gRPC [Remote Storage API][storage.proto].
+
 ## Clients configuration (internal)
 
 Client libraries not only submit finished spans to Jaeger backend, but also periodically poll the Agents for various configurations, such as sampling strategies. The schema for the payload is defined by [sampling.thrift][sampling.thrift], encoded as JSON using Thrift's built-in JSON generation capabilities.
@@ -95,3 +99,4 @@ Please refer to the [SPM Documentation](../spm#API)
 [grpc-reflection]: https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md#enable-server-reflection
 [gogo-reflection]: https://jbrandhorst.com/post/gogoproto/#reflection
 [otlp]: https://opentelemetry.io/docs/reference/specification/protocol/
+[storage.proto]: https://github.com/jaegertracing/jaeger/blob/main/plugin/storage/grpc/proto/storage.proto

--- a/content/docs/next-release/faq.md
+++ b/content/docs/next-release/faq.md
@@ -7,7 +7,7 @@ weight: 11
 
 ## Why is the Dependencies page empty?
 
-The Dependencies page shows a graph of services traced by Jaeger and connections between them. When you are using `all-in-one` binary with in-memory storage, the graph is calculated on-demand from all the traces stored in memory. However, if you are using a real distributed storage like Cassandra or Elasticsearch, it is too expensive to scan all the data in the database to build the service graph. Instead, the Jaeger project provides "big data" jobs that can be used to extract the service graph data from traces:
+The Dependencies page shows a graph of services traced by Jaeger and connections between them. When you are using `all-in-one` binary with in-memory storage, the graph is calculated on-demand from all the traces stored in memory. However, if you are using a real distributed storage like Cassandra or OpenSearch/Elasticsearch, it is too expensive to scan all the data in the database to build the service graph. Instead, the Jaeger project provides "big data" jobs that can be used to extract the service graph data from traces:
 
   * https://github.com/jaegertracing/spark-dependencies - the older Spark job that can be run periodically
   * https://github.com/jaegertracing/jaeger-analytics - the new (experimental) streaming Flink jobs that run continuously and builds the service graph in smaller time intervals
@@ -26,13 +26,13 @@ Please refer to the [Troubleshooting](../troubleshooting/) guide.
 
 ## What is the recommended storage backend?
 
-The Jaeger team recommends Elasticsearch as the storage backend over Cassandra, for the following reasons:
+The Jaeger team recommends OpenSearch/Elasticsearch as the storage backend over Cassandra, for the following reasons:
 
-  * Cassandra is a key-value database, so it is more efficient for retrieving traces by trace ID, but it does not provide the same powerful search capabilities as Elasticsearch. Effectively, the Jaeger backend implements the search functionality on the client side, on top of k-v storage, which is limited and may produce inconsistent results (see [issue-166][issue-166] for more details). Elasticsearch does not suffer from these issues, resulting in better usability. Elasticsearch can also be queried directly, e.g. from Kibana dashboards, and provide useful analytics and aggregations.
+  * Cassandra is a key-value database, so it is more efficient for retrieving traces by trace ID, but it does not provide the same powerful search capabilities as OpenSearch. Effectively, the Jaeger backend implements the search functionality on the client side, on top of k-v storage, which is limited and may produce inconsistent results (see [issue-166][issue-166] for more details). OpenSearch does not suffer from these issues, resulting in better usability. OpenSearch can also be queried directly, e.g. from Kibana dashboards, and provide useful analytics and aggregations.
 
-  * Based on past performance experiments we observed single writes to be much faster in Cassandra than Elasticsearch, which might suggest that it may sustain higher write throughput. However, because the Jaeger backend needs to implement search capability on top of k-v storage, writing spans to Cassandra is actually subject to large write amplification: in addition to writing a record for the span itself, Jaeger performs extra writes for service name and operation name indexing, as well as extra index writes for every tag. In contrast, saving a span to Elasticsearch is a single write, and all indexing takes place inside the ES node. As a result, the overall throughput to Cassandra is comparable with Elasticsearch.
+  * Based on past performance experiments we observed single writes to be much faster in Cassandra than OpenSearch, which might suggest that it may sustain higher write throughput. However, because the Jaeger backend needs to implement search capability on top of k-v storage, writing spans to Cassandra is actually subject to large write amplification: in addition to writing a record for the span itself, Jaeger performs extra writes for service name and operation name indexing, as well as extra index writes for every tag. In contrast, saving a span to OpenSearch is a single write, and all indexing takes place inside the OpenSearch node. As a result, the overall throughput to Cassandra is comparable with OpenSearch.
 
-One benefit of Cassandra backend is simplified maintenance due to its native support for data TTL. In Elasticsearch the data expiration is managed through index rotation, which requires additional setup (see [Elasticsearch Rollover](../deployment/#elasticsearch-rollover)).
+One benefit of Cassandra backend is simplified maintenance due to its native support for data TTL. In OpenSearch the data expiration is managed through index rotation, which requires additional setup (see [Elasticsearch Rollover](../deployment/#elasticsearch-rollover)).
 
 [issue-166]: https://github.com/jaegertracing/jaeger/issues/166
 

--- a/data/download.yaml
+++ b/data/download.yaml
@@ -28,6 +28,9 @@ docker:
 - image: jaeger-ingester
   description: An alternative to collector; reads spans from Kafka topic and saves them to storage.
   since: 1.7
+- image: jaeger-remote-storage
+  description: A service that implements the Remote Storage API on top of another supported backend. Can be used to share a single-node storage backend, like `memory`, across multiple Jaeger processes.
+  since: 1.37
 - image: spark-dependencies
   description: An [Apache Spark](http://spark.apache.org/) job that collects Jaeger spans from storage, analyzes links between services, and stores them for later presentation in the Jaeger UI
   latest: latest


### PR DESCRIPTION
* Add `jaeger-remote-storage` component
* Round up the description of all binaries in one place, above the storage backends section.

Per https://github.com/jaegertracing/jaeger/issues/3835