### PR TITLE
Fix typo

### DIFF
--- a/content/docs/1.13/operator.md
+++ b/content/docs/1.13/operator.md
@@ -316,7 +316,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.14/operator.md
+++ b/content/docs/1.14/operator.md
@@ -287,7 +287,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.15/operator.md
+++ b/content/docs/1.15/operator.md
@@ -287,7 +287,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.16/operator.md
+++ b/content/docs/1.16/operator.md
@@ -310,7 +310,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.17/operator.md
+++ b/content/docs/1.17/operator.md
@@ -430,7 +430,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.18/operator.md
+++ b/content/docs/1.18/operator.md
@@ -447,7 +447,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.19/operator.md
+++ b/content/docs/1.19/operator.md
@@ -451,7 +451,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.20/operator.md
+++ b/content/docs/1.20/operator.md
@@ -451,7 +451,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.21/operator.md
+++ b/content/docs/1.21/operator.md
@@ -451,7 +451,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.22/operator.md
+++ b/content/docs/1.22/operator.md
@@ -451,7 +451,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.23/operator.md
+++ b/content/docs/1.23/operator.md
@@ -451,7 +451,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.24/operator.md
+++ b/content/docs/1.24/operator.md
@@ -451,7 +451,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.25/operator.md
+++ b/content/docs/1.25/operator.md
@@ -451,7 +451,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.26/operator.md
+++ b/content/docs/1.26/operator.md
@@ -451,7 +451,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.27/operator.md
+++ b/content/docs/1.27/operator.md
@@ -451,7 +451,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.28/operator.md
+++ b/content/docs/1.28/operator.md
@@ -451,7 +451,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.29/operator.md
+++ b/content/docs/1.29/operator.md
@@ -431,7 +431,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.30/operator.md
+++ b/content/docs/1.30/operator.md
@@ -431,7 +431,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.31/operator.md
+++ b/content/docs/1.31/operator.md
@@ -439,7 +439,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.32/operator.md
+++ b/content/docs/1.32/operator.md
@@ -439,7 +439,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.33/operator.md
+++ b/content/docs/1.33/operator.md
@@ -439,7 +439,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.34/operator.md
+++ b/content/docs/1.34/operator.md
@@ -439,7 +439,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.35/operator.md
+++ b/content/docs/1.35/operator.md
@@ -439,7 +439,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.36/operator.md
+++ b/content/docs/1.36/operator.md
@@ -439,7 +439,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.37/operator.md
+++ b/content/docs/1.37/operator.md
@@ -439,7 +439,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.38/operator.md
+++ b/content/docs/1.38/operator.md
@@ -439,7 +439,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.39/operator.md
+++ b/content/docs/1.39/operator.md
@@ -439,7 +439,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.40/operator.md
+++ b/content/docs/1.40/operator.md
@@ -439,7 +439,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.41/operator.md
+++ b/content/docs/1.41/operator.md
@@ -439,7 +439,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/1.42/operator.md
+++ b/content/docs/1.42/operator.md
@@ -439,7 +439,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -439,7 +439,7 @@ You can use the simplest example (shown above) and create a Jaeger instance usin
 
 ### Cassandra storage
 
-When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfuly created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
+When the storage type is set to Cassandra, the operator will automatically create a batch job that creates the required schema for Jaeger to run. This batch job will block the Jaeger installation, so that it starts only after the schema is successfully created. The creation of this batch job can be disabled by setting the `enabled` property to `false`:
 
 ```yaml
 apiVersion: jaegertracing.io/v1


### PR DESCRIPTION
## Short description of the changes
Fix the typo "successfuly" -> "successfully" throughout the documentation.