### PR TITLE
Github Action Added to Block PRs from fork/main branch

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -33,3 +33,6 @@ jobs:
     - name: Build
       run: |
         make build
+
+    - name: Ensure PR is not on main branch
+      uses: jaegertracing/jaeger/.github/actions/block-pr-not-on-main@main


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?

- Resolves https://github.com/jaegertracing/jaeger/issues/5271

## Description of the changes
-  Added the github actions file that check the PR is from main branch of fork and blocks it.

## How was this change tested?
-  Will be tested

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
