### PR TITLE
Corrected the URL for jaegar-operator.yaml file 

### DIFF
--- a/content/docs/1.62/operator.md
+++ b/content/docs/1.62/operator.md
@@ -69,7 +69,7 @@ Make sure your `kubectl` command is properly configured to talk to a valid Kuber
 To install the operator, run:
 ```bash
 kubectl create namespace observability # <1>
-kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/download/v{{< currentVersion >}}.0/jaeger-operator.yaml -n observability # <2>
+kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/download/v{{< currentVersion >}}/jaeger-operator.yaml -n observability # <2>
 ```
 <1> This creates the namespace used by default in the deployment files. If you want to install the Jaeger operator in a different namespace, you must edit the deployment files to change `observability` to the desired namespace value.
 
@@ -98,7 +98,7 @@ The instructions from the previous section also work for installing the operator
 oc login -u <privileged user>
 
 oc new-project observability # <1>
-oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/v{{< currentVersion >}}.0/jaeger-operator.yaml -n observability # <2>
+oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/v{{< currentVersion >}}/jaeger-operator.yaml -n observability # <2>
 ```
 <1> This creates the namespace used by default in the deployment files. If you want to install the Jaeger operator in a different namespace, you must edit the deployment files to change `observability` to the desired namespace value.
 
@@ -1457,5 +1457,5 @@ The Jaeger Operator does not yet publish its own metrics. Rather, it makes avail
 To uninstall the operator, run the following commands:
 
 ```bash
-kubectl delete -n observability -f https://github.com/jaegertracing/jaeger-operator/releases/download/v{{< currentVersion >}}.0/jaeger-operator.yaml
+kubectl delete -n observability -f https://github.com/jaegertracing/jaeger-operator/releases/download/v{{< currentVersion >}}/jaeger-operator.yaml
 ```

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -20,7 +20,7 @@ While we intend to have the Jaeger Operator working for as many Kubernetes versi
 While multiple operators might coexist watching the same set of namespaces, which operator will succeed in setting itself as the owner of the CR is undefined behavior. Automatic injection of the sidecars might also result in undefined behavior. Therefore, it's highly recommended to have at most one operator watching each namespace. Note that namespaces might contain any number of Jaeger instances (CRs).
 
 {{< info >}}
-The Jaeger Operator version tracks one version of the Jaeger components (**jaeger-query**, **jaeger-collector**, **jaeger-agent**). When a new version of the Jaeger components is released, a new version of the operator will be released that understands how running instances of the previous version can be upgraded to the new version.
+The Jaeger Operator version tracks one version of the Jaeger components (**jaeger-query**, **jaeger-collector**). When a new version of the Jaeger components is released, a new version of the operator will be released that understands how running instances of the previous version can be upgraded to the new version.
 {{< /info >}}
 
 ## Prerequisite
@@ -119,7 +119,7 @@ After the role is granted, switch back to a non-privileged user.
 
 # Quick Start - Deploying the AllInOne image
 
-The simplest possible way to create a Jaeger instance is by creating a YAML file like the following example.  This will install the default AllInOne strategy, which deploys the **all-in-one** image (combining **jaeger-agent**, **jaeger-collector**, **jaeger-query**, and Jaeger UI) in a single pod, using in-memory storage by default.
+The simplest possible way to create a Jaeger instance is by creating a YAML file like the following example.  This will install the default AllInOne strategy, which deploys the **all-in-one** image (combining **jaeger-collector**, **jaeger-query**, and Jaeger UI) in a single pod, using in-memory storage by default.
 
 {{< info >}}
 This default strategy is intended for development, testing, and demo purposes, not for production.
@@ -240,7 +240,7 @@ The available strategies are described in the following sections.
 
 This strategy is intended for development, testing, and demo purposes.
 
-The main backend components,**jaeger-agent**, **jaeger-collector** and **jaeger-query** service, are all packaged into a single executable which is configured (by default) to use in-memory storage. This strategy cannot be scaled beyond one replica.
+The main backend components, **jaeger-collector** and **jaeger-query** service, are all packaged into a single executable which is configured (by default) to use in-memory storage. This strategy cannot be scaled beyond one replica.
 
 ## Production strategy
 

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -20,7 +20,7 @@ While we intend to have the Jaeger Operator working for as many Kubernetes versi
 While multiple operators might coexist watching the same set of namespaces, which operator will succeed in setting itself as the owner of the CR is undefined behavior. Automatic injection of the sidecars might also result in undefined behavior. Therefore, it's highly recommended to have at most one operator watching each namespace. Note that namespaces might contain any number of Jaeger instances (CRs).
 
 {{< info >}}
-The Jaeger Operator version tracks one version of the Jaeger components (**jaeger-query**, **jaeger-collector**). When a new version of the Jaeger components is released, a new version of the operator will be released that understands how running instances of the previous version can be upgraded to the new version.
+The Jaeger Operator version tracks one version of the Jaeger components (**jaeger-query**, **jaeger-collector**, **jaeger-agent**). When a new version of the Jaeger components is released, a new version of the operator will be released that understands how running instances of the previous version can be upgraded to the new version.
 {{< /info >}}
 
 ## Prerequisite
@@ -69,7 +69,7 @@ Make sure your `kubectl` command is properly configured to talk to a valid Kuber
 To install the operator, run:
 ```bash
 kubectl create namespace observability # <1>
-kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/download/v{{< currentVersion >}}.0/jaeger-operator.yaml -n observability # <2>
+kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/download/v{{< currentVersion >}}/jaeger-operator.yaml -n observability # <2>
 ```
 <1> This creates the namespace used by default in the deployment files. If you want to install the Jaeger operator in a different namespace, you must edit the deployment files to change `observability` to the desired namespace value.
 
@@ -98,7 +98,7 @@ The instructions from the previous section also work for installing the operator
 oc login -u <privileged user>
 
 oc new-project observability # <1>
-oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/v{{< currentVersion >}}.0/jaeger-operator.yaml -n observability # <2>
+oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/v{{< currentVersion >}}/jaeger-operator.yaml -n observability # <2>
 ```
 <1> This creates the namespace used by default in the deployment files. If you want to install the Jaeger operator in a different namespace, you must edit the deployment files to change `observability` to the desired namespace value.
 
@@ -119,7 +119,7 @@ After the role is granted, switch back to a non-privileged user.
 
 # Quick Start - Deploying the AllInOne image
 
-The simplest possible way to create a Jaeger instance is by creating a YAML file like the following example.  This will install the default AllInOne strategy, which deploys the **all-in-one** image (combining **jaeger-collector**, **jaeger-query**, and Jaeger UI) in a single pod, using in-memory storage by default.
+The simplest possible way to create a Jaeger instance is by creating a YAML file like the following example.  This will install the default AllInOne strategy, which deploys the **all-in-one** image (combining **jaeger-agent**, **jaeger-collector**, **jaeger-query**, and Jaeger UI) in a single pod, using in-memory storage by default.
 
 {{< info >}}
 This default strategy is intended for development, testing, and demo purposes, not for production.
@@ -240,7 +240,7 @@ The available strategies are described in the following sections.
 
 This strategy is intended for development, testing, and demo purposes.
 
-The main backend components, **jaeger-collector** and **jaeger-query** service, are all packaged into a single executable which is configured (by default) to use in-memory storage. This strategy cannot be scaled beyond one replica.
+The main backend components,**jaeger-agent**, **jaeger-collector** and **jaeger-query** service, are all packaged into a single executable which is configured (by default) to use in-memory storage. This strategy cannot be scaled beyond one replica.
 
 ## Production strategy
 
@@ -1457,5 +1457,5 @@ The Jaeger Operator does not yet publish its own metrics. Rather, it makes avail
 To uninstall the operator, run the following commands:
 
 ```bash
-kubectl delete -n observability -f https://github.com/jaegertracing/jaeger-operator/releases/download/v{{< currentVersion >}}.0/jaeger-operator.yaml
+kubectl delete -n observability -f https://github.com/jaegertracing/jaeger-operator/releases/download/v{{< currentVersion >}}/jaeger-operator.yaml
 ```


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #768 

## Description of the changes
- To fix the URL in content/docs/1.62/operator.md, remove the extra .0 after {{< currentVersion >}} in the jaeger-operator.yaml URL. The {{< currentVersion >}} already includes the full version (major.minor.patch), so adding .0 results in an incorrect URL. This change resolves the 404 error.

## How was this change tested?

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits