### PR TITLE
Made toc Sidebar Expand to Fit Page

### DIFF
--- a/themes/jaeger-docs/assets/sass/toc.sass
+++ b/themes/jaeger-docs/assets/sass/toc.sass
@@ -16,10 +16,12 @@ $left-border: 4px solid $jaeger-beige
   position: fixed
   margin: 0
   padding: 0
+  height: calc(100vh - 6rem)
 
   .jaeger-toc-page-list
     padding-left: 20px
     line-height: 1.3
+    position: static
 
   .jaeger-toc-page-link
     display: block


### PR DESCRIPTION
As per issue #744, opened by yurishkuro, I made the sidebar expand to fill the page.

## Which problem is this PR solving?
- Resolved #744

## Description of the changes
- Two lines in "./documentation/themes/jaeger-docs/assets/sass/toc.sass"
- css attribute "height" added to "toc" class.
- css attribute "position" added to "jaeger-toc-page-list" class

## How was this change tested?
- Local development environment utilizing hugo server.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`

![Screenshot 2024-09-26 161400](https://github.com/user-attachments/assets/94d5f116-fdf3-4c11-b81d-8185f01a3256)
![Screenshot 2024-09-26 161415](https://github.com/user-attachments/assets/c113f4b6-17bf-45ec-ad68-a9eaf7a43c96)

