### PR TITLE
Fix typo in Kubernetes installation docs

### DIFF
--- a/content/docs/1.29/operator.md
+++ b/content/docs/1.29/operator.md
@@ -67,7 +67,7 @@ kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/down
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 At this point, there should be a `jaeger-operator` deployment available.  You can view it by running the following command:
 
@@ -96,7 +96,7 @@ oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 Once the operator is installed, grant the role `jaeger-operator` to users who should be able to install individual Jaeger instances. The following example creates a role binding allowing the user `developer` to create Jaeger instances:
 

--- a/content/docs/1.30/operator.md
+++ b/content/docs/1.30/operator.md
@@ -67,7 +67,7 @@ kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/down
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 At this point, there should be a `jaeger-operator` deployment available.  You can view it by running the following command:
 
@@ -96,7 +96,7 @@ oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 Once the operator is installed, grant the role `jaeger-operator` to users who should be able to install individual Jaeger instances. The following example creates a role binding allowing the user `developer` to create Jaeger instances:
 

--- a/content/docs/1.31/operator.md
+++ b/content/docs/1.31/operator.md
@@ -75,7 +75,7 @@ kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/down
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 At this point, there should be a `jaeger-operator` deployment available.  You can view it by running the following command:
 
@@ -104,7 +104,7 @@ oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 Once the operator is installed, grant the role `jaeger-operator` to users who should be able to install individual Jaeger instances. The following example creates a role binding allowing the user `developer` to create Jaeger instances:
 

--- a/content/docs/1.32/operator.md
+++ b/content/docs/1.32/operator.md
@@ -75,7 +75,7 @@ kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/down
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 At this point, there should be a `jaeger-operator` deployment available.  You can view it by running the following command:
 
@@ -104,7 +104,7 @@ oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 Once the operator is installed, grant the role `jaeger-operator` to users who should be able to install individual Jaeger instances. The following example creates a role binding allowing the user `developer` to create Jaeger instances:
 

--- a/content/docs/1.33/operator.md
+++ b/content/docs/1.33/operator.md
@@ -75,7 +75,7 @@ kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/down
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 At this point, there should be a `jaeger-operator` deployment available.  You can view it by running the following command:
 
@@ -104,7 +104,7 @@ oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 Once the operator is installed, grant the role `jaeger-operator` to users who should be able to install individual Jaeger instances. The following example creates a role binding allowing the user `developer` to create Jaeger instances:
 

--- a/content/docs/1.34/operator.md
+++ b/content/docs/1.34/operator.md
@@ -75,7 +75,7 @@ kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/down
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 At this point, there should be a `jaeger-operator` deployment available.  You can view it by running the following command:
 
@@ -104,7 +104,7 @@ oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 Once the operator is installed, grant the role `jaeger-operator` to users who should be able to install individual Jaeger instances. The following example creates a role binding allowing the user `developer` to create Jaeger instances:
 

--- a/content/docs/1.35/operator.md
+++ b/content/docs/1.35/operator.md
@@ -75,7 +75,7 @@ kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/down
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 At this point, there should be a `jaeger-operator` deployment available.  You can view it by running the following command:
 
@@ -104,7 +104,7 @@ oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 Once the operator is installed, grant the role `jaeger-operator` to users who should be able to install individual Jaeger instances. The following example creates a role binding allowing the user `developer` to create Jaeger instances:
 

--- a/content/docs/1.36/operator.md
+++ b/content/docs/1.36/operator.md
@@ -75,7 +75,7 @@ kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/down
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 At this point, there should be a `jaeger-operator` deployment available.  You can view it by running the following command:
 
@@ -104,7 +104,7 @@ oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 Once the operator is installed, grant the role `jaeger-operator` to users who should be able to install individual Jaeger instances. The following example creates a role binding allowing the user `developer` to create Jaeger instances:
 

--- a/content/docs/1.37/operator.md
+++ b/content/docs/1.37/operator.md
@@ -75,7 +75,7 @@ kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/down
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 At this point, there should be a `jaeger-operator` deployment available.  You can view it by running the following command:
 
@@ -104,7 +104,7 @@ oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 Once the operator is installed, grant the role `jaeger-operator` to users who should be able to install individual Jaeger instances. The following example creates a role binding allowing the user `developer` to create Jaeger instances:
 

--- a/content/docs/1.38/operator.md
+++ b/content/docs/1.38/operator.md
@@ -75,7 +75,7 @@ kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/down
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 At this point, there should be a `jaeger-operator` deployment available.  You can view it by running the following command:
 
@@ -104,7 +104,7 @@ oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 Once the operator is installed, grant the role `jaeger-operator` to users who should be able to install individual Jaeger instances. The following example creates a role binding allowing the user `developer` to create Jaeger instances:
 

