### PR TITLE
Fixed one more typo in scripts/cspell/project-words.txt

### DIFF
--- a/content/docs/1.33/spm.md
+++ b/content/docs/1.33/spm.md
@@ -75,7 +75,7 @@ as such, is only relevant to the Jaeger Query component (and All In One).
 graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_PROC[Spanmetrics Processor]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
-    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     UI[Jaeger UI] --> QUERY
     QUERY[Jaeger Query Service] --> METRICS_STORE[Metrics Storage]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE

--- a/content/docs/1.34/spm.md
+++ b/content/docs/1.34/spm.md
@@ -77,7 +77,7 @@ as such, is only relevant to the Jaeger Query component (and All In One).
 graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_PROC[Spanmetrics Processor]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
-    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     UI[Jaeger UI] --> QUERY
     QUERY[Jaeger Query Service] --> METRICS_STORE[Metrics Storage]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE

--- a/content/docs/1.35/spm.md
+++ b/content/docs/1.35/spm.md
@@ -75,7 +75,7 @@ as such, is only relevant to the Jaeger Query component (and All In One).
 graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_PROC[Spanmetrics Processor]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
-    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     UI[Jaeger UI] --> QUERY
     QUERY[Jaeger Query Service] --> METRICS_STORE[Metrics Storage]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE

--- a/content/docs/1.36/spm.md
+++ b/content/docs/1.36/spm.md
@@ -75,7 +75,7 @@ as such, is only relevant to the Jaeger Query component (and All In One).
 graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_PROC[Spanmetrics Processor]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
-    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     UI[Jaeger UI] --> QUERY
     QUERY[Jaeger Query Service] --> METRICS_STORE[Metrics Storage]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE

--- a/content/docs/1.37/spm.md
+++ b/content/docs/1.37/spm.md
@@ -75,7 +75,7 @@ as such, is only relevant to the Jaeger Query component (and All In One).
 graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_PROC[Spanmetrics Processor]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
-    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     UI[Jaeger UI] --> QUERY
     QUERY[Jaeger Query Service] --> METRICS_STORE[Metrics Storage]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE

--- a/content/docs/1.38/spm.md
+++ b/content/docs/1.38/spm.md
@@ -75,7 +75,7 @@ as such, is only relevant to the Jaeger Query component (and All In One).
 graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_PROC[Spanmetrics Processor]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
-    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     UI[Jaeger UI] --> QUERY
     QUERY[Jaeger Query Service] --> METRICS_STORE[Metrics Storage]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE

--- a/content/docs/1.39/spm.md
+++ b/content/docs/1.39/spm.md
@@ -75,7 +75,7 @@ as such, is only relevant to the Jaeger Query component (and All In One).
 graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_PROC[Spanmetrics Processor]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
-    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     UI[Jaeger UI] --> QUERY
     QUERY[Jaeger Query Service] --> METRICS_STORE[Metrics Storage]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE

--- a/content/docs/1.40/spm.md
+++ b/content/docs/1.40/spm.md
@@ -75,7 +75,7 @@ as such, is only relevant to the Jaeger Query component (and All In One).
 graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_PROC[Spanmetrics Processor]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
-    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     UI[Jaeger UI] --> QUERY
     QUERY[Jaeger Query Service] --> METRICS_STORE[Metrics Storage]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE

--- a/content/docs/1.41/spm.md
+++ b/content/docs/1.41/spm.md
@@ -75,7 +75,7 @@ as such, is only relevant to the Jaeger Query component (and All In One).
 graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_PROC[Spanmetrics Processor]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
-    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     UI[Jaeger UI] --> QUERY
     QUERY[Jaeger Query Service] --> METRICS_STORE[Metrics Storage]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE

--- a/content/docs/1.42/spm.md
+++ b/content/docs/1.42/spm.md
@@ -75,7 +75,7 @@ as such, is only relevant to the Jaeger Query component (and All In One).
 graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_PROC[Spanmetrics Processor]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
-    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     UI[Jaeger UI] --> QUERY
     QUERY[Jaeger Query Service] --> METRICS_STORE[Metrics Storage]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE

--- a/content/docs/1.43/spm.md
+++ b/content/docs/1.43/spm.md
@@ -80,7 +80,7 @@ graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_PROC[Spanmetrics Processor]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
     TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
-    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
 
     COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]

--- a/content/docs/1.44/spm.md
+++ b/content/docs/1.44/spm.md
@@ -80,7 +80,7 @@ graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_PROC[Spanmetrics Processor]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
     TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
-    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
 
     COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]

--- a/content/docs/1.45/spm.md
+++ b/content/docs/1.45/spm.md
@@ -80,7 +80,7 @@ graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_PROC[Spanmetrics Processor]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
     TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
-    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_PROC --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
 
     COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]

--- a/content/docs/1.46/spm.md
+++ b/content/docs/1.46/spm.md
@@ -86,7 +86,7 @@ graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_CONN[SpanMetrics Connector]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
     TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
-    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
 
     COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]

