### PR TITLE
[docs] Change Supported Version For Cassandra

### DIFF
--- a/content/docs/1.61/deployment.md
+++ b/content/docs/1.61/deployment.md
@@ -283,7 +283,7 @@ docker run \
 * [Badger file permissions as non-root service](https://github.com/jaegertracing/jaeger/blob/main/plugin/storage/badger/docs/storage-file-non-root-permission.md)
 
 ### Cassandra
-* Supported versions: 3.4+
+* Supported versions: 4.0+
 
 Deploying Cassandra itself is out of scope for our documentation. One good
 source of documentation is the [Apache Cassandra Docs](https://cassandra.apache.org/doc/latest/).


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves https://github.com/jaegertracing/jaeger/issues/5160

## Description of the changes
- In https://github.com/jaegertracing/jaeger/pull/5962, we removed support for Cassandra 3.x. This PR updates the documentation to refelct that.

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
