### PR TITLE
Fix footer covering sidebar menu

### DIFF
--- a/themes/jaeger-docs/assets/sass/article.sass
+++ b/themes/jaeger-docs/assets/sass/article.sass
@@ -10,14 +10,27 @@
       li a
         font-size: 1.5rem
 
+    &.article--docs
+    .container
+      &.is-fluid
+        position: relative
+        top: 0
+        padding: 0
+        margin: auto
+       
+  &.is-2.is-hidden-touch
+    position: sticky
+    top: 0vh
+    height: 100vh
+    padding: 0
+    width: fit-content
+
   &.article--docs, &.article--download, &.article--terms
     .is-size-1
       line-height: 125%
 
     +touch
       padding: 0 7%
-
-    margin-top: 2rem
 
     .is-8
       padding: 0 1rem
@@ -64,3 +77,10 @@
 
   &.article--docs, &.article--download
     margin: 3rem 0 10rem 0
+
+// Changed 2 - *2 merged
+.container
+  &.is-fluid
+    position: relative
+    top: 0
+    padding: 0

--- a/themes/jaeger-docs/assets/sass/pages.sass
+++ b/themes/jaeger-docs/assets/sass/pages.sass
@@ -49,13 +49,14 @@
   &--docs
     /* Left-hand documentation nav */
     .nav-wrapper
-      position: fixed
-      bottom: 0%
-      top: 9rem
-      left: 3rem 
+      position: sticky
+      top: 25vh
+      padding: 0
+      height : 70vh
+      padding-left: 2rem
 
       .nav
-        position: absolute
+        position: unset
         z-index: 10
         min-width: 15rem
         max-width: 25rem
@@ -63,6 +64,7 @@
         overflow-y: scroll
         overflow-x: hidden
         height: 100%
+        margin-left : -7rem
 
         .nav-link
           a

--- a/themes/jaeger-docs/assets/sass/toc.sass
+++ b/themes/jaeger-docs/assets/sass/toc.sass
@@ -12,8 +12,9 @@ $left-border: 4px solid $jaeger-beige
 
 .toc
   z-index: 1
-  width: inherit
-  position: fixed
+  position: sticky
+  width: 100%
+  top: 30vh
   margin: 0
   padding: 0
 


### PR DESCRIPTION
## Which problem is this PR solving?
- fixes #745

## Description of the changes
- fixed footer covering sidebar menu
- fixed the text covered by the scroll bar

## How was this change tested?
- tested locally by running it using `make develop`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
