### PR TITLE
Fixed typo in scripts/cspell/project-words.txt

### DIFF
--- a/content/docs/1.16/operator.md
+++ b/content/docs/1.16/operator.md
@@ -976,7 +976,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.17/operator.md
+++ b/content/docs/1.17/operator.md
@@ -701,16 +701,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1142,7 +1142,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.18/operator.md
+++ b/content/docs/1.18/operator.md
@@ -717,16 +717,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1158,7 +1158,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.19/operator.md
+++ b/content/docs/1.19/operator.md
@@ -783,16 +783,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1226,7 +1226,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.20/operator.md
+++ b/content/docs/1.20/operator.md
@@ -783,16 +783,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1226,7 +1226,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.21/operator.md
+++ b/content/docs/1.21/operator.md
@@ -783,16 +783,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1226,7 +1226,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.22/operator.md
+++ b/content/docs/1.22/operator.md
@@ -783,16 +783,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1226,7 +1226,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.23/operator.md
+++ b/content/docs/1.23/operator.md
@@ -783,16 +783,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1226,7 +1226,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.24/operator.md
+++ b/content/docs/1.24/operator.md
@@ -783,16 +783,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1226,7 +1226,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.25/operator.md
+++ b/content/docs/1.25/operator.md
@@ -825,16 +825,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1268,7 +1268,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.26/operator.md
+++ b/content/docs/1.26/operator.md
@@ -825,16 +825,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1268,7 +1268,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.27/operator.md
+++ b/content/docs/1.27/operator.md
@@ -825,16 +825,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1268,7 +1268,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.28/operator.md
+++ b/content/docs/1.28/operator.md
@@ -825,16 +825,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1268,7 +1268,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.29/operator.md
+++ b/content/docs/1.29/operator.md
@@ -805,16 +805,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1248,7 +1248,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.30/operator.md
+++ b/content/docs/1.30/operator.md
@@ -805,16 +805,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1248,7 +1248,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.31/operator.md
+++ b/content/docs/1.31/operator.md
@@ -813,16 +813,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1256,7 +1256,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.32/operator.md
+++ b/content/docs/1.32/operator.md
@@ -813,16 +813,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1256,7 +1256,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.33/operator.md
+++ b/content/docs/1.33/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1301,7 +1301,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.34/operator.md
+++ b/content/docs/1.34/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1301,7 +1301,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.35/operator.md
+++ b/content/docs/1.35/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1301,7 +1301,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.36/operator.md
+++ b/content/docs/1.36/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1301,7 +1301,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.37/operator.md
+++ b/content/docs/1.37/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1301,7 +1301,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.38/operator.md
+++ b/content/docs/1.38/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1301,7 +1301,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.39/operator.md
+++ b/content/docs/1.39/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1301,7 +1301,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.40/operator.md
+++ b/content/docs/1.40/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1411,7 +1411,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.41/operator.md
+++ b/content/docs/1.41/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1411,7 +1411,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.42/operator.md
+++ b/content/docs/1.42/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1411,7 +1411,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.43/operator.md
+++ b/content/docs/1.43/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1411,7 +1411,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.44/operator.md
+++ b/content/docs/1.44/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1411,7 +1411,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.45/operator.md
+++ b/content/docs/1.45/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1411,7 +1411,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.46/operator.md
+++ b/content/docs/1.46/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1411,7 +1411,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.47/operator.md
+++ b/content/docs/1.47/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1411,7 +1411,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.48/operator.md
+++ b/content/docs/1.48/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1411,7 +1411,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.49/operator.md
+++ b/content/docs/1.49/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1411,7 +1411,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.50/operator.md
+++ b/content/docs/1.50/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1411,7 +1411,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.51/operator.md
+++ b/content/docs/1.51/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1411,7 +1411,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.52/operator.md
+++ b/content/docs/1.52/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1411,7 +1411,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.53/operator.md
+++ b/content/docs/1.53/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1411,7 +1411,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.54/operator.md
+++ b/content/docs/1.54/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1411,7 +1411,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.55/operator.md
+++ b/content/docs/1.55/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1411,7 +1411,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.56/operator.md
+++ b/content/docs/1.56/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1411,7 +1411,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.57/operator.md
+++ b/content/docs/1.57/operator.md
@@ -858,16 +858,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1411,7 +1411,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.58/operator.md
+++ b/content/docs/1.58/operator.md
@@ -822,16 +822,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1375,7 +1375,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.59/operator.md
+++ b/content/docs/1.59/operator.md
@@ -822,16 +822,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1375,7 +1375,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.60/operator.md
+++ b/content/docs/1.60/operator.md
@@ -822,16 +822,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1375,7 +1375,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.61/operator.md
+++ b/content/docs/1.61/operator.md
@@ -822,16 +822,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1375,7 +1375,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/1.62/operator.md
+++ b/content/docs/1.62/operator.md
@@ -822,16 +822,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1375,7 +1375,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/next-release-v2/operator.md
+++ b/content/docs/next-release-v2/operator.md
@@ -822,16 +822,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1375,7 +1375,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -822,16 +822,16 @@ The following snippet shows the manual definition you can include in your `conta
   imagePullPolicy: IfNotPresent
   ports:
     - containerPort: 5775
-      name: zk-compact-trft
+      name: zk-compact-thrift
       protocol: UDP
     - containerPort: 5778
       name: config-rest
       protocol: TCP
     - containerPort: 6831
-      name: jg-compact-trft
+      name: jg-compact-thrift
       protocol: UDP
     - containerPort: 6832
-      name: jg-binary-trft
+      name: jg-binary-thrift
       protocol: UDP
     - containerPort: 14271
       name: admin-http
@@ -1375,7 +1375,7 @@ Starting from version 1.16.0, the Jaeger Operator is able to generate spans rela
         - --reporter.grpc.host-port=dns:///jaeger-collector-headless.$(POD_NAMESPACE).svc.cluster.local:14250
         ports:
         - containerPort: 6831
-          name: jg-compact-trft
+          name: jg-compact-thrift
           protocol: UDP
 ```
 

--- a/scripts/cspell/project-words.txt
+++ b/scripts/cspell/project-words.txt
@@ -36,8 +36,8 @@ hostnames
 hostport
 htpasswd
 ingester
-ingesters
 ingester's
+ingesters
 istio
 istio's
 jaegertracing

--- a/scripts/cspell/project-words.txt
+++ b/scripts/cspell/project-words.txt
@@ -36,8 +36,8 @@ hostnames
 hostport
 htpasswd
 ingester
-ingester's
 ingesters
+ingester's
 istio
 istio's
 jaegertracing
@@ -100,11 +100,9 @@ strimzi's
 struct
 subpages
 tchannel
-telemtery
 thriftrw
 tolerations
 tracegen
-trft
 uberctx
 unmarshaling
 upsample


### PR DESCRIPTION

## Which problem is this PR solving?
-  Part of #701 

## Description of the changes
-  Removed unnecessary words from the dictionary and updated their occurrences in the relevant files.
## How was this change tested?
- make spellcheck

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits

