### PR TITLE
Fix OTEL specification sdk-environment-variables document URL

### DIFF
--- a/content/docs/1.44/troubleshooting.md
+++ b/content/docs/1.44/troubleshooting.md
@@ -12,7 +12,7 @@ Before everything else, make sure to confirm what sampling strategy is being use
 
 ### OpenTelemtery SDKs
 
-If you are using OpenTelemetry SDKs, they should default to `parentbased_always_on` sampler, which is effectively sampling at 100%. It can be changed via `OTEL_TRACES_SAMPLER` environment variable ([see documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md)).
+If you are using OpenTelemetry SDKs, they should default to `parentbased_always_on` sampler, which is effectively sampling at 100%. It can be changed via `OTEL_TRACES_SAMPLER` environment variable ([see documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md)).
 
 #### Using stdout Exporter
 

--- a/content/docs/1.45/troubleshooting.md
+++ b/content/docs/1.45/troubleshooting.md
@@ -12,7 +12,7 @@ Before everything else, make sure to confirm what sampling strategy is being use
 
 ### OpenTelemtery SDKs
 
-If you are using OpenTelemetry SDKs, they should default to `parentbased_always_on` sampler, which is effectively sampling at 100%. It can be changed via `OTEL_TRACES_SAMPLER` environment variable ([see documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md)).
+If you are using OpenTelemetry SDKs, they should default to `parentbased_always_on` sampler, which is effectively sampling at 100%. It can be changed via `OTEL_TRACES_SAMPLER` environment variable ([see documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md)).
 
 #### Using stdout Exporter
 

--- a/content/docs/next-release/troubleshooting.md
+++ b/content/docs/next-release/troubleshooting.md
@@ -12,7 +12,7 @@ Before everything else, make sure to confirm what sampling strategy is being use
 
 ### OpenTelemtery SDKs
 
-If you are using OpenTelemetry SDKs, they should default to `parentbased_always_on` sampler, which is effectively sampling at 100%. It can be changed via `OTEL_TRACES_SAMPLER` environment variable ([see documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md)).
+If you are using OpenTelemetry SDKs, they should default to `parentbased_always_on` sampler, which is effectively sampling at 100%. It can be changed via `OTEL_TRACES_SAMPLER` environment variable ([see documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md)).
 
 #### Using stdout Exporter
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Upstream documentation in https://github.com/open-telemetry/opentelemetry-specification repository was relocated, leaving Jaeger documentation with broken links.

## Short description of the changes
- We are updating upstream URLs in Jaeger configuration.
