### PR TITLE
Mention jaeger-cassandra-schema Docker image

### DIFF
--- a/content/docs/1.59/deployment.md
+++ b/content/docs/1.59/deployment.md
@@ -317,6 +317,13 @@ using Cassandra's interactive shell [`cqlsh`][cqlsh]:
 MODE=test sh ./plugin/storage/cassandra/schema/create.sh | cqlsh
 ```
 
+Or using the published Docker image (make sure to provide the right IP address):
+```sh
+docker run \
+  -e CQLSH_HOST={server IP address}  \
+  jaegertracing/jaeger-cassandra-schema:{{< currentVersion >}}
+```
+
 For production deployment, pass `MODE=prod DATACENTER={datacenter}` arguments to the script,
 where `{datacenter}` is the name used in the Cassandra configuration / network topology.
 

--- a/content/docs/next-release/deployment.md
+++ b/content/docs/next-release/deployment.md
@@ -317,6 +317,13 @@ using Cassandra's interactive shell [`cqlsh`][cqlsh]:
 MODE=test sh ./plugin/storage/cassandra/schema/create.sh | cqlsh
 ```
 
+Or using the published Docker image (make sure to provide the right IP address):
+```sh
+docker run \
+  -e CQLSH_HOST={server IP address}  \
+  jaegertracing/jaeger-cassandra-schema:{{< currentVersion >}}
+```
+
 For production deployment, pass `MODE=prod DATACENTER={datacenter}` arguments to the script,
 where `{datacenter}` is the name used in the Cassandra configuration / network topology.
 


### PR DESCRIPTION
## Which problem is this PR solving?
- We seem to be completely lacking documentation on using this image to create DB schema

## Description of the changes
- Add example of using the image

## How was this change tested?
```
$ docker run --env CQLSH_HOST=192.168.68.82 jaegertracing/jaeger-cassandra-schema:1.59.0
Checking if Cassandra is up at 192.168.68.82:9042.
WARNING: cqlsh was built against 5.0-beta1, but this server is 3.11.17.  All features may not work!

WARN: DESCRIBE|DESC was moved to server side in Cassandra 4.0. As a consequence DESRIBE|DESC will not work in cqlsh '6.2.0' connected to Cassandra '3.11.17', the version that you are connected to. DESCRIBE does not exist server side prior Cassandra 4.0.
Cassandra connection established.
Cassandra version detected:
3
Generating the schema for the keyspace jaeger_v1_dc1 and datacenter dc1.
Using template file /cassandra-schema/v004.cql.tmpl with parameters:
    mode = test
    datacenter = dc1
    keyspace = jaeger_v1_dc1
    replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}
    trace_ttl = 172800
    dependencies_ttl = 0
    compaction_window_size = 96
    compaction_window_unit = MINUTES
WARNING: cqlsh was built against 5.0-beta1, but this server is 3.11.17.  All features may not work!
Schema generated.
```