### PR TITLE
Add jaeger-postgresql to storage plugins list

### DIFF
--- a/content/docs/next-release/deployment.md
+++ b/content/docs/next-release/deployment.md
@@ -760,7 +760,7 @@ Available sidecar plugins:
 * [InfluxDB](https://github.com/influxdata/influxdb-observability/blob/main/jaeger-influxdb/README.md) - time series database.
 * [Logz.io](https://github.com/logzio/jaeger-logzio) - secure, scalable, managed, cloud-based ELK storage.
 * [ClickHouse](https://github.com/jaegertracing/jaeger-clickhouse) - fast open-source OLAP DBMS.
-
+* [PostgreSQL](https://github.com/robbert229/jaeger-postgresql) - a powerful, open source object-relational database system.
 ### Compatible Backends
 
 * ScyllaDB [can be used](https://github.com/jaegertracing/jaeger/blob/main/plugin/storage/scylladb/README.md) as a drop-in replacement for Cassandra since it uses the same data model and query language.


### PR DESCRIPTION
## Which problem is this PR solving?
This PR lists the postgres-jaeger storage plugin that I maintain to the storage plugins list.


## Description of the changes
Adds a link to the storage plugin list.

## How was this change tested?
It was visually checked.
![image](https://github.com/jaegertracing/documentation/assets/3454480/75592214-10c7-4338-b3f7-c5d009386eef)

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [X] I have added unit tests for the new functionality
- [X] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`