### PR TITLE
Fix typo in OpenTelemetry

### DIFF
--- a/content/docs/1.44/troubleshooting.md
+++ b/content/docs/1.44/troubleshooting.md
@@ -10,7 +10,7 @@ Jaeger backend is itself a distributed system, composed of different components,
 
 Before everything else, make sure to confirm what sampling strategy is being used. For development purposes or for low-traffic scenarios, it is useful to sample every trace. In production, you may want to use lower rates. When diagnosing why spans are not being received by the backend, make sure to configure the SDK to _sample every trace_. Typically, the sampling strategy can be set via environment variables.
 
-### OpenTelemtery SDKs
+### OpenTelemetry SDKs
 
 If you are using OpenTelemetry SDKs, they should default to `parentbased_always_on` sampler, which is effectively sampling at 100%. It can be changed via `OTEL_TRACES_SAMPLER` environment variable ([see documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md)).
 

--- a/content/docs/1.45/troubleshooting.md
+++ b/content/docs/1.45/troubleshooting.md
@@ -10,7 +10,7 @@ Jaeger backend is itself a distributed system, composed of different components,
 
 Before everything else, make sure to confirm what sampling strategy is being used. For development purposes or for low-traffic scenarios, it is useful to sample every trace. In production, you may want to use lower rates. When diagnosing why spans are not being received by the backend, make sure to configure the SDK to _sample every trace_. Typically, the sampling strategy can be set via environment variables.
 
-### OpenTelemtery SDKs
+### OpenTelemetry SDKs
 
 If you are using OpenTelemetry SDKs, they should default to `parentbased_always_on` sampler, which is effectively sampling at 100%. It can be changed via `OTEL_TRACES_SAMPLER` environment variable ([see documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md)).
 

--- a/content/docs/1.46/troubleshooting.md
+++ b/content/docs/1.46/troubleshooting.md
@@ -10,7 +10,7 @@ Jaeger backend is itself a distributed system, composed of different components,
 
 Before everything else, make sure to confirm what sampling strategy is being used. For development purposes or for low-traffic scenarios, it is useful to sample every trace. In production, you may want to use lower rates. When diagnosing why spans are not being received by the backend, make sure to configure the SDK to _sample every trace_. Typically, the sampling strategy can be set via environment variables.
 
-### OpenTelemtery SDKs
+### OpenTelemetry SDKs
 
 If you are using OpenTelemetry SDKs, they should default to `parentbased_always_on` sampler, which is effectively sampling at 100%. It can be changed via `OTEL_TRACES_SAMPLER` environment variable ([see documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md)).
 

--- a/content/docs/1.47/troubleshooting.md
+++ b/content/docs/1.47/troubleshooting.md
@@ -12,7 +12,7 @@ If you are using the OpenTelemetry Collector as part of your pipeline, make sure
 
 Before everything else, make sure to confirm what sampling strategy is being used. For development purposes or for low-traffic scenarios, it is useful to sample every trace. In production, you may want to use lower rates. When diagnosing why spans are not being received by the backend, make sure to configure the SDK to _sample every trace_. Typically, the sampling strategy can be set via environment variables.
 
-### OpenTelemtery SDKs
+### OpenTelemetry SDKs
 
 If you are using OpenTelemetry SDKs, they should default to `parentbased_always_on` sampler, which is effectively sampling at 100%. It can be changed via `OTEL_TRACES_SAMPLER` environment variable ([see documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md)).
 

--- a/content/docs/1.48/troubleshooting.md
+++ b/content/docs/1.48/troubleshooting.md
@@ -12,7 +12,7 @@ If you are using the OpenTelemetry Collector as part of your pipeline, make sure
 
 Before everything else, make sure to confirm what sampling strategy is being used. For development purposes or for low-traffic scenarios, it is useful to sample every trace. In production, you may want to use lower rates. When diagnosing why spans are not being received by the backend, make sure to configure the SDK to _sample every trace_. Typically, the sampling strategy can be set via environment variables.
 
-### OpenTelemtery SDKs
+### OpenTelemetry SDKs
 
 If you are using OpenTelemetry SDKs, they should default to `parentbased_always_on` sampler, which is effectively sampling at 100%. It can be changed via `OTEL_TRACES_SAMPLER` environment variable ([see documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md)).
 