--- a/content/docs/1.47/spm.md
+++ b/content/docs/1.47/spm.md
@@ -86,7 +86,7 @@ graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_CONN[SpanMetrics Connector]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
     TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
-    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
 
     COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]

--- a/content/docs/1.48/spm.md
+++ b/content/docs/1.48/spm.md
@@ -86,7 +86,7 @@ graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_CONN[SpanMetrics Connector]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
     TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
-    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
 
     COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]

--- a/content/docs/1.49/spm.md
+++ b/content/docs/1.49/spm.md
@@ -86,7 +86,7 @@ graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_CONN[SpanMetrics Connector]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
     TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
-    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
 
     COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]

--- a/content/docs/1.50/spm.md
+++ b/content/docs/1.50/spm.md
@@ -86,7 +86,7 @@ graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_CONN[SpanMetrics Connector]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
     TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
-    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
 
     COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]

--- a/content/docs/1.51/spm.md
+++ b/content/docs/1.51/spm.md
@@ -86,7 +86,7 @@ graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_CONN[SpanMetrics Connector]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
     TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
-    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
 
     COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]

--- a/content/docs/1.52/spm.md
+++ b/content/docs/1.52/spm.md
@@ -86,7 +86,7 @@ graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_CONN[SpanMetrics Connector]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
     TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
-    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
 
     COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]

--- a/content/docs/1.53/spm.md
+++ b/content/docs/1.53/spm.md
@@ -86,7 +86,7 @@ graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_CONN[SpanMetrics Connector]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
     TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
-    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
 
     COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]

--- a/content/docs/1.54/spm.md
+++ b/content/docs/1.54/spm.md
@@ -86,7 +86,7 @@ graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_CONN[SpanMetrics Connector]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
     TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
-    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
 
     COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]

--- a/content/docs/1.55/spm.md
+++ b/content/docs/1.55/spm.md
@@ -86,7 +86,7 @@ graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_CONN[SpanMetrics Connector]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
     TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
-    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
 
     COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]

--- a/content/docs/1.56/spm.md
+++ b/content/docs/1.56/spm.md
@@ -86,7 +86,7 @@ graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_CONN[SpanMetrics Connector]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
     TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
-    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
 
     COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]

--- a/content/docs/1.57/spm.md
+++ b/content/docs/1.57/spm.md
@@ -86,7 +86,7 @@ graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_CONN[SpanMetrics Connector]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
     TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
-    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
 
     COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]

--- a/content/docs/1.58/spm.md
+++ b/content/docs/1.58/spm.md
@@ -80,7 +80,7 @@ graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_CONN[SpanMetrics Connector]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
     TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
-    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
 
     COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]

--- a/content/docs/1.59/spm.md
+++ b/content/docs/1.59/spm.md
@@ -80,7 +80,7 @@ graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_CONN[SpanMetrics Connector]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
     TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
-    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
 
     COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]

--- a/content/docs/1.60/spm.md
+++ b/content/docs/1.60/spm.md
@@ -80,7 +80,7 @@ graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_CONN[SpanMetrics Connector]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
     TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
-    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
 
     COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]

--- a/content/docs/1.61/spm.md
+++ b/content/docs/1.61/spm.md
@@ -80,7 +80,7 @@ graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_CONN[SpanMetrics Connector]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
     TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
-    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
 
     COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]

--- a/content/docs/1.62/spm.md
+++ b/content/docs/1.62/spm.md
@@ -80,7 +80,7 @@ graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_CONN[SpanMetrics Connector]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
     TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
-    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
 
     COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]

--- a/content/docs/next-release-v2/features.md
+++ b/content/docs/next-release-v2/features.md
@@ -233,7 +233,7 @@ graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_CONN[SpanMetrics Connector]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
     TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
-    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
 
     COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]

--- a/content/docs/next-release/spm.md
+++ b/content/docs/next-release/spm.md
@@ -80,7 +80,7 @@ graph
     TRACE_RECEIVER[Trace Receiver] --> |spans| SPANMETRICS_CONN[SpanMetrics Connector]
     TRACE_RECEIVER --> |spans| TRACE_EXPORTER[Trace Exporter]
     TRACE_EXPORTER --> |spans| COLLECTOR[Jaeger Collector]
-    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PromethesusRemoteWrite Exporter]
+    SPANMETRICS_CONN --> |metrics| PROMETHEUS_EXPORTER[Prometheus/PrometheusRemoteWrite Exporter]
     PROMETHEUS_EXPORTER --> |metrics| METRICS_STORE[(Metrics Storage)]
 
     COLLECTOR --> |spans| SPAN_STORE[(Span Storage)]

--- a/scripts/cspell/project-words.txt
+++ b/scripts/cspell/project-words.txt
@@ -78,7 +78,6 @@ otlp
 outreachy
 parentbased
 potpose
-promethesus
 prometheusexporter
 promscale
 proto


### PR DESCRIPTION

## Which problem is this PR solving?
- Part of #701 

## Description of the changes
- Removed misspelled word "Promethesus" and replaced the occurrences of that word with "Prometheus".

## How was this change tested?
- make spellcheck

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits

