### PR TITLE
Add SDK, collector and trace storage in arch diagram

### DIFF
--- a/content/docs/next-release/spm.md
+++ b/content/docs/next-release/spm.md
@@ -69,27 +69,44 @@ as such, is only relevant to the Jaeger Query component (and All In One).
 
 {{<mermaid align="center">}}
 graph
-    TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_PROC[Spanmetrics Processor]
-    TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
-    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
-    UI[Jaeger UI] --> QUERY
-    QUERY[Jaeger Query Service] --> METRICS_STORE[Metrics Storage]
-    PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE
-    subgraph OpenTelemetry Collector
-        subgraph Pipeline
-            TRACE_RECEIVER
-            SPANMETRICS_PROC
-            TRACE_EXPORTER
-            PROMETHEUS_EXPORTER
-        end
-    end
-    style UI fill:#9AEBFE,color:black
-    style QUERY fill:#9AEBFE,color:black
 
-    style TRACE_RECEIVER fill:#404ca8,color:white
-    style TRACE_EXPORTER fill:#404ca8,color:white
-    style SPANMETRICS_PROC fill:#404ca8,color:white
-    style PROMETHEUS_EXPORTER fill:#404ca8,color:white
+  OTLP_EXPORTER[OTLP Exporter] --> TRACE_RECEIVER
+
+  subgraph Service
+    subgraph OpenTelemetry SDK
+      OTLP_EXPORTER
+    end
+  end
+
+  TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_PROC[Spanmetrics Processor]
+  TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
+  TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
+  SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+  PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
+
+  COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]
+  SPAN_STORE --> QUERY[Jaeger Query Service]
+  METRICS_STORE --> QUERY
+  QUERY --> UI[Jaeger UI]
+
+  subgraph OpenTelemetry Collector
+      subgraph Pipeline
+          TRACE_RECEIVER
+          SPANMETRICS_PROC
+          TRACE_EXPORTER
+          PROMETHEUS_EXPORTER
+      end
+  end
+
+  style UI fill:#9AEBFE,color:black
+  style QUERY fill:#9AEBFE,color:black
+  style COLLECTOR fill:#9AEBFE,color:black
+
+  style OTLP_EXPORTER fill:#404ca8,color:white
+  style TRACE_RECEIVER fill:#404ca8,color:white
+  style TRACE_EXPORTER fill:#404ca8,color:white
+  style SPANMETRICS_PROC fill:#404ca8,color:white
+  style PROMETHEUS_EXPORTER fill:#404ca8,color:white
 {{< /mermaid >}}
 
 ## Derived Time Series

--- a/content/docs/next-release/spm.md
+++ b/content/docs/next-release/spm.md
@@ -84,7 +84,7 @@ graph
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
 
     COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]
-    SPAN_STORE --> QUERY[Jaeger Query Service]
+    SPAN_STORE --> QUERY[Jaeger Query]
     METRICS_STORE --> QUERY
     QUERY --> UI[Jaeger UI]
 

--- a/content/docs/next-release/spm.md
+++ b/content/docs/next-release/spm.md
@@ -97,15 +97,17 @@ graph
         end
     end
 
+    style Service fill:#DFDFDF,color:black
+
+    style OTLP_EXPORTER fill:#404CA8,color:white
+    style TRACE_RECEIVER fill:#404CA8,color:white
+    style TRACE_EXPORTER fill:#404CA8,color:white
+    style SPANMETRICS_PROC fill:#404CA8,color:white
+    style PROMETHEUS_EXPORTER fill:#404CA8,color:white
+
     style UI fill:#9AEBFE,color:black
     style QUERY fill:#9AEBFE,color:black
     style COLLECTOR fill:#9AEBFE,color:black
-
-    style OTLP_EXPORTER fill:#404ca8,color:white
-    style TRACE_RECEIVER fill:#404ca8,color:white
-    style TRACE_EXPORTER fill:#404ca8,color:white
-    style SPANMETRICS_PROC fill:#404ca8,color:white
-    style PROMETHEUS_EXPORTER fill:#404ca8,color:white
 {{< /mermaid >}}
 
 ## Derived Time Series

--- a/content/docs/next-release/spm.md
+++ b/content/docs/next-release/spm.md
@@ -69,44 +69,43 @@ as such, is only relevant to the Jaeger Query component (and All In One).
 
 {{<mermaid align="center">}}
 graph
+    OTLP_EXPORTER[OTLP Exporter] --> TRACE_RECEIVER
 
-  OTLP_EXPORTER[OTLP Exporter] --> TRACE_RECEIVER
-
-  subgraph Service
-    subgraph OpenTelemetry SDK
-      OTLP_EXPORTER
+    subgraph Service
+        subgraph OpenTelemetry SDK
+            OTLP_EXPORTER
+        end
     end
-  end
 
-  TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_PROC[Spanmetrics Processor]
-  TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
-  TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
-  SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
-  PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
+    TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_PROC[Spanmetrics Processor]
+    TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
+    TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
+    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
 
-  COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]
-  SPAN_STORE --> QUERY[Jaeger Query Service]
-  METRICS_STORE --> QUERY
-  QUERY --> UI[Jaeger UI]
+    COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]
+    SPAN_STORE --> QUERY[Jaeger Query Service]
+    METRICS_STORE --> QUERY
+    QUERY --> UI[Jaeger UI]
 
-  subgraph OpenTelemetry Collector
-      subgraph Pipeline
-          TRACE_RECEIVER
-          SPANMETRICS_PROC
-          TRACE_EXPORTER
-          PROMETHEUS_EXPORTER
-      end
-  end
+    subgraph OpenTelemetry Collector
+        subgraph Pipeline
+            TRACE_RECEIVER
+            SPANMETRICS_PROC
+            TRACE_EXPORTER
+            PROMETHEUS_EXPORTER
+        end
+    end
 
-  style UI fill:#9AEBFE,color:black
-  style QUERY fill:#9AEBFE,color:black
-  style COLLECTOR fill:#9AEBFE,color:black
+    style UI fill:#9AEBFE,color:black
+    style QUERY fill:#9AEBFE,color:black
+    style COLLECTOR fill:#9AEBFE,color:black
 
-  style OTLP_EXPORTER fill:#404ca8,color:white
-  style TRACE_RECEIVER fill:#404ca8,color:white
-  style TRACE_EXPORTER fill:#404ca8,color:white
-  style SPANMETRICS_PROC fill:#404ca8,color:white
-  style PROMETHEUS_EXPORTER fill:#404ca8,color:white
+    style OTLP_EXPORTER fill:#404ca8,color:white
+    style TRACE_RECEIVER fill:#404ca8,color:white
+    style TRACE_EXPORTER fill:#404ca8,color:white
+    style SPANMETRICS_PROC fill:#404ca8,color:white
+    style PROMETHEUS_EXPORTER fill:#404ca8,color:white
 {{< /mermaid >}}
 
 ## Derived Time Series


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #616

## Short description of the changes
- Adds OTEL SDK, OTLP exporter, Jaeger collector and trace storage to architecture diagram to provide a more complete picture of the components involved for SPM.

Rendered diagram:

<img width="783" alt="Screenshot 2023-03-11 at 7 30 03 am" src="https://user-images.githubusercontent.com/26584478/224422491-a9a6b33f-37b8-492d-9fd7-deb6da47c5bf.png">