--- a/content/docs/1.39/operator.md
+++ b/content/docs/1.39/operator.md
@@ -75,7 +75,7 @@ kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/down
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 At this point, there should be a `jaeger-operator` deployment available.  You can view it by running the following command:
 
@@ -104,7 +104,7 @@ oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 Once the operator is installed, grant the role `jaeger-operator` to users who should be able to install individual Jaeger instances. The following example creates a role binding allowing the user `developer` to create Jaeger instances:
 

--- a/content/docs/1.40/operator.md
+++ b/content/docs/1.40/operator.md
@@ -75,7 +75,7 @@ kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/down
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 At this point, there should be a `jaeger-operator` deployment available.  You can view it by running the following command:
 
@@ -104,7 +104,7 @@ oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 Once the operator is installed, grant the role `jaeger-operator` to users who should be able to install individual Jaeger instances. The following example creates a role binding allowing the user `developer` to create Jaeger instances:
 

--- a/content/docs/1.41/operator.md
+++ b/content/docs/1.41/operator.md
@@ -75,7 +75,7 @@ kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/down
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 At this point, there should be a `jaeger-operator` deployment available.  You can view it by running the following command:
 
@@ -104,7 +104,7 @@ oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 Once the operator is installed, grant the role `jaeger-operator` to users who should be able to install individual Jaeger instances. The following example creates a role binding allowing the user `developer` to create Jaeger instances:
 

--- a/content/docs/1.42/operator.md
+++ b/content/docs/1.42/operator.md
@@ -75,7 +75,7 @@ kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/down
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 At this point, there should be a `jaeger-operator` deployment available.  You can view it by running the following command:
 
@@ -104,7 +104,7 @@ oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 Once the operator is installed, grant the role `jaeger-operator` to users who should be able to install individual Jaeger instances. The following example creates a role binding allowing the user `developer` to create Jaeger instances:
 

--- a/content/docs/1.43/operator.md
+++ b/content/docs/1.43/operator.md
@@ -75,7 +75,7 @@ kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/down
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 At this point, there should be a `jaeger-operator` deployment available.  You can view it by running the following command:
 
@@ -104,7 +104,7 @@ oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 Once the operator is installed, grant the role `jaeger-operator` to users who should be able to install individual Jaeger instances. The following example creates a role binding allowing the user `developer` to create Jaeger instances:
 

--- a/content/docs/1.44/operator.md
+++ b/content/docs/1.44/operator.md
@@ -75,7 +75,7 @@ kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/down
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 At this point, there should be a `jaeger-operator` deployment available.  You can view it by running the following command:
 
@@ -104,7 +104,7 @@ oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 Once the operator is installed, grant the role `jaeger-operator` to users who should be able to install individual Jaeger instances. The following example creates a role binding allowing the user `developer` to create Jaeger instances:
 

--- a/content/docs/1.45/operator.md
+++ b/content/docs/1.45/operator.md
@@ -75,7 +75,7 @@ kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/down
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 At this point, there should be a `jaeger-operator` deployment available.  You can view it by running the following command:
 
@@ -104,7 +104,7 @@ oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 Once the operator is installed, grant the role `jaeger-operator` to users who should be able to install individual Jaeger instances. The following example creates a role binding allowing the user `developer` to create Jaeger instances:
 

--- a/content/docs/1.46/operator.md
+++ b/content/docs/1.46/operator.md
@@ -75,7 +75,7 @@ kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/down
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 At this point, there should be a `jaeger-operator` deployment available.  You can view it by running the following command:
 
@@ -104,7 +104,7 @@ oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 Once the operator is installed, grant the role `jaeger-operator` to users who should be able to install individual Jaeger instances. The following example creates a role binding allowing the user `developer` to create Jaeger instances:
 

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -75,7 +75,7 @@ kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/down
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 At this point, there should be a `jaeger-operator` deployment available.  You can view it by running the following command:
 
@@ -104,7 +104,7 @@ oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
 
-The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterBindingRole` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
+The operator will be installed in cluster wide mode, if you want to only watch an specific namespace you need to change the `ClusterRole` and `ClusterRoleBinding` of the operator manifest to `Role` and `RoleBinding`, also set the `WATCH_NAMESPACE` environment variable on the jaeger operator Deployment.
 
 Once the operator is installed, grant the role `jaeger-operator` to users who should be able to install individual Jaeger instances. The following example creates a role binding allowing the user `developer` to create Jaeger instances:
 


### PR DESCRIPTION
## Which problem is this PR solving?
- fixes some typos in the jaeger operator installation guide
- `ClusterBindingRole` -> `ClusterRoleBinding`
