### PR TITLE
Remove: support ElasticSearch 5.x & 6.x

### DIFF
--- a/content/docs/next-release/_index.md
+++ b/content/docs/next-release/_index.md
@@ -43,7 +43,7 @@ See [Features](./features/) page for more details.
   * React/Javascript UI
   * Supported storage backends:
     * [Cassandra 3.4+](./deployment/#cassandra)
-    * [Elasticsearch 5.x, 6.x, 7.x](./deployment/#elasticsearch)
+    * [Elasticsearch 7.x, 8.x](./deployment/#elasticsearch)
     * [Badger](./deployment/#badger---local-storage)
     * [Kafka](./deployment/#kafka) - as an intermediate buffer
     * memory storage

--- a/content/docs/next-release/deployment.md
+++ b/content/docs/next-release/deployment.md
@@ -372,7 +372,7 @@ usercert = ~/.cassandra/client-cert
 
 ### Elasticsearch
 * Supported since Jaeger v0.6.0
-* Supported ES versions: 5.x, 6.x, 7.x, 8.x (since Jaeger v1.52.0)
+* Supported ES versions: 7.x, 8.x (since Jaeger v1.52.0)
 
 Elasticsearch version is automatically retrieved from root/ping endpoint.
 Based on this version Jaeger uses compatible index mappings and Elasticsearch REST API.
@@ -531,19 +531,19 @@ For example:
 #### Upgrade Elasticsearch version
 
 Elasticsearch defines wire and index compatibility versions. The index compatibility defines
-the minimal version a node can read data from. For example Elasticsearch 7 can read indices
-created by Elasticsearch 6, however it cannot read indices created by Elasticsearch 5 even
-though they use the same index mappings. Therefore upgrade from Elasticsearch 6 to 7 does not require any
-data migration. However, upgrade from Elasticsearch 5 to 7 has to be done through Elasticsearch 6 and wait
-until indices created by ES 5.x are removed or explicitly reindexed.
+the minimal version a node can read data from. For example Elasticsearch 8 can read indices
+created by Elasticsearch 7, however it cannot read indices created by Elasticsearch 6 even
+though they use the same index mappings. Therefore upgrade from Elasticsearch 7 to 8 does not require any
+data migration. However, upgrade from Elasticsearch 6 to 8 has to be done through Elasticsearch 7 and wait
+until indices created by ES 6.x are removed or explicitly reindexed.
 
 Refer to the Elasticsearch [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current//setup-upgrade.html)
 for wire and index compatibility versions. Generally this information can be retrieved from root/ping REST endpoint.
 
 ##### Reindex
 
-Manual reindexing can be used when upgrading from Elasticsearch 5 to 7 (through Elasticsearch 6)
-without waiting until indices created by Elasticsearch 5 are removed.
+Manual reindexing can be used when upgrading from Elasticsearch 6 to 8 (through Elasticsearch 7)
+without waiting until indices created by Elasticsearch 6 are removed.
 
 1. Reindex all span indices to new indices with suffix `-1`:
 

--- a/content/docs/next-release/features.md
+++ b/content/docs/next-release/features.md
@@ -20,7 +20,7 @@ Since v1.35, the Jaeger backend can receive trace data from the OpenTelemetry SD
 ## Multiple storage backends
 
 Jaeger can be used with a growing a number of storage backends:
-* It natively supports popular open source NoSQL databases as trace storage backends: Cassandra 3.4+, Elasticsearch 5.x/6.x/7.x, and OpenSearch 1.0+.
+* It natively supports popular open source NoSQL databases as trace storage backends: Cassandra 3.4+, Elasticsearch 7.x/8.x, and OpenSearch 1.0+.
 * It integrates via a gRPC API with other well known databases that have been certified to be Jaeger compliant: [ClickHouse](https://github.com/jaegertracing/jaeger-clickhouse).
 * There is embedded database support using [Badger](https://github.com/dgraph-io/badger) and simple in-memory storage for testing setups.
 * There are ongoing community experiments using other databases; you can find more in [this issue](https://github.com/jaegertracing/jaeger/issues/638).


### PR DESCRIPTION
## Which problem is this PR solving?
- Relate https://github.com/jaegertracing/jaeger/issues/5439

## Description of the changes
- Remove ElasticSearch 5.x & 6.x documentation

## How was this change tested?
- Manual

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
