### PR TITLE
Update Promscale on native Jaeger ingest support

### DIFF
--- a/content/docs/next-release/deployment.md
+++ b/content/docs/next-release/deployment.md
@@ -768,7 +768,7 @@ Available remote storage backends:
 
 * [Promscale](https://github.com/timescale/promscale#promscale-for-jaeger-and-opentelemetry) - Jaeger and Prometheus storage backend built on PostgreSQL.
   * Implements the read path of Jaeger's Remote Storage API, thus can be used as a backend with Jaeger Query.
-  * Currently does not implement the write path of Jaeger's Remote Storage API. Trace ingestion must be done via the OpenTelemetry Collector using the OpenTelemetry Protocol (OTLP).
+  * Implements the write path of Jaeger's Remote Storage API, thus can be used as a storage backend with Jaeger SDK/Agent/Collector.
   * Supports remote storage API for Prometheus, thus can be used as a metrics storage backend for [SPM](../spm).
 
 ## Metrics Storage Backends

--- a/content/docs/next-release/deployment.md
+++ b/content/docs/next-release/deployment.md
@@ -767,8 +767,7 @@ docker run \
 Available remote storage backends:
 
 * [Promscale](https://github.com/timescale/promscale#promscale-for-jaeger-and-opentelemetry) - Jaeger and Prometheus storage backend built on PostgreSQL.
-  * Implements the read path of Jaeger's Remote Storage API, thus can be used as a backend with Jaeger Query.
-  * Implements the write path of Jaeger's Remote Storage API, thus can be used as a storage backend with Jaeger SDK/Agent/Collector.
+  * Implements full Jaeger's Remote Storage API; can be used as a span storage backend.
   * Supports remote storage API for Prometheus, thus can be used as a metrics storage backend for [SPM](../spm).
 
 ## Metrics Storage Backends


### PR DESCRIPTION
## Short description of the changes
- Recent Promscale release i.e. `0.14.0` now natively supports Jaeger write interface. In the past Promscale only supported Jaeger's read path. Now Promscale natively supports Jaeger's both read and write paths. 
