### PR TITLE
Make the elastic search version requirement a bit more clear

### DIFF
--- a/content/docs/1.51/deployment.md
+++ b/content/docs/1.51/deployment.md
@@ -476,7 +476,8 @@ usercert = ~/.cassandra/client-cert
 
 ### Elasticsearch
 Supported in Jaeger since 0.6.0
-Supported versions: 5.x, 6.x, 7.x
+Supported ElasticSearch versions: 5.x, 6.x, 7.x 
+Warning: Jaeger does not support ElasticSearch 8.x 
 
 Elasticsearch version is automatically retrieved from root/ping endpoint.
 Based on this version Jaeger uses compatible index mappings and Elasticsearch REST API.


### PR DESCRIPTION

## Which problem is this PR solving?
I spent an hour before I figured that Jaeger doesn't support Elasticsearch 8.x - the information was technically there but could use some clarification.

## Description of the changes
- Update the docs to make it clear that ES 8.x is _not supported_

## How was this change tested?
- Docs change, are there tests?

## Checklist
- [ X ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ?] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
