### PR TITLE
add a note about scylladb as a storage backend to deployment.md

### DIFF
--- a/content/docs/next-release/deployment.md
+++ b/content/docs/next-release/deployment.md
@@ -472,6 +472,22 @@ usercert = ~/.cassandra/client-cert
 # validate = false
 ```
 
+### ScyllaDB
+Last checked version: 5.1.7
+
+ScyllaDB can be utilized as a drop-in replacement for Cassandra when deploying the Jaeger tracing server. The integration process is straightforward and requires minimal changes to your existing configuration.
+
+To utilize ScyllaDB in place of Cassandra, you simply need to update the CASSANDRA_SERVERS environment variable to point to your ScyllaDB hosts. No other specific configuration changes are necessary, as ScyllaDB is fully compatible with Cassandra settings. Ensure that the environment variable reflects the correct host information, and the Jaeger tracing server will function seamlessly with ScyllaDB.
+
+Example:
+
+```sh
+docker run \
+  -e SPAN_STORAGE_TYPE=cassandra \
+  -e CASSANDRA_SERVERS="scylla_db_1, scylla_db_2, scylla_db_3" \
+  jaegertracing/jaeger-collector:{{< currentVersion >}}
+```
+
 ### Elasticsearch
 Supported in Jaeger since 0.6.0
 Supported versions: 5.x, 6.x, 7.x

--- a/content/docs/next-release/deployment.md
+++ b/content/docs/next-release/deployment.md
@@ -472,22 +472,6 @@ usercert = ~/.cassandra/client-cert
 # validate = false
 ```
 
-### ScyllaDB
-Last checked version: 5.1.7
-
-ScyllaDB can be utilized as a drop-in replacement for Cassandra when deploying the Jaeger tracing server. The integration process is straightforward and requires minimal changes to your existing configuration.
-
-To utilize ScyllaDB in place of Cassandra, you simply need to update the CASSANDRA_SERVERS environment variable to point to your ScyllaDB hosts. No other specific configuration changes are necessary, as ScyllaDB is fully compatible with Cassandra settings. Ensure that the environment variable reflects the correct host information, and the Jaeger tracing server will function seamlessly with ScyllaDB.
-
-Example:
-
-```sh
-docker run \
-  -e SPAN_STORAGE_TYPE=cassandra \
-  -e CASSANDRA_SERVERS="scylla_db_1, scylla_db_2, scylla_db_3" \
-  jaegertracing/jaeger-collector:{{< currentVersion >}}
-```
-
 ### Elasticsearch
 Supported in Jaeger since 0.6.0
 Supported versions: 5.x, 6.x, 7.x
@@ -774,6 +758,10 @@ Available sidecar plugins:
 * [InfluxDB](https://github.com/influxdata/influxdb-observability/blob/main/jaeger-influxdb/README.md) - time series database.
 * [Logz.io](https://github.com/logzio/jaeger-logzio) - secure, scalable, managed, cloud-based ELK storage.
 * [ClickHouse](https://github.com/jaegertracing/jaeger-clickhouse) - fast open-source OLAP DBMS.
+
+### Compatible Backends
+
+* ScyllaDB [can be used](https://github.com/jaegertracing/jaeger/blob/main/plugin/storage/scylladb/README.md) as a drop-in replacement for Cassandra since it uses the same data model and query language.
 
 #### Remote storage model
 


### PR DESCRIPTION
## Which problem is this PR solving?

This PR solves the lack of documentation regarding the use of ScyllaDB as a drop-in replacement for Cassandra in Jaeger tracing server deployment. By providing clear instructions on how to configure the CASSANDRA_SERVERS environment variable, users can easily switch to ScyllaDB for enhanced performance and compatibility without any additional changes to their existing setup.

## Short description of the changes

This PR adds a note to the Jaeger tracing server deployment documentation, explaining how to configure the system to use ScyllaDB as a drop-in replacement for Cassandra by simply updating the CASSANDRA_SERVERS environment variable to point to ScyllaDB hosts.
