### PR TITLE
Improved docs (supported backends and removed experimental for monitor tab and SPM

### DIFF
--- a/content/docs/next-release/features.md
+++ b/content/docs/next-release/features.md
@@ -29,10 +29,10 @@ Since v1.35, the Jaeger backend can receive trace data from the OpenTelemetry SD
 ## Multiple storage backends
 
 Jaeger can be used with a growing a number of storage backends:
-* It natively supports two popular open source NoSQL databases as trace storage backends: Cassandra 3.4+ and Elasticsearch 5.x/6.x/7.x.
+* It natively supports two popular open source NoSQL databases as trace storage backends: Cassandra 3.4+, Elasticsearch 5.x/6.x/7.x, and OpenSearch 1.0+.
 * It integrates via a gRPC API with other well known databases that have been certified to be Jaeger compliant: [ClickHouse](https://github.com/jaegertracing/jaeger-clickhouse).
 * There is embedded database support using [Badger](https://github.com/dgraph-io/badger) and simple in-memory storage for testing setups.
-* There are ongoing community experiments using other databases, such as ScyllaDB, InfluxDB, Amazon DynamoDB, Logz.io.
+* There are ongoing community experiments using other databases, such as ScyllaDB, InfluxDB, Amazon DynamoDB, Logz.io. You can find more by following [this issue](https://github.com/jaegertracing/jaeger/issues/638).
 
 ## Modern Web UI
 

--- a/content/docs/next-release/frontend-ui.md
+++ b/content/docs/next-release/frontend-ui.md
@@ -76,7 +76,7 @@ An example configuration file:
 
 `dependencies.menuEnabled` enables (`true`) or disables (`false`) the dependencies menu button. Default: `true`.
 
-### Monitor (Experimental)
+### Monitor
 
 `monitor.menuEnabled` enables (`true`) or disables (`false`) the Monitor menu button. Default: `false`.
 

--- a/content/docs/next-release/spm.md
+++ b/content/docs/next-release/spm.md
@@ -1,11 +1,7 @@
 ---
-title: Service Performance Monitoring (SPM) - Experimental
+title: Service Performance Monitoring (SPM)
 hasparent: true
 ---
-
-{{< info >}}
-The Service Performance Monitoring feature is currently considered **experimental**.
-{{< /info >}}
 
 ![Service Performance Monitoring](/img/frontend-ui/spm.png)
 


### PR DESCRIPTION
Improved docs for supported backends, and removed monitor tab and SPM experimental mentions. 