### PR TITLE
fixing padding and spacing to get TOC to render right

### DIFF
--- a/themes/jaeger-docs/assets/sass/article.sass
+++ b/themes/jaeger-docs/assets/sass/article.sass
@@ -20,7 +20,7 @@
     margin-top: 2rem
 
     .is-8
-      padding: 0 2rem
+      padding: 0 1rem
 
     .content
       ul, ul li

--- a/themes/jaeger-docs/assets/sass/pages.sass
+++ b/themes/jaeger-docs/assets/sass/pages.sass
@@ -57,8 +57,8 @@
       .nav
         position: absolute
         z-index: 10
-        width: 180px
-        max-width: 20rem
+        min-width: 15rem
+        max-width: 25rem
         line-height: 150%
         overflow-y: scroll
         overflow-x: hidden

--- a/themes/jaeger-docs/assets/sass/pages.sass
+++ b/themes/jaeger-docs/assets/sass/pages.sass
@@ -52,12 +52,13 @@
       position: fixed
       bottom: 0%
       top: 9rem
+      left: 3rem 
 
       .nav
         position: absolute
         z-index: 10
-        width: inherit
-        max-width: 11rem
+        width: 180px
+        max-width: 20rem
         line-height: 150%
         overflow-y: scroll
         overflow-x: hidden


### PR DESCRIPTION
This change will fix the spacing on all of the docs to make the screen real state better with less white space. It makes
 a bigger difference in the v2 docs with the new TOC.

I did some testing on smaller screens as well.

Happy to get feedback.
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [X] I have run lint and test steps successfully