### PR TITLE
Remove references to jaeger-agent

### DIFF
--- a/content/docs/next-release/apis.md
+++ b/content/docs/next-release/apis.md
@@ -35,7 +35,7 @@ The OTLP data is accepted in these formats: (1) binary gRPC, (2) Protobuf over H
 
 **Deprecated**: we recommend the OpenTelemetry protocol.
 
-Since Jaeger v1.11, the official protocol between applicationss and **jaeger-collector**s is `jaeger.api_v2.CollectorService` gRPC endpoint defined in [collector.proto] IDL file. The same endpoint can be used to submit trace data from SDKs directly to **jaeger-collector**.
+Since Jaeger v1.11, the official protocol between user applications and **jaeger-collector**s is `jaeger.api_v2.CollectorService` gRPC endpoint defined in [collector.proto] IDL file. The same endpoint can be used to submit trace data from SDKs directly to **jaeger-collector**.
 
 ### Thrift over HTTP (stable)
 

--- a/content/docs/next-release/architecture.md
+++ b/content/docs/next-release/architecture.md
@@ -104,14 +104,6 @@ Instrumentation typically should not depend on specific tracing SDKs, but only o
 
 The instrumentation is designed to be always on in production. To minimize  overhead, the SDKs employ various sampling strategies. When a trace is sampled, the profiling span data is captured and transmitted to the Jaeger backend. When a trace is not sampled, no profiling data is collected at all, and the calls to the tracing API are short-circuited to incur a minimal amount of overhead. For more information, please refer to the [Sampling](../sampling/) page.
 
