### PR TITLE
Add 'for mentees' and 'for mentors' pages

### DIFF
--- a/content/mentorship-for-mentees.md
+++ b/content/mentorship-for-mentees.md
@@ -1,0 +1,56 @@
+---
+title: Mentorship - For Mentees
+---
+
+Congratulations on being selected as a Jaeger Mentee! It can be daunting when starting off on your project, so here are some guidelines to help you get started.
+
+## Onboarding Checklist
+
+- [ ] Please review the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+  It offers a guideline that both mentors and mentees should follow to ensure a
+  safe environment for communication.
+- [ ] Create an account on the [CNCF Slack](https://slack.cncf.io/) and
+  personalize it with a photo/image to help you stand out.
+- [ ] Send your mentors your slack account handle, so we can add you to private channels.
+  We will create one with just you and your mentor, and second permanent private channel
+  with all past and new mentees and mentors together.
+- [ ] Join the [#jaeger](https://cloud-native.slack.com/archives/CGG7NFUJ3) public channel.
+  This is where you can get help from the Jaeger community.
+- [ ] Say “hello” to your mentors, fellow mentees, and jaeger community; and if
+  you’re comfortable with it, introduce yourself with a few sentences.
+- [ ] Read our contributing guides ([#1](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md),
+  [#2](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md)),
+  containing instructions on the development workflow.
+- [ ] Familiarize yourself with the [Jaeger documentation](https://www.jaegertracing.io/docs/latest/),
+  which provides an architecture overview of Jaeger, a comprehensive list of all
+  CLI flags, among others.
+- [ ] Carefully read through the Github issue to get a firm understanding of the requirements.
+  Post any clarifying questions on that issue, ensuring a persistent record for
+  later reference by yourself, mentors and the community.
+
+## Tips
+
+- [ ] Ask questions! A good rule of thumb is if you spend more than an hour not able to find an answer
+  in the documentation or the code, then don’t hesitate to ask your mentor for pointers. You can also ask in
+  [#jaeger](https://cloud-native.slack.com/archives/CGG7NFUJ3) and #jaeger-mentorships Slack channels.
+- [ ] Before embarking on a relatively substantial change, write up a plan on what you plan to do,
+  why and potential challenges or unknowns. Consider documentiing this as a
+  [new issue](https://github.com/jaegertracing/jaeger/issues) in Jaeger.
+- [ ] Work on small deliverables at a time, making small enhancements as you go along.
+  Breaking down a large task into smaller pieces can help make a seemingly daunting task appear manageable.
+  It also helps reduce cognitive load on reviewers! 😀
+- [ ] It can be quite challenging to break down a problem, while dealing with the uncertainty of whether
+  your approach will work in the end. A basic proof of concept provides assurance of the final outcome,
+  can help highlight the sub-problems to tackle individually, while also giving you a chance
+  to explore the various alternative solutions and identify the best option.
+- [ ] You are welcome to join the [monthly Jaeger video calls](https://www.jaegertracing.io/get-in-touch/):
+  every 3rd Thursday, 11am New York time.
+- [ ] Write unit tests and, if applicable, run live integration tests locally. Tests give assurance
+  to yourself that what you’ve written works, documents the expected behavior to readers of the code,
+  and prevents regressions from future contributions.
+- [ ] You’re encouraged to review others’ PRs (e.g. from your fellow mentees)
+  with kind and constructive feedback. It’s a great way to learn about good coding
+  practices, while also helping familiarize yourself with the codebase.
+- [ ] Feel free to suggest improvements! For example, if you’re experiencing a
+  lot of friction in the development workflow, is there anything we can do to
+  improve the developer experience through better documentation or automation?

--- a/content/mentorship-for-mentors.md
+++ b/content/mentorship-for-mentors.md
@@ -1,0 +1,15 @@
+---
+title: Mentorship - For Mentors
+---
+
+## Retrospective
+
+We want to keep improving to make sure mentees have an enjoyable and productive time during their tenure.
+
+During the last week of the program, mentors and mentees should prepare a document with two headings:
+What we did well.
+What we could do better.
+
+Be specific, blameless and honest. It’s not about offending anyone, but looking for improvements for both Mentor and Mentees work. Be critical to yourself, but also try to balance the good and to improve parts. There is always something we could do better or worse.
+
+Identify any learnings and/or actions from the feedback and ensure these are reflected or documented somewhere accessible, prior to the next mentorship program.

--- a/themes/jaeger-docs/layouts/partials/navbar.html
+++ b/themes/jaeger-docs/layouts/partials/navbar.html
@@ -125,6 +125,14 @@
               Mentorships
             </a>
 
+            <a class="navbar-item" href="/mentorship-for-mentees">
+              Mentorships - For Mentees
+            </a>
+
+            <a class="navbar-item" href="/mentorship-for-mentors">
+              Mentorships - For Mentors
+            </a>
+
             <a class="navbar-item" href="/news">
               News
             </a>


### PR DESCRIPTION
## Which problem is this PR solving?
- We are missing mentorship onboarding documentation, to offer guidance to those new to making open source contributions.

## Short description of the changes
- Add separate "For Mentees" and "For Mentors" pages, containing various guidelines on contributing to Jaeger and on the mentorship programs in general.
