### PR TITLE
Use full versions in Docker commands

### DIFF
--- a/themes/jaeger-docs/layouts/partials/docs/panel.html
+++ b/themes/jaeger-docs/layouts/partials/docs/panel.html
@@ -5,8 +5,8 @@
 {{ else }}
   {{ $path = .Path }}
 {{ end }}
-{{ $currentVersion := index (split $path "/") 1 }}
-{{ $versionDocsPath := printf "content/docs/%s" $currentVersion }}
+{{ $majorMinorVersion := index (split $path "/") 1 }}
+{{ $versionDocsPath := printf "content/docs/%s" $majorMinorVersion }}
 {{ $url := .RelPermalink }}
 <div class="nav-wrapper">
   <aside class="nav">
@@ -18,7 +18,7 @@
         {{ $pagePath = .Path }}
       {{ end }}
       {{ $docVersion := index (split $pagePath "/") 1 }}
-      {{ if and (eq $docVersion $currentVersion) (not .Params.hasParent) }}
+      {{ if and (eq $docVersion $majorMinorVersion) (not .Params.hasParent) }}
         {{ $isCurrentPage := eq $url .RelPermalink }}
         <div class="nav-link">
           <a href="{{ .Permalink }}"{{ if $isCurrentPage }} class="is-active"{{ end }}>
@@ -27,7 +27,7 @@
 
           {{ with .Params.children }}
             {{ range . }}
-              {{ $url := printf "/docs/%s/%s/" $currentVersion .url }}
+              {{ $url := printf "/docs/%s/%s/" $majorMinorVersion .url }}
               {{ $isCurrentPage := eq $url $.RelPermalink }}
               <br />
               <a class="nav-sublink{{ if $isCurrentPage }} is-active{{ end }}" href="{{ $url }}">

--- a/themes/jaeger-docs/layouts/partials/navbar.html
+++ b/themes/jaeger-docs/layouts/partials/navbar.html
@@ -13,7 +13,7 @@
 {{ else }}
   {{ $path = .Path }}
 {{ end }}
-{{ $currentVersion := index (split $path "/") 1 }}
+{{ $majorMinorVersion := index (split $path "/") 1 }}
 <nav class="navbar is-fixed-top">
   <div class="container is-fluid">
     <div class="navbar-brand">
@@ -32,7 +32,7 @@
     <div id="topNav" class="navbar-menu">
       <div class="navbar-end">
         {{ if $isDocsPage }}
-        {{ if eq $latest $currentVersion }}
+        {{ if eq $latest $majorMinorVersion }}
         <div class="navbar-item">
           <div class="dropdown" id="search-dropdown">
             <div class="dropdown-trigger">
@@ -70,15 +70,15 @@
               {{ $docVersion := index (split $docPath "/") 1 }}
               <!-- When generating Docs menu for home page, use the latest version, -->
               <!-- when generating menu for pages inside docs/, use same version as the doc -->
-              {{ $matchVersion := cond ($isDocsPage) $currentVersion $latest }}
+              {{ $matchVersion := cond ($isDocsPage) $majorMinorVersion $latest }}
               {{ if and (eq $docVersion $matchVersion) (not .Params.hasparent) }}
                 <a class="navbar-item" href="{{ .RelPermalink }}">
                   {{ .Title }}
                 </a>
 
                 {{ with .Params.children }}
-                  {{ range . }}
-                    {{ $url := cond $isDocsPage (printf "/docs/%s/%s" $currentVersion .url) (printf "/docs/%s/%s" $latest .url) }}
+                    {{ range . }}
+                    {{ $url := cond $isDocsPage (printf "/docs/%s/%s" $majorMinorVersion .url) (printf "/docs/%s/%s" $latest .url) }}
                     <a class="navbar-item is-small is-hidden-desktop" href="{{ $url }}">
                       &cir; {{ if .navtitle }}{{ .navtitle }}{{ else }}{{ .title }}{{ end }}
                     </a>

--- a/themes/jaeger-docs/layouts/shortcodes/currentVersion.html
+++ b/themes/jaeger-docs/layouts/shortcodes/currentVersion.html
@@ -1,1 +1,1 @@
-{{ index (split $.Page.File.Path "/") 1 }}
+{{ add (index (split $.Page.File.Path "/") 1) ".0" }}

--- a/themes/jaeger-docs/layouts/shortcodes/dockerImages.html
+++ b/themes/jaeger-docs/layouts/shortcodes/dockerImages.html
@@ -1,5 +1,5 @@
 {{ $dockerImages := site.Data.download.docker }}
-{{ $latest       := site.Params.latest }}
+{{ $latest       := site.Params.binariesLatest }}
 <table>
   <thead>
     <tr>


### PR DESCRIPTION
## Which problem is this PR solving?
- In v1.61.0 we stopped publishing shortcut Docker tags like `1` and `1.61`, and only publish fully qualified versions `1.61.0`
- But the docs were still referencing major/minor versions ([reported on Slack](https://cloud-native.slack.com/archives/CGG7NFUJ3/p1727056265543819))

## Description of the changes
- Use fully qualified versions everywhere
- The docs URLs still use major.minor, so rename the variables to `$majorMinorVersion` to avoid confusion with the `currentVersion` shortcut