-### Agent
-
-{{< warning >}}
-**jaeger-agent** is [deprecated](https://github.com/jaegertracing/jaeger/issues/4739). The OpenTelemetry data can be sent from the OpenTelemetry SDKs (equipped with OTLP exporters) directly to **jaeger-collector**. Alternatively, use the OpenTelemetry Collector as a local agent.
-{{< /warning >}}
-
-**jaeger-agent** is a network daemon that listens for spans sent over UDP, which are batched and sent to the collector. It is designed to be deployed to all hosts as an infrastructure component. The agent abstracts the routing and discovery of the collectors away from the client. **jaeger-agent** is **not** a required component.
-
 ### Collector
 
 **jaeger-collector** receives traces, runs them through a processing pipeline for validation and clean-up/enrichment, and stores them in a storage backend. Jaeger comes with built-in support for several storage backends (see [Deployment](../deployment)), as well as extensible plugin framework for implementing custom storage plugins.

--- a/content/docs/next-release/external-guides.md
+++ b/content/docs/next-release/external-guides.md
@@ -23,10 +23,8 @@ weight: 13
 
 ## Deployment
 
-* [Running Jaeger on bare metal](https://medium.com/jaegertracing/running-jaeger-agent-on-bare-metal-d1fc47d31fab) by Juraci Paixão Kröhling
 * [Protecting Jaeger UI with an OAuth sidecar Proxy](https://medium.com/jaegertracing/protecting-jaeger-ui-with-an-oauth-sidecar-proxy-34205cca4bb1) by Juraci Paixão Kröhling
 * [Jaeger and multi-tenancy](https://medium.com/jaegertracing/jaeger-and-multitenancy-99dfa1d49dc0) by Juraci Paixão Kröhling
-* [Deployment strategies for the Jaeger Agent](https://medium.com/jaegertracing/deployment-strategies-for-the-jaeger-agent-1d6f91796d09) by Juraci Paixão Kröhling
 * [How to deploy Jaeger on AWS: a comprehensive step-by-step guide](https://www.aspecto.io/blog/how-to-deploy-jaeger-on-aws-a-comprehensive-step-by-step-guide/) by Tom Zach
 
 ## Jaeger Performance Tuning

--- a/content/docs/next-release/faq.md
+++ b/content/docs/next-release/faq.md
@@ -16,17 +16,17 @@ The Dependencies page shows a graph of services traced by Jaeger and connections
 
 Please refer to the [Troubleshooting](../troubleshooting/) guide.
 
-## Do I need to run jaeger-agent?
+## What happened to jaeger-agent?
 
-{{< warning >}}
-Since the Jaeger client libraries [are deprecated](../client-libraries) and the OpenTelemetry SDKs are phasing out support for Jaeger Thrift format, the **jaeger-agent** is no longer required or recommended. See the [Architecture](../architecture) page for alternative deployment options.
-{{< /warning >}}
+Since the Jaeger client libraries [are deprecated](../client-libraries) and the OpenTelemetry SDKs are phasing out support for Jaeger Thrift format, the **jaeger-agent** is no longer required and no longer supported. See the [Architecture](../architecture) page for alternative deployment options.
 
-`jaeger-agent` is not always necessary. Jaeger client libraries can be configured to export trace data directly to `jaeger-collector`. However, the following are the reasons why running `jaeger-agent` is recommended:
+Sometimes it is still desireable to run a **host agent**:
 
-  * If we want Jaeger client libraries to send trace data directly to **jaeger-collector**s, we must provide them with a URL of the HTTP endpoint. It means that our applications require additional configuration containing this parameter, especially if we are running multiple Jaeger installations (e.g. in different availability zones or regions) and want the data sent to a nearby installation. In contrast, when using the agent, the libraries require no additional configuration because the agent is always accessible via `localhost`. It acts as a sidecar and proxies the requests to the appropriate **jaeger-collector**s.
-  * **jaeger-agent** can be configured to enrich the tracing data with infrastructure-specific metadata by adding extra tags to the spans, such as the current zone, region, etc. If **jaeger-agent** is running as a host daemon, it will be shared by all applications running on the same host. If **jaeger-agent** is running as a true sidecar, i.e. one per application, it can provide additional functionality such as strong authentication, multi-tenancy (see [this blog post](https://medium.com/jaegertracing/jaeger-and-multitenancy-99dfa1d49dc0)), pod name, etc.
-  * **jaeger-agent**s allow implementing traffic control to **jaeger-collector**s. If we have thousands of hosts in the data center, each running many applications, and each application sending data directly to **jaeger-collector**s, there may be too many open connections for each **jaeger-collector** to handle. The agents can load balance this traffic with fewer connections.
+  * If we want SDKs to send trace data directly to **jaeger-collector**s, we must provide them with a URL of the HTTP endpoint. It means that our applications require additional configuration containing this parameter, especially if we are running multiple Jaeger installations (e.g. in different availability zones or regions) and want the data sent to a nearby installation. In contrast, when using the host agent, the libraries require no additional configuration because the agent is always accessible via `localhost`. It acts as a sidecar and proxies the requests to the appropriate **jaeger-collector**s.
+  * A host agent can be configured to enrich the tracing data with infrastructure-specific metadata by adding extra tags to the spans, such as the current zone, region, etc. If the host agent is running as a host daemon, it will be shared by all applications running on the same host. If the host agent is running as a true sidecar, i.e. one per application, it can provide additional functionality such as strong authentication, multi-tenancy (see [this blog post](https://medium.com/jaegertracing/jaeger-and-multitenancy-99dfa1d49dc0)), pod name, etc.
+  * Host agents allow implementing traffic control to **jaeger-collector**s. If we have thousands of hosts in the data center, each running many applications, and each application sending data directly to **jaeger-collector**s, there may be too many open connections for each **jaeger-collector** to handle. The agents can load balance this traffic with fewer connections.
+
+If your circumstances requires a host agent, you can deploy OpenTelemetry Collector in that capacity.
 
 ## What is the recommended storage backend?
 

--- a/content/docs/next-release/faq.md
+++ b/content/docs/next-release/faq.md
@@ -20,7 +20,7 @@ Please refer to the [Troubleshooting](../troubleshooting/) guide.
 
 Since the Jaeger client libraries [are deprecated](../client-libraries) and the OpenTelemetry SDKs are phasing out support for Jaeger Thrift format, the **jaeger-agent** is no longer required and no longer supported. See the [Architecture](../architecture) page for alternative deployment options.
 
-Sometimes it is still desireable to run a **host agent**:
+Sometimes it is still desirable to run a **host agent**:
 
   * If we want SDKs to send trace data directly to **jaeger-collector**s, we must provide them with a URL of the HTTP endpoint. It means that our applications require additional configuration containing this parameter, especially if we are running multiple Jaeger installations (e.g. in different availability zones or regions) and want the data sent to a nearby installation. In contrast, when using the host agent, the libraries require no additional configuration because the agent is always accessible via `localhost`. It acts as a sidecar and proxies the requests to the appropriate **jaeger-collector**s.
   * A host agent can be configured to enrich the tracing data with infrastructure-specific metadata by adding extra tags to the spans, such as the current zone, region, etc. If the host agent is running as a host daemon, it will be shared by all applications running on the same host. If the host agent is running as a true sidecar, i.e. one per application, it can provide additional functionality such as strong authentication, multi-tenancy (see [this blog post](https://medium.com/jaegertracing/jaeger-and-multitenancy-99dfa1d49dc0)), pod name, etc.

--- a/content/docs/next-release/getting-started.md
+++ b/content/docs/next-release/getting-started.md
@@ -14,16 +14,13 @@ Historically, the Jaeger project supported its own SDKs (aka tracers, client lib
 
 ## All in One
 
-**all-in-one** is an executable designed for quick local testing. It includes the Jaeger UI, **jaeger-collector**, **jaeger-query**, and **jaeger-agent**, with an in memory storage component.
+**all-in-one** is an executable designed for quick local testing. It includes the Jaeger UI, **jaeger-collector**, and **jaeger-query**, with an in memory storage component.
 
 The simplest way to start the all-in-one is to use the pre-built image published to DockerHub (a single command line).
 
 ```bash
 docker run --rm --name jaeger \
   -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
-  -p 6831:6831/udp \
-  -p 6832:6832/udp \
-  -p 5778:5778 \
   -p 16686:16686 \
   -p 4317:4317 \
   -p 4318:4318 \
@@ -46,11 +43,6 @@ The container exposes the following ports:
 
 Port  | Protocol | Component | Function
 ----- | -------  | --------- | ---
-6831  | UDP      | agent     | accept `jaeger.thrift` over Thrift-compact protocol (used by most SDKs)
-6832  | UDP      | agent     | accept `jaeger.thrift` over Thrift-binary protocol (used by Node.js SDK)
-5775  | UDP      | agent     | (deprecated) accept `zipkin.thrift` over compact Thrift protocol (used by legacy clients only)
-5778  | HTTP     | agent     | serve configs (sampling, etc.)
-      |          |           |
 16686 | HTTP     | query     | serve frontend
       |          |           |
 4317  | HTTP     | collector | accept OpenTelemetry Protocol (OTLP) over gRPC

--- a/content/docs/next-release/monitoring.md
+++ b/content/docs/next-release/monitoring.md
@@ -18,7 +18,6 @@ Each Jaeger component exposes the metrics scraping endpoint on the admin port:
 
 Component             | Port
 --------------------- | ---
-**jaeger-agent**      | 14271
 **jaeger-collector**  | 14269
 **jaeger-query**      | 16687
 **jaeger-ingester**   | 14270

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -20,7 +20,7 @@ While we intend to have the Jaeger Operator working for as many Kubernetes versi
 While multiple operators might coexist watching the same set of namespaces, which operator will succeed in setting itself as the owner of the CR is undefined behavior. Automatic injection of the sidecars might also result in undefined behavior. Therefore, it's highly recommended to have at most one operator watching each namespace. Note that namespaces might contain any number of Jaeger instances (CRs).
 
 {{< info >}}
-The Jaeger Operator version tracks one version of the Jaeger components (**jaeger-query**, **jaeger-collector**, **jaeger-agent**). When a new version of the Jaeger components is released, a new version of the operator will be released that understands how running instances of the previous version can be upgraded to the new version.
+The Jaeger Operator version tracks one version of the Jaeger components (**jaeger-query**, **jaeger-collector**). When a new version of the Jaeger components is released, a new version of the operator will be released that understands how running instances of the previous version can be upgraded to the new version.
 {{< /info >}}
 
 ## Prerequisite
@@ -119,7 +119,7 @@ After the role is granted, switch back to a non-privileged user.
 
 # Quick Start - Deploying the AllInOne image
 
-The simplest possible way to create a Jaeger instance is by creating a YAML file like the following example.  This will install the default AllInOne strategy, which deploys the **all-in-one** image (combining **jaeger-agent**, **jaeger-collector**, **jaeger-query**, and Jaeger UI) in a single pod, using in-memory storage by default.
+The simplest possible way to create a Jaeger instance is by creating a YAML file like the following example.  This will install the default AllInOne strategy, which deploys the **all-in-one** image (combining **jaeger-collector**, **jaeger-query**, and Jaeger UI) in a single pod, using in-memory storage by default.
 
 {{< info >}}
 This default strategy is intended for development, testing, and demo purposes, not for production.
@@ -240,7 +240,7 @@ The available strategies are described in the following sections.
 
 This strategy is intended for development, testing, and demo purposes.
 
-The main backend components,**jaeger-agent**, **jaeger-collector** and **jaeger-query** service, are all packaged into a single executable which is configured (by default) to use in-memory storage. This strategy cannot be scaled beyond one replica.
+The main backend components, **jaeger-collector** and **jaeger-query** service, are all packaged into a single executable which is configured (by default) to use in-memory storage. This strategy cannot be scaled beyond one replica.
 
 ## Production strategy
 

--- a/content/docs/next-release/performance-tuning.md
+++ b/content/docs/next-release/performance-tuning.md
@@ -21,14 +21,6 @@ Adding **jaeger-collector** instances is recommended when your platform provides
 
 Each span is written to the storage by **jaeger-collector** using one worker, blocking it until the span has been stored. When the storage is too slow, the number of workers blocked by the storage might be too high, causing spans to be dropped. To help diagnose this situation, the histogram `jaeger_collector_save_latency_bucket` can be analyzed. Ideally, the latency should remain the same over time. When the histogram shows that most spans are taking longer and longer over time, it’s a good indication that your storage might need some attention.
 
-### Place the Agents close to your applications
-
-{{< warning >}}
-Since the Jaeger client libraries [are deprecated](../client-libraries) and the OpenTelemetry SDKs are phasing out support for Jaeger Thrift format, the **jaeger-agent** is no longer required or recommended. See the [Architecture](../architecture) page for alternative deployment options.
-{{< /warning >}}
-
-**jaeger-agent** is meant to be placed on the same host as the instrumented application, in order to avoid UDP packet loss over the network. This is typically accomplished by having one **jaeger-agent** per bare metal host for traditional applications, or as a sidecar in container environments like Kubernetes, as this helps spread the load handled by **jaeger-agent**s with the additional advantage of allowing each **jaeger-agent** to be tweaked individually, according to the application’s needs and importance.
-
 ### Consider using Apache Kafka as intermediate buffer
 
 Jaeger [can use Apache Kafka](../architecture/) as a buffer between **jaeger-collector** and the actual backing storage (Elasticsearch, Apache Cassandra). This is ideal for cases where the traffic spikes are relatively frequent (prime time traffic) but the storage can eventually catch up once the traffic normalizes. For that, the `SPAN_STORAGE_TYPE` environment variable should be set to `kafka` in  **jaeger-collector**, and **jaeger-ingester** component must be used, reading data from Kafka and writing it to the storage.
@@ -61,51 +53,25 @@ We recommend setting your clients/SDKs to use the [`remote` sampling strategy](.
 
 ### Increase in-memory queue size
 
-Most of the Jaeger clients, such as the Java, Go, and C# clients, buffer spans in memory before sending them to **jaeger-agent**/**jaeger-collector**. The maximum size of this buffer is defined by the environment variable `JAEGER_REPORTER_MAX_QUEUE_SIZE` (default value: about `100` spans): the larger the size, the higher the potential memory consumption. When the instrumented application is generating a large number of spans, it’s possible that the queue will be full causing the Client to discard the new spans (metric `jaeger_tracer_reporter_spans_total{result="dropped",}`).
+Most of the SDKs buffer spans in memory before sending them to **jaeger-collector**. The maximum size of this buffer is configurable (see respective OpenTelemetry SDK documentation): the larger the size, the higher the potential memory consumption. When the instrumented application is generating a large number of spans, it’s possible that the queue will be full causing the SDK to discard the new spans.
 
-In most common scenarios, the queue will be close to empty (metric: `jaeger_tracer_reporter_queue_length`), as spans are flushed to **jaeger-agent** or **jaeger-collector** at regular intervals or when a certain size of the batch is reached. The detailed behavior of this queue is described in this [GitHub issue](https://github.com/jaegertracing/jaeger-client-java/issues/607).
-
-Thrift clients also report their dropped spans to **jaeger-agent**.  These are then published by **jaeger-agent** itself as `jaeger_agent_client_stats_spans_dropped_total{cause="full-queue|send-failure|too-large",}`.  This can be useful if client metrics are unavailable for some reason.
+In most common scenarios, the queue will be close to empty, as spans are flushed to **jaeger-collector** at regular intervals or when a certain size of the batch is reached.
 
 ### Modify the batched spans flush interval
 
-The Java, Go, NodeJS, Python and C# Clients allow the customization of the flush interval (default value: `1000` milliseconds, or 1 second) used by the reporters, such as the `RemoteReporter`, to trigger a `flush` operation, sending all in-memory spans to **jaeger-agent** or **jaeger-collector**. The lower the flush interval is set to, the more frequent the flush operations happen. As most reporters will wait until enough data is in the queue, this setting will force a flush operation at periodic intervals, so that spans are sent to the backend in a timely fashion.
+The SDKs allow the customization of the flush interval used by the exporters. The lower the flush interval is set to, the more frequent the flush operations happen. As most exporters will wait until enough data is in the queue, this setting will force a flush operation at periodic intervals, so that spans are sent to the backend in a timely fashion.
 
-When the instrumented application is generating a large number of spans and **jaeger-agent**/**jaeger-collector** is close to the application, the networking overhead might be low, justifying a higher number of flush operations. When the `HttpSender` is being used and the **jaeger-collector** is not close enough to the application, the networking overhead might be too high so that a higher value for this property makes sense.
-
-## Agent settings
-
-{{< warning >}}
-Since the Jaeger client libraries [are deprecated](../client-libraries) and the OpenTelemetry SDKs are phasing out support for Jaeger Thrift format, the **jaeger-agent** is no longer required or recommended. See the [Architecture](../architecture) page for alternative deployment options.
-{{< /warning >}}
-
-**jaeger-agent**s receive data from Clients, sending them in batches to **jaeger-collector**. When not properly configured, it might end up discarding data even if the host machine has plenty of resources.
-
-### Adjust server queue sizes
-
-The set of “server queue size” properties ( `processor.jaeger-binary.server-queue-size`, `processor.jaeger-compact.server-queue-size`, `processor.zipkin-compact.server-queue-size`) indicate the maximum number of span batches that **jaeger-agent** can accept and store in memory. It’s safe to assume that `jaeger-compact` is the most important processor in your **jaeger-agent** setup, as it’s the only one available in most Clients, such as the Java and Go Clients.
-
-The default value for each queue is `1000` span batches. Given that each span batch has up to 64KiB worth of spans, each queue can hold up to 64MiB worth of spans.
-
-In typical scenarios, the queue will be close to empty (metric `jaeger_agent_thrift_udp_server_queue_size`) as span batches should be quickly picked up and processed by a worker. However, sudden spikes in the number of span batches submitted by Clients might occur, causing the batches to be queued. When the queue is full, the older batches are overridden causing spans to be discarded (metric `jaeger_agent_thrift_udp_server_packets_dropped_total`).
-
-### Adjust processor workers
-
-The set of “processor workers” properties ( `processor.jaeger-binary.workers`, `processor.jaeger-compact.workers`, `processor.zipkin-compact.workers`) indicate the number of parallel span batch processors to start. Each worker type has a default size of `10`. In general, span batches are processed as soon as they are placed in the server queue and will block a worker until the whole packet is sent to **jaeger-collector**. For **jaeger-agent**s processing data from multiple Clients, the number of workers should be increased. Given that the cost of each worker is low, a good rule of thumb is 10 workers per Client with moderate traffic: given that each span batch might contain up to 64KiB worth of spans, it means that 10 workers are able to send about 640KiB concurrently to a **jaeger-collector**.
+When the instrumented application is generating a large number of spans and **jaeger-collector** is close to the application, the networking overhead might be low, justifying a higher number of flush operations. When the `HttpSender` is being used and the **jaeger-collector** is not close enough to the application, the networking overhead might be too high so that a higher value for this property makes sense.
 
 ## Collector settings
 
-**jaeger-collector** receives data from Clients and **jaeger-agent**s. When not properly configured, it might process less data than what would be possible on the same host, or it might overload the host by consuming more memory than permitted.
+**jaeger-collector** receives data from SDKs. When not properly configured, it might process less data than what would be possible on the same host, or it might overload the host by consuming more memory than permitted.
 
 ### Adjust queue size
 
-Similar to the **jaeger-agent**, **jaeger-collector** is able to receive spans and place them in an internal queue for processing. This allows **jaeger-collector** to return immediately to the Client/**jaeger-agent** instead of waiting for the span to make its way to the storage.
+**jaeger-collector** is able to receive spans and place them in an internal queue for processing. This allows **jaeger-collector** to return immediately to the SDK instead of waiting for the span to make its way to the storage.
 
 The setting `collector.queue-size` (default: `2000`) dictates how many spans the queue should support. In the typical scenario, the queue will be close to empty, as enough workers should exist picking up spans from the queue and sending them to the storage. When the number of items in the queue (metric `jaeger_collector_queue_length`) is permanently high, it’s an indication that either the number of workers should be increased or that the storage cannot keep up with the volume of data that it’s receiving. When the queue is full, the older items in the queue are overridden, causing spans to be discarded (metric `jaeger_collector_spans_dropped_total`).
-
-{{< warning >}}
-The queue size for **jaeger-agent** is about _span batches_, whereas the queue size for the Collector is about _individual spans_.
-{{< /warning >}}
 
 Given that the queue size should be close to empty most of the time, this setting should be as high as the available memory for the Collector, to provide maximum protection against sudden traffic spikes. However, if your storage layer is under-provisioned and cannot keep up, even a large queue will quickly fill up and start dropping data.
 

--- a/content/docs/next-release/sampling.md
+++ b/content/docs/next-release/sampling.md
@@ -17,7 +17,7 @@ When using configuration object to instantiate the tracer, the type of sampling 
 * **Constant** (`sampler.type=const`) sampler always makes the same decision for all traces. It either samples all traces (`sampler.param=1`) or none of them (`sampler.param=0`).
 * **Probabilistic** (`sampler.type=probabilistic`) sampler makes a random sampling decision with the probability of sampling equal to the value of `sampler.param` property. For example, with `sampler.param=0.1` approximately 1 in 10 traces will be sampled.
 * **Rate Limiting** (`sampler.type=ratelimiting`) sampler uses a leaky bucket rate limiter to ensure that traces are sampled with a certain constant rate. For example, when `sampler.param=2.0` it will sample requests with the rate of 2 traces per second.
-* **Remote** (`sampler.type=remote`, which is also the default) sampler consults **jaeger-agent** for the appropriate sampling strategy to use in the current service. This allows controlling the sampling strategies in the services from a central configuration in Jaeger backend (see [Remote Sampling](#remote-sampling)), or even dynamically (see [Adaptive Sampling](#adaptive-sampling)).
+* **Remote** (`sampler.type=remote`, which is also the default) sampler consults **jaeger-collector** for the appropriate sampling strategy to use in the current service. This allows controlling the sampling strategies in the services from a central configuration in Jaeger backend (see [Remote Sampling](#remote-sampling)), or even dynamically (see [Adaptive Sampling](#adaptive-sampling)).
 
 ## Remote Sampling
 

--- a/content/docs/next-release/security.md
+++ b/content/docs/next-release/security.md
@@ -5,17 +5,6 @@ hasparent: true
 
 This page documents the existing security mechanisms in Jaeger, organized by the pairwise connections between Jaeger components. We ask for community help with implementing additional security measures (see [issue-1718][]).
 
-## SDK to Agent
-
-{{< warning >}}
-**jaeger-agent** is [deprecated](https://github.com/jaegertracing/jaeger/issues/4739). The OpenTelemetry data can be sent from the OpenTelemetry SDKs (equipped with OTLP exporters) directly to **jaeger-collector**. Alternatively, use the OpenTelemetry Collector as a local agent.
-{{< /warning >}}
-
-Deployments that involve **jaeger-agent** are meant for trusted environments where the agent is run as a sidecar within the container's network namespace, or as a host agent. Therefore, there is currently no support for traffic encryption between clients and agents.
-
-* {{< check_no >}} Sending trace data over UDP - no TLS/authentication.
-* {{< check_no >}} Retrieving sampling configuration via HTTP - no TLS/authentication.
-
 ## SDK to Collector
 
 OpenTelemetry SDKs can be configured to communicate directly with **jaeger-collector** via gRPC or HTTP, with optional TLS enabled.
@@ -23,14 +12,6 @@ OpenTelemetry SDKs can be configured to communicate directly with **jaeger-colle
 * {{< check_yes >}} HTTP - TLS with mTLS (client cert authentication) supported.
 * {{< check_yes >}} gRPC - TLS with mTLS (client cert authentication) supported.
   * Covers both span export and sampling configuration querying.
-
-## Agent to Collector
-
-{{< warning >}}
-**jaeger-agent** is [deprecated](https://github.com/jaegertracing/jaeger/issues/4739).
-{{< /warning >}}
-
-* {{< check_yes >}} gRPC - TLS with client cert authentication supported.
 
 ## Collector/Ingester/Query-Service to Storage
 

--- a/content/docs/next-release/windows.md
+++ b/content/docs/next-release/windows.md
@@ -5,17 +5,6 @@ hasparent: true
 
 In Windows environments, Jaeger processes can be hosted and managed as Windows services controlled via the `sc` utility.  To configure such services on Windows, download [nssm.exe](https://nssm.cc/download) for the appropriate architecture, and issue commands similar to how Jaeger is typically run.  The example below showcases a basic Elasticsearch setup, configured using both environment variables and process arguments.
 
-## Agent
-```bat
-nssm install JaegerAgent C:\Jaeger\jaeger-agent.exe --reporter.grpc.host-port=localhost:14250
-
-nssm set JaegerAgent AppStdout C:\Jaeger\jaeger-agent.out.log
-nssm set JaegerAgent AppStderr C:\Jaeger\jaeger-agent.err.log
-nssm set JaegerAgent Description Jaeger Agent service
-
-nssm start JaegerAgent
-```
-
 ## Collector
 ```bat
 nssm install JaegerCollector C:\Jaeger\jaeger-collector.exe --es.server-urls=http://localhost:9200 --es.username=jaeger --es.password=PASSWORD


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of https://github.com/jaegertracing/jaeger/issues/4739

## Description of the changes
- Remove references to `jaeger-agent` everywhere except FAQ and Operator
- Operator page needs to be cleaned-up separately, perhaps it needs changes in the operator to support OTEL Collector as the agent

## How was this change tested?
- CI