--- a/content/docs/1.49/troubleshooting.md
+++ b/content/docs/1.49/troubleshooting.md
@@ -12,7 +12,7 @@ If you are using the OpenTelemetry Collector as part of your pipeline, make sure
 
 Before everything else, make sure to confirm what sampling strategy is being used. For development purposes or for low-traffic scenarios, it is useful to sample every trace. In production, you may want to use lower rates. When diagnosing why spans are not being received by the backend, make sure to configure the SDK to _sample every trace_. Typically, the sampling strategy can be set via environment variables.
 
-### OpenTelemtery SDKs
+### OpenTelemetry SDKs
 
 If you are using OpenTelemetry SDKs, they should default to `parentbased_always_on` sampler, which is effectively sampling at 100%. It can be changed via `OTEL_TRACES_SAMPLER` environment variable ([see documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md)).
 

--- a/content/docs/1.50/troubleshooting.md
+++ b/content/docs/1.50/troubleshooting.md
@@ -12,7 +12,7 @@ If you are using the OpenTelemetry Collector as part of your pipeline, make sure
 
 Before everything else, make sure to confirm what sampling strategy is being used. For development purposes or for low-traffic scenarios, it is useful to sample every trace. In production, you may want to use lower rates. When diagnosing why spans are not being received by the backend, make sure to configure the SDK to _sample every trace_. Typically, the sampling strategy can be set via environment variables.
 
-### OpenTelemtery SDKs
+### OpenTelemetry SDKs
 
 If you are using OpenTelemetry SDKs, they should default to `parentbased_always_on` sampler, which is effectively sampling at 100%. It can be changed via `OTEL_TRACES_SAMPLER` environment variable ([see documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md)).
 

--- a/content/docs/1.51/troubleshooting.md
+++ b/content/docs/1.51/troubleshooting.md
@@ -12,7 +12,7 @@ If you are using the OpenTelemetry Collector as part of your pipeline, make sure
 
 Before everything else, make sure to confirm what sampling strategy is being used. For development purposes or for low-traffic scenarios, it is useful to sample every trace. In production, you may want to use lower rates. When diagnosing why spans are not being received by the backend, make sure to configure the SDK to _sample every trace_. Typically, the sampling strategy can be set via environment variables.
 
-### OpenTelemtery SDKs
+### OpenTelemetry SDKs
 
 If you are using OpenTelemetry SDKs, they should default to `parentbased_always_on` sampler, which is effectively sampling at 100%. It can be changed via `OTEL_TRACES_SAMPLER` environment variable ([see documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md)).
 

--- a/content/docs/1.52/troubleshooting.md
+++ b/content/docs/1.52/troubleshooting.md
@@ -12,7 +12,7 @@ If you are using the OpenTelemetry Collector as part of your pipeline, make sure
 
 Before everything else, make sure to confirm what sampling strategy is being used. For development purposes or for low-traffic scenarios, it is useful to sample every trace. In production, you may want to use lower rates. When diagnosing why spans are not being received by the backend, make sure to configure the SDK to _sample every trace_. Typically, the sampling strategy can be set via environment variables.
 
-### OpenTelemtery SDKs
+### OpenTelemetry SDKs
 
 If you are using OpenTelemetry SDKs, they should default to `parentbased_always_on` sampler, which is effectively sampling at 100%. It can be changed via `OTEL_TRACES_SAMPLER` environment variable ([see documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md)).
 

--- a/content/docs/1.53/troubleshooting.md
+++ b/content/docs/1.53/troubleshooting.md
@@ -12,7 +12,7 @@ If you are using the OpenTelemetry Collector as part of your pipeline, make sure
 
 Before everything else, make sure to confirm what sampling strategy is being used. For development purposes or for low-traffic scenarios, it is useful to sample every trace. In production, you may want to use lower rates. When diagnosing why spans are not being received by the backend, make sure to configure the SDK to _sample every trace_. Typically, the sampling strategy can be set via environment variables.
 
-### OpenTelemtery SDKs
+### OpenTelemetry SDKs
 
 If you are using OpenTelemetry SDKs, they should default to `parentbased_always_on` sampler, which is effectively sampling at 100%. It can be changed via `OTEL_TRACES_SAMPLER` environment variable ([see documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md)).
 

--- a/content/docs/1.54/troubleshooting.md
+++ b/content/docs/1.54/troubleshooting.md
@@ -12,7 +12,7 @@ If you are using the OpenTelemetry Collector as part of your pipeline, make sure
 
 Before everything else, make sure to confirm what sampling strategy is being used. For development purposes or for low-traffic scenarios, it is useful to sample every trace. In production, you may want to use lower rates. When diagnosing why spans are not being received by the backend, make sure to configure the SDK to _sample every trace_. Typically, the sampling strategy can be set via environment variables.
 
-### OpenTelemtery SDKs
+### OpenTelemetry SDKs
 
 If you are using OpenTelemetry SDKs, they should default to `parentbased_always_on` sampler, which is effectively sampling at 100%. It can be changed via `OTEL_TRACES_SAMPLER` environment variable ([see documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md)).
 

--- a/content/docs/1.55/troubleshooting.md
+++ b/content/docs/1.55/troubleshooting.md
@@ -12,7 +12,7 @@ If you are using the OpenTelemetry Collector as part of your pipeline, make sure
 
 Before everything else, make sure to confirm what sampling strategy is being used. For development purposes or for low-traffic scenarios, it is useful to sample every trace. In production, you may want to use lower rates. When diagnosing why spans are not being received by the backend, make sure to configure the SDK to _sample every trace_. Typically, the sampling strategy can be set via environment variables.
 
-### OpenTelemtery SDKs
+### OpenTelemetry SDKs
 
 If you are using OpenTelemetry SDKs, they should default to `parentbased_always_on` sampler, which is effectively sampling at 100%. It can be changed via `OTEL_TRACES_SAMPLER` environment variable ([see documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md)).
 

--- a/content/docs/1.56/troubleshooting.md
+++ b/content/docs/1.56/troubleshooting.md
@@ -12,7 +12,7 @@ If you are using the OpenTelemetry Collector as part of your pipeline, make sure
 
 Before everything else, make sure to confirm what sampling strategy is being used. For development purposes or for low-traffic scenarios, it is useful to sample every trace. In production, you may want to use lower rates. When diagnosing why spans are not being received by the backend, make sure to configure the SDK to _sample every trace_. Typically, the sampling strategy can be set via environment variables.
 
-### OpenTelemtery SDKs
+### OpenTelemetry SDKs
 
 If you are using OpenTelemetry SDKs, they should default to `parentbased_always_on` sampler, which is effectively sampling at 100%. It can be changed via `OTEL_TRACES_SAMPLER` environment variable ([see documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md)).
 

--- a/content/docs/1.57/troubleshooting.md
+++ b/content/docs/1.57/troubleshooting.md
@@ -12,7 +12,7 @@ If you are using the OpenTelemetry Collector as part of your pipeline, make sure
 
 Before everything else, make sure to confirm what sampling strategy is being used. For development purposes or for low-traffic scenarios, it is useful to sample every trace. In production, you may want to use lower rates. When diagnosing why spans are not being received by the backend, make sure to configure the SDK to _sample every trace_. Typically, the sampling strategy can be set via environment variables.
 
-### OpenTelemtery SDKs
+### OpenTelemetry SDKs
 
 If you are using OpenTelemetry SDKs, they should default to `parentbased_always_on` sampler, which is effectively sampling at 100%. It can be changed via `OTEL_TRACES_SAMPLER` environment variable ([see documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md)).
 

--- a/content/docs/next-release/troubleshooting.md
+++ b/content/docs/next-release/troubleshooting.md
@@ -12,7 +12,7 @@ If you are using the OpenTelemetry Collector as part of your pipeline, make sure
 
 Before everything else, make sure to confirm what sampling strategy is being used. For development purposes or for low-traffic scenarios, it is useful to sample every trace. In production, you may want to use lower rates. When diagnosing why spans are not being received by the backend, make sure to configure the SDK to _sample every trace_. Typically, the sampling strategy can be set via environment variables.
 
-### OpenTelemtery SDKs
+### OpenTelemetry SDKs
 
 If you are using OpenTelemetry SDKs, they should default to `parentbased_always_on` sampler, which is effectively sampling at 100%. It can be changed via `OTEL_TRACES_SAMPLER` environment variable ([see documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md)).
 


### PR DESCRIPTION
## Which problem is this PR solving?
a typo in troubleshooting.MD

Surprisingly, the spellcheck didn't pick this one up, probably due to the Markdown hashtags being interpreted as a comment.
![image](https://github.com/jaegertracing/documentation/assets/62351083/d790d827-d0e6-453b-9d25-8bdd1a7c3ff1)



## Checklist
- [ X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ X] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
