### PR TITLE
Fix Medium's post thumbnail

### DIFF
--- a/themes/jaeger-docs/layouts/index.html
+++ b/themes/jaeger-docs/layouts/index.html
@@ -3,12 +3,31 @@
 {{ with resources.GetRemote "https://api.rss2json.com/v1/api.json?rss_url=https://medium.com/feed/jaegertracing" }}
   {{ $json = . | transform.Unmarshal }}
 {{ end }}
-{{ $posts        := first 100 $json.items }}
+{{ $posts := first 100 $json.items }}
+{{ $imgLinks := slice }}
+{{ $defaultImgLink := "/img/jaeger-icon-color.png" }}
+
+{{/* Parse Medium's post first image link */}}
+{{ range $k, $v := $posts }}
+  {{ $imgLink := $defaultImgLink }}
+  {{ with strings.FindRESubmatch "<img[^>]+src=\"([^\">]+)\"" (index $v "content") 1 }}
+    {{ if . }} {{/* If image found in post */}}
+      {{ $findMatch := index . 0 }} {{/* Choose the first image */}}
+      {{ with $findMatch }}
+        {{ $findGroup := index . 1 }}
+        {{ if . }} {{/* If src link found */}}
+          {{ $imgLink = $findGroup }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+  {{ $imgLinks = $imgLinks | append $imgLink }}
+{{ end }}
 
 {{ partial "home/hero.html" (dict "posts" $posts "title" site.Title "tagline" site.Params.tagline "latestVersion" site.Params.latest) }}
 {{ partial "home/why.html" . }}
 {{ partial "home/features.html" . }}
-{{ partial "home/articles.html" (dict "posts" $posts) }}
+{{ partial "home/articles.html" (dict "posts" $posts "imgLinks" $imgLinks) }}
 {{ partial "home/contributing.html" . }}
 {{ partial "home/cncf.html" . }}
 {{ end }}

--- a/themes/jaeger-docs/layouts/partials/home/articles.html
+++ b/themes/jaeger-docs/layouts/partials/home/articles.html
@@ -4,9 +4,9 @@
 
     <div class="blog__container">
       <ul class="blog__slider">
-        {{ range .posts }}
+        {{ range $idx, $val := .posts }}
         {{ $link    := .link }}
-        {{ $img     := .thumbnail }}
+        {{ $img     := (index $.imgLinks $idx) }}
         {{ $title   := .title | plainify }}
         {{ $author  := .author }}
         {{ $dateRaw := .pubDate }}


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #677

## Description of the changes
- Fix Medium's post thumbnail
  - Solution following: https://medium.com/@kartikyathakur/getting-those-thumbnails-from-medium-rss-feed-183f74aefa8c

## How was this change tested?
- Manual test

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
