### PR TITLE
Add support for v2 in the release workflow

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,13 +1,21 @@
 name: Release
 
 on:
-  push:
-    branches: [ main ]
-    tags: ["release-*.*.*"]
+  workflow_dispatch:
+    inputs:
+      version_v1:
+        required: true
+        type: string
+        description: "Version number for v1 docs, in #.#.# format"
+
+      version_v2:
+        required: true
+        type: string
+        description: "Version number for v2 docs, in #.#.# format"
 
 jobs:
-  release:
-    if: ${{ github.repository == 'jaegertracing/documentation' && startsWith(github.ref, 'refs/tags/release-') }}
+  prepare-release:
+    if: ${{ github.repository == 'jaegertracing/documentation' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -25,12 +33,11 @@ jobs:
         git config user.email "jaegertracingbot+jaeger-tracing@googlegroups.com"
         # git config credential.helper "store --file=.git/credentials"
         # echo "https://${{ secrets.JAEGERTRACINGBOT_GITHUB_TOKEN }}" > .git/credentials
-        export RELEASE_TAG=${GITHUB_REF##*/}
-        ./scripts/release.sh
+        ./scripts/release.sh ${{ inputs.version_v1 }} ${{ inputs.version_v2 }}
 
     - name: GH CLI create PR
       run: |
-        export TAG=${GITHUB_REF##*/}
+        export TAG="${{ inputs.version_v2 }}/${{ inputs.version_v1 }}"
         git checkout -b gen-release-${TAG} # branch is need for GH CLI
         git push origin gen-release-${TAG} # branch has to be on remote  before PR is opened
         gh pr create --base main --title "Release ${TAG}" --body "Release ${TAG}. This PR is created from CI and is part of the release process."

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HUGO_THEME   = jaeger-docs
 THEME_DIR    := themes/$(HUGO_THEME)
 
 client-libs-docs:
-	@for d in $(shell ls -d content/docs/* | grep -v next-release-v2); do \
+	@for d in $(shell ls -d content/docs/* | grep -v next-release-v2 | grep -vE '2\.[0-9]+\.[0-9]+'); do \
 		cp content/_client_libs/client-libraries.md $$d/; \
 		cp content/_client_libs/client-features.md $$d/; \
 		echo "copied content/_client_libs/*.md -> $$d/"; \

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,33 +2,19 @@
 
 Each Jaeger version is documented in a separate directory e.g. [content/docs/1.8/](./content/docs/1.8/). A special directory [content/docs/next-release/](./content/docs/next-release/) is reserved for the changes to be published as the next version. If you are adding documentation for features that are not yet released in the main Jaeger repository, add your changes to the `next-release` directory. If you're adding documentation for already released features, you may need to make the same change twice, i.e. in the most recent release (e.g. `1.8`) and in the `next-release` directories.
 
+Jaeger v2 next-release documentation is in the `next-release-v2` directory.
+
 Before creating a new release:
 
   - Make sure all outstanding PRs for that version are merged to `next-release` directory.
   - Make sure the actual Jaeger release is done and Docker images for the new version are published.
   - If there are new Jaeger binaries or new storage options added to the release, make sure the CLI docs config file `data/cli/next-release/config.json` is updated accordingly (see below).
-  - Make sure you have git remote `upstream` pointing to the official repository, e.g.
-    `git remote add upstream git@github.com:jaegertracing/documentation.git`
-  - Make sure you are on your `main` branch.
 
-Then create a release by pushing a tag corresponding to the jaegertracing/jaeger version `release-X.Y.0`, e.g.
-
-```shell
-make start-release VERSION=1.12.0
-
-# or manually
-
-git tag release-1.12.0
-git push upstream release-1.12.0
-```
-
-  - Wait for the [CI job](https://github.com/jaegertracing/documentation/actions) to create a
-    [pull request](https://github.com/jaegertracing/documentation/pulls) with the documentation
-    changes for the new version.
+To create a new release:
+  - Manually trigger the [Release](https://github.com/jaegertracing/documentation/actions/workflows/ci-release.yml) workflow on GitHub. It will ask for v1 and v2 version numbers (same versions as in the main Jaeger repo), and create a
+[pull request](https://github.com/jaegertracing/documentation/pulls) with the documentation changes.
   - Approve and merge that pull request.
   - Because the site is statically generated, the release is completed after the merge.
-
-TODO: shouldn't the tag only specify major/minor, not patch? I don't think the process will work twice for the same major.minor
 
 ### Auto-generated documentation for CLI flags
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -68,7 +68,7 @@ gen_cli_docs_v1() {
 set -x
 safe_checkout_main
 
-for version in "${version_v1}" "${version_v1}"; do
+for version in "${version_v1}" "${version_v2}"; do
   versionMajorMinor=$(echo "${version}" | sed 's/\.[[:digit:]]$//')
   echo "Creating new documentation for ${version} (${versionMajorMinor})"
   var_suffix=""

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -95,5 +95,5 @@ if [[ "$DRY_RUN" = "true" ]]; then
   echo "Not committing changes because DRY_RUN=$DRY_RUN"
   exit 0
 fi
-git add config.toml ./content/docs/${versionMajorMinor} ./data/cli/${versionMajorMinor}
+git add config.toml ./content/docs/ ./data/cli/
 git commit -m "Release ${version}" -s

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -96,4 +96,4 @@ if [[ "$DRY_RUN" = "true" ]]; then
   exit 0
 fi
 git add config.toml ./content/docs/ ./data/cli/
-git commit -m "Release ${version}" -s
+git commit -m "Release ${version_v2}/${version_v1}" -s

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -77,8 +77,7 @@ for version in "${version_v1}" "${version_v2}"; do
     var_suffix="V2"
   else
     cp -r ./content/docs/next-release/ ./content/docs/${versionMajorMinor}
-    # @nocommit skip this
-    # gen_cli_docs_v1 ${versionMajorMinor}
+    gen_cli_docs_v1 ${versionMajorMinor}
   fi
 
   versions=$(grep -E "versions${var_suffix} *=" config.toml)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -21,13 +21,13 @@ fi
 if [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   version_v1="$1"
 else
-  echo "🔴 ERROR: Version $1 is not in in major.minor.patch format."
+  echo "🔴 ERROR: Version $1 is not in a major.minor.patch format."
   print_usage
 fi
 if [[ "$2" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   version_v2="$2"
 else
-  echo "🔴 ERROR: Version $2 is not in in major.minor.patch format."
+  echo "🔴 ERROR: Version $2 is not in a major.minor.patch format."
   print_usage
 fi
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Prepares a pull request for the next release.
-# Set environment varibale DRY_RUN=true to skip committing the changes.
+# Set environment variable DRY_RUN=true to skip committing the changes.
 
 set -euf -o errexit -o pipefail
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,14 +1,46 @@
 #!/usr/bin/env bash
 
-set -x -o errexit -o pipefail
+# Copyright (c) 2024 The Jaeger Authors.
+# SPDX-License-Identifier: Apache-2.0
 
-checkoutBranch=main
+# Prepares a pull request for the next release.
+# Set environment varibale DRY_RUN=true to skip committing the changes.
+
+set -euf -o errexit -o pipefail
+
+print_usage() {
+  echo "Usage: $0 <version_v1> <version_v2>"
+  echo "  Both versions must be in #.#.# format (major, minor, patch)"
+  exit 1
+}
+
+if [ "$#" -ne 2 ]; then
+  print_usage
+fi
+
+if [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  version_v1="$1"
+else
+  echo "🔴 ERROR: Version $1 is not in in major.minor.patch format."
+  print_usage
+fi
+if [[ "$2" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  version_v2="$2"
+else
+  echo "🔴 ERROR: Version $2 is not in in major.minor.patch format."
+  print_usage
+fi
 
 safe_checkout_main() {
   # We need to be on a branch to be able to create commits,
   # and we want that branch to be main, which has been checked before.
   # But we also want to make sure that we build and release exactly the tagged version, so we verify that the remote
   # branch is where our tag is.
+  local checkoutBranch=main
+  if [[ "$DRY_RUN" = "true" ]]; then
+    echo "Skipping branch validation"
+    return
+  fi
   git remote -v
   git checkout -B "${checkoutBranch}"
   git fetch origin "${checkoutBranch}":origin/"${checkoutBranch}"
@@ -20,33 +52,49 @@ safe_checkout_main() {
   fi
 }
 
-if [[ "$RELEASE_TAG" =~ ^release-[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+?$ ]]; then
-    echo "We are on release-x.y.z tag: $RELEASE_TAG"
-    safe_checkout_main
-    version=$(echo "${RELEASE_TAG}" | sed 's/^release-//')
-    versionMajorMinor=$(echo "${version}" | sed 's/\.[[:digit:]]$//')
-    echo "Creating new documentation for ${version}"
-    cp -r ./content/docs/next-release/ ./content/docs/${versionMajorMinor}
+gen_cli_docs_v1() {
+  local versionMajorMinor=$1
+  # we set this as a temp dir with write permissions to everyone to overcome #441
+  # we then set the permissions back to sane levels once we are done
+  cliDocsTempDir=$(mktemp -d -t cli-docs-XXXXXXXX)
+  mkdir -p ${cliDocsTempDir}/data/cli
+  cp -r ./data/cli/next-release/ ${cliDocsTempDir}/data/cli/${versionMajorMinor}
+  chmod -R a+w ${cliDocsTempDir}
+  python ./scripts/gen-cli-data.py ${versionMajorMinor} ${cliDocsTempDir}
+  rm -f ${cliDocsTempDir}/data/cli/${versionMajorMinor}/*_completion_*.yaml
+  mv ${cliDocsTempDir}/data/cli/${versionMajorMinor} ./data/cli/
+}
 
-    # we set this as a temp dir with write permissions to everyone to overcome #441
-    # we then set the permissions back to sane levels once we are done
-    cliDocsTempDir=$(mktemp -d -t cli-docs-XXXXXXXX)
-    mkdir -p ${cliDocsTempDir}/data/cli
-    cp -r ./data/cli/next-release/ ${cliDocsTempDir}/data/cli/${versionMajorMinor}
-    chmod a+w -R ${cliDocsTempDir}
-    python ./scripts/gen-cli-data.py ${versionMajorMinor} ${cliDocsTempDir}
-    rm -f ${cliDocsTempDir}/data/cli/${versionMajorMinor}/*_completion_*.yaml
-    mv ${cliDocsTempDir}/data/cli/${versionMajorMinor} ./data/cli/
-    sed -i -e "s/latest *=.*$/latest = \"${versionMajorMinor}\"/" config.toml
-    sed -i -e "s/binariesLatest *=.*$/binariesLatest = \"${version}\"/" config.toml
-    sed -i -e "s/versions *= *\[/versions = \[\"${versionMajorMinor}\"\,/" config.toml
-    if [[ "$DRY_RUN" = "true" ]]; then
-      echo "Not committing changes because DRY_RUN=$DRY_RUN"
-      exit 0
-    fi
-    git add config.toml ./content/docs/${versionMajorMinor} ./data/cli/${versionMajorMinor}
-    git commit -m "Release ${version}" -s
-else
-    echo "RELEASE_TAG=$RELEASE_TAG is not in the form release-x.y.z, skipping release"
+set -x
+safe_checkout_main
+
+for version in "${version_v1}" "${version_v1}"; do
+  versionMajorMinor=$(echo "${version}" | sed 's/\.[[:digit:]]$//')
+  echo "Creating new documentation for ${version} (${versionMajorMinor})"
+  var_suffix=""
+  if [[ "${versionMajorMinor}" == 2* ]]; then
+    cp -r ./content/docs/next-release-v2/ ./content/docs/${versionMajorMinor}
+    var_suffix="V2"
+  else
+    cp -r ./content/docs/next-release/ ./content/docs/${versionMajorMinor}
+    # @nocommit skip this
+    # gen_cli_docs_v1 ${versionMajorMinor}
+  fi
+
+  versions=$(grep -E "versions${var_suffix} *=" config.toml)
+  if [[ "$versions" == *"$versionMajorMinor"* ]]; then
+    echo "🔴 ERROR: Version ${versionMajorMinor} is already included in the versions list."
     exit 1
+  fi
+
+  sed -i -e "s/latest${var_suffix} *=.*$/latest${var_suffix} = \"${versionMajorMinor}\"/" config.toml
+  sed -i -e "s/binariesLatest${var_suffix} *=.*$/binariesLatest${var_suffix} = \"${version}\"/" config.toml
+  sed -i -e "s/versions${var_suffix} *= *\[/versions${var_suffix} = \[\"${versionMajorMinor}\"\,/" config.toml
+done
+
+if [[ "$DRY_RUN" = "true" ]]; then
+  echo "Not committing changes because DRY_RUN=$DRY_RUN"
+  exit 0
 fi
+git add config.toml ./content/docs/${versionMajorMinor} ./data/cli/${versionMajorMinor}
+git commit -m "Release ${version}" -s


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #731

## Description of the changes
- Change release GH workflow from automatic to manual trigger
- Add support for dual v1/v2 release

## How was this change tested?
```
$ DRY_RUN=true bash5 scripts/release.sh 1.64.0 2.0.0
+ safe_checkout_main
+ local checkoutBranch=main
+ [[ true = \t\r\u\e ]]
+ echo 'Skipping branch validation'
Skipping branch validation
+ return
+ for version in "${version_v1}" "${version_v2}"
++ echo 1.64.0
++ sed 's/\.[[:digit:]]$//'
+ versionMajorMinor=1.64
+ echo 'Creating new documentation for 1.64.0 (1.64)'
Creating new documentation for 1.64.0 (1.64)
+ var_suffix=
+ [[ 1.64 == 2* ]]
+ cp -r ./content/docs/next-release/ ./content/docs/1.64
++ grep -E 'versions *=' config.toml
+ versions='  versions = ["1.62","1.61","1.60","1.59","1.58","1.57","1.56","1.55","1.54","1.53","1.52"]'
+ [[   versions = ["1.62","1.61","1.60","1.59","1.58","1.57","1.56","1.55","1.54","1.53","1.52"] == *\1\.\6\4* ]]
+ sed -i -e 's/latest *=.*$/latest = "1.64"/' config.toml
+ sed -i -e 's/binariesLatest *=.*$/binariesLatest = "1.64.0"/' config.toml
+ sed -i -e 's/versions *= *\[/versions = \["1.64"\,/' config.toml
+ for version in "${version_v1}" "${version_v2}"
++ echo 2.0.0
++ sed 's/\.[[:digit:]]$//'
+ versionMajorMinor=2.0
+ echo 'Creating new documentation for 2.0.0 (2.0)'
Creating new documentation for 2.0.0 (2.0)
+ var_suffix=
+ [[ 2.0 == 2* ]]
+ cp -r ./content/docs/next-release-v2/ ./content/docs/2.0
+ var_suffix=V2
++ grep -E 'versionsV2 *=' config.toml
+ versions='  versionsV2 = []'
+ [[   versionsV2 = [] == *\2\.\0* ]]
+ sed -i -e 's/latestV2 *=.*$/latestV2 = "2.0"/' config.toml
+ sed -i -e 's/binariesLatestV2 *=.*$/binariesLatestV2 = "2.0.0"/' config.toml
+ sed -i -e 's/versionsV2 *= *\[/versionsV2 = \["2.0"\,/' config.toml
+ [[ true = \t\r\u\e ]]
+ echo 'Not committing changes because DRY_RUN=true'
Not committing changes because DRY_RUN=true
+ exit 0
```