### PR TITLE
GitHub Action Checkout step version upgraded to v4

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -10,7 +10,7 @@ jobs:
     if: ${{ github.repository == 'jaegertracing/documentation' && startsWith(github.ref, 'refs/tags/release-') }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 


### PR DESCRIPTION
## Which problem is this PR solving?

Node.js 16 actions are deprecated therefore I upgraded github action action checkout step to latest version of v4
Closes: https://github.com/jaegertracing/documentation/issues/715
<img width="1078" alt="Screenshot 2024-06-18 at 12 39 17" src="https://github.com/jaegertracing/documentation/assets/19349315/f4a61b67-9114-4b49-8028-7e7ddaef295c">

## Description of the changes
-  Node.js 16 actions are deprecated. with this upgrade, deprecated warning will go away


## How was this change tested?
- Tested on GitHub Action run

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
