### PR TITLE
Remove grpc-plugin storage type

### DIFF
--- a/content/docs/next-release/_index.md
+++ b/content/docs/next-release/_index.md
@@ -44,12 +44,13 @@ See [Features](./features/) page for more details.
   * Supported storage backends:
     * [Cassandra 3.4+](./deployment/#cassandra)
     * [Elasticsearch 5.x, 6.x, 7.x](./deployment/#elasticsearch)
-    * [Kafka](./deployment/#kafka)
+    * [Badger](./deployment/#badger---local-storage)
+    * [Kafka](./deployment/#kafka) - as an intermediate buffer
     * memory storage
-    * certified grpc-plugins:
-      * [ClickHouse](./deployment/#sidecar-model)
+    * Custom backends via [Remote Storage API](./deployment/#remote-storage)
 
 ## Quick Start
+
 See [Getting Started](./getting-started).
 
 ## Screenshots

--- a/content/docs/next-release/apis.md
+++ b/content/docs/next-release/apis.md
@@ -77,7 +77,7 @@ Jaeger UI communicates with **jaeger-query** Service via JSON API. For example, 
 
 ## Remote Storage API (stable)
 
-When using the `grpc-plugin` storage type (a.k.a. [storage plugin](../deployment/#storage-plugin)), Jaeger components can use custom storage backends as long as those backends implement the gRPC [Remote Storage API][storage.proto].
+When using the `grpc` storage type (a.k.a. [remote storage](../deployment/#remote-storage)), Jaeger components can use custom storage backends as long as those backends implement the gRPC [Remote Storage API][storage.proto].
 
 ## Remote Sampling Configuration (stable)
 

--- a/content/docs/next-release/deployment.md
+++ b/content/docs/next-release/deployment.md
@@ -246,7 +246,7 @@ Port  | Protocol | Function
 
 Jaeger requires a persistent storage backend. Cassandra and Elasticsearch/OpenSearch are the primary supported distributed storage backends. Additional backends are [discussed here](https://github.com/jaegertracing/jaeger/issues/638).
 
-The storage type can be passed via `SPAN_STORAGE_TYPE` environment variable. Valid values are `cassandra`, `elasticsearch`, `kafka` (only as a buffer), `grpc-plugin`, `badger` and `memory`.
+The storage type can be passed via `SPAN_STORAGE_TYPE` environment variable. Valid values are `cassandra`, `elasticsearch`, `kafka` (only as a buffer), `badger` and `memory`.
 
 As of version 1.6.0, it's possible to use multiple storage types at the same time by providing a comma-separated list of valid types to the `SPAN_STORAGE_TYPE` environment variable. It's important to note that all listed storage types are used for writing, but only the first type in the list will be used for reading and archiving.
 
@@ -365,6 +365,10 @@ userkey = ~/.cassandra/client-key
 usercert = ~/.cassandra/client-cert
 # validate = false
 ```
+
+#### Compatible Backends
+
+* ScyllaDB [can be used](https://github.com/jaegertracing/jaeger/blob/main/plugin/storage/scylladb/README.md) as a drop-in replacement for Cassandra since it uses the same data model and query language.
 
 ### Elasticsearch
 * Supported since Jaeger v0.6.0
@@ -628,49 +632,23 @@ Unless your Kafka cluster is configured to automatically create topics, you will
 
 You can find more information about topics and partitions in general in the [official documentation](https://kafka.apache.org/documentation/#intro_topics). [This article](https://www.confluent.io/blog/how-to-choose-the-number-of-topicspartitions-in-a-kafka-cluster/) provide more details about how to choose the number of partitions.
 
-### Storage plugin
+### Remote Storage
 
-Jaeger supports a gRPC-based [Remote Storage API][storage.proto] that allows extending the Jaeger ecosystem with other storage backends, or "plugins", not directly supported by the project. These storage backends can be deployed in two modes: as a sidecar or as a remote gRPC server (since Jaeger v1.30).
+Jaeger supports a gRPC-based [Remote Storage API][storage.proto] that allows extending the Jaeger ecosystem with custom storage backends, not directly supported by the project. These storage backends can be deployed as a remote gRPC server (since Jaeger v1.30). Older deployment mode as sidecar plugin will not be supported starting from v1.58.
 
-To use a storage plugin as Jaeger storage backend, use `grpc-plugin` as the storage type and specify either the binary name for the sidecar mode, or the remote gRPC server address. For more information, please refer to [jaeger/plugin/storage/grpc](https://github.com/jaegertracing/jaeger/tree/master/plugin/storage/grpc).
-
-#### Sidecar model
-
-In the sidecar model, the backend server that implements the Remote Storage API runs as a child process of some Jaeger component (the [Hashicorp go-plugin model](https://github.com/hashicorp/go-plugin)).
+To use a remote storage as Jaeger storage backend, use `grpc` as the storage type and specify the remote gRPC server address. For more information, please refer to [jaeger/plugin/storage/grpc](https://github.com/jaegertracing/jaeger/tree/master/plugin/storage/grpc).
 
 Example:
 ```sh
 docker run \
-  -e SPAN_STORAGE_TYPE=grpc-plugin \
-  -e GRPC_STORAGE_PLUGIN_BINARY=<...> \
-  -e GRPC_STORAGE_PLUGIN_CONFIGURATION_FILE=<...> \
-  jaegertracing/all-in-one:{{< currentVersion >}}
-```
-
-Available sidecar plugins:
-
-* [InfluxDB](https://github.com/influxdata/influxdb-observability/blob/main/jaeger-influxdb/README.md) - time series database.
-* [Logz.io](https://github.com/logzio/jaeger-logzio) - secure, scalable, managed, cloud-based ELK storage.
-* [ClickHouse](https://github.com/jaegertracing/jaeger-clickhouse) - fast open-source OLAP DBMS.
-### Compatible Backends
-
-* ScyllaDB [can be used](https://github.com/jaegertracing/jaeger/blob/main/plugin/storage/scylladb/README.md) as a drop-in replacement for Cassandra since it uses the same data model and query language.
-
-#### Remote storage model
-
-In the remote storage model the backend server runs as a separate process, and the Jaeger components are configured to talk to it over gRPC.
-
-Example:
-```sh
-docker run \
-  -e SPAN_STORAGE_TYPE=grpc-plugin \
+  -e SPAN_STORAGE_TYPE=grpc \
   -e GRPC_STORAGE_SERVER=<...> \
   jaegertracing/all-in-one:{{< currentVersion >}}
 ```
 
 Known remote storage backends:
 
-* [PostgreSQL](https://github.com/robbert229/jaeger-postgresql) - a powerful, open source object-relational database system.
+* [PostgreSQL by robbert229](https://github.com/robbert229/jaeger-postgresql)
 
 ## Metrics Storage Backends
 

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -664,45 +664,9 @@ spec:
 
 ### Storage plugin
 
-Setting `spec.storage.type` to `grpc-plugin` enables using Jaeger with 3rd party storage implementations.
-
-The following is an example of a Jaeger CR using the `allInOne` deployment strategy
-and the Clickhouse storage plugin.
-Refer to [jaeger-clickhouse](https://github.com/pavolloffay/jaeger-clickhouse) for documentation
-and a fully functional example.
-
-```yaml
-apiVersion: jaegertracing.io/v1
-kind: Jaeger
-metadata:
-  name: clickhouse-grpc-plugin
-spec:
-  strategy: allInOne
-  storage:
-    type: grpc-plugin # <1>
-    grpcPlugin:
-      image: ghcr.io/pavolloffay/jaeger-clickhouse:0.5.1 # <2>
-    options:
-      grpc-storage-plugin: # <3>
-        binary: /plugin/jaeger-clickhouse
-        configuration-file: /plugin-config/config.yaml
-        log-level: debug
-  volumeMounts:
-    - name: plugin-config
-      mountPath: /plugin-config
-  volumes:
-    - name: plugin-config
-      configMap:
-        name: jaeger-clickhouse # <4>
- ```
-
-<1> Storage type set to `grpc-plugin`.
-
-<2> Image with the plugin binary. The image is used as init-container to copy the binary into volume that is available to the Jaeger process. The image has to copy the binary into `/plugin` directory.
-
-<3> Configuration options for the `grpc-plugin`.
-
-<4> User created config map with the plugin configuration.
+{{< warning >}}
+Sidecar plugins will not be supported from v1.58. Custom storage backends should migrate to Remote Storage API.
+{{< /warning >}}
 
 ## Metrics storage options
 

--- a/scripts/cspell/project-words.txt
+++ b/scripts/cspell/project-words.txt
@@ -117,6 +117,7 @@ rebalance
 reddy
 reindex
 reindexing
+robbert
 rolebinding
 ryans
 shkuro

--- a/scripts/cspell/spellcheck.sh
+++ b/scripts/cspell/spellcheck.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 if ! sort -c project-words.txt; then
-    echo "project-words.txt is not sorted." 
+    echo "project-words.txt is not sorted."
     exit 1
 fi
-npm install cspell
+npm ci  # clean install, do not upgrade dependencies
 npm run spellcheck
 if [ $? -ne 0 ]; then
     echo "Misspelling(s) found."


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of https://github.com/jaegertracing/jaeger/issues/4647

## Description of the changes
- Replace `grpc-plugin` with `grpc` where applicable, remove otherwise.

## How was this change tested?
- CI
