### PR TITLE
Make v2 docs the default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HUGO_THEME   = jaeger-docs
 THEME_DIR    := themes/$(HUGO_THEME)
 
 client-libs-docs:
-	@for d in $(shell ls -d content/docs/* | grep -v next-release-v2 | grep -vE '2\.[0-9]+\.[0-9]+'); do \
+	@for d in $(shell ls -d content/docs/* | grep -v next-release-v2 | grep -vE '2\.[0-9]+'); do \
 		cp content/_client_libs/client-libraries.md $$d/; \
 		cp content/_client_libs/client-features.md $$d/; \
 		echo "copied content/_client_libs/*.md -> $$d/"; \

--- a/content/docs/next-release-v2/getting-started.md
+++ b/content/docs/next-release-v2/getting-started.md
@@ -17,14 +17,10 @@ docker run --rm --name jaeger \
   -p 14250:14250 \
   -p 14268:14268 \
   -p 9411:9411 \
-  jaegertracing/jaeger:{{< currentVersion >}} \
-  --set receivers.otlp.protocols.http.endpoint=0.0.0.0:4318 \
-  --set receivers.otlp.protocols.grpc.endpoint=0.0.0.0:4317
+  jaegertracing/jaeger:{{< currentVersion >}}
 ```
 
 This runs the "all-in-one" configuration of Jaeger (using a configuration file embedded in the binary) that combines collector and query components in a single process and uses a transient in-memory storage for trace data. You can navigate to `http://localhost:16686` to access the Jaeger UI. See the [APIs page](../apis/) for a list of other exposed ports.
-
-Note: the `--set` flags are necessary because by default OTLP receiver listens on `localhost` and therefore is not accessible from the host network even with port mappings. In the future versions the default will be changed to `0.0.0.0`.
 
 ## Instrumentation
 

--- a/content/download/_index.md
+++ b/content/download/_index.md
@@ -5,11 +5,11 @@ title: Download Jaeger
 Jaeger components can be downloaded in two ways:
 
 * As [executable binaries](#binaries)
-* As [Docker images](#docker-images)
+* As [container images](#docker-images)
 
-## Try Jaeger v2
+## Try Jaeger v2 🎉
 
-Jaeger v2 executable can be found in the latest [GitHub release](https://github.com/jaegertracing/jaeger/releases/) or as a Docker image [jaegertracing/jaeger](https://hub.docker.com/r/jaegertracing/jaeger/tags).
+_November 12, 2024_: Jaeger v2 is a new major release based on the OpenTelemetry Collector framework. Read [the blog post](https://medium.com/jaegertracing/jaeger-v2-released-09a6033d1b10) for more details.
 
 ## Binaries
 
@@ -19,9 +19,9 @@ Jaeger binaries are available for macOS, Linux, and Windows. The table below lis
 
 You can find the binaries for previous versions on the [GitHub releases page](https://github.com/jaegertracing/jaeger/releases/).
 
-## Docker images
+## Container images
 
-The following Docker images are available for the Jaeger project via the `jaegertracing` organization on [Docker Hub](https://hub.docker.com/r/jaegertracing/) and [Quay.io](https://quay.io/organization/jaegertracing):
+The following container images are available for the Jaeger project via the `jaegertracing` organization on [Docker Hub](https://hub.docker.com/r/jaegertracing/) and [Quay.io](https://quay.io/organization/jaegertracing):
 
 {{< dockerImages >}}
 

--- a/data/download.yaml
+++ b/data/download.yaml
@@ -10,37 +10,53 @@ binaries:
       name: Windows
       icon: fa-windows
 docker:
+- image: jaeger
+  description: The only binary you need to run Jaeger v2.
+  since: "2.0"
+  major: v2
 - image: all-in-one
   description: Designed for quick local testing. It launches the Jaeger UI, collector, query, and agent, with an in-memory storage component.
   since: 0.8
+  major: v1
 - image: example-hotrod
   description: Sample application "[HotROD](https://github.com/jaegertracing/jaeger/tree/main/examples/hotrod)" that demonstrates features of distributed tracing ([blog post](https://medium.com/@YuriShkuro/take-opentracing-for-a-hotrod-ride-f6e3141f7941)).
   since: 1.6
-- image: jaeger-agent
-  description: (deprecated) Receives spans from Jaeger clients and forwards to collector. Designed to run as a sidecar or a host agent. **jaeger-agent** is deprecated and no longer recommended for use, see https://github.com/jaegertracing/jaeger/issues/4739.
-  since: 0.8
+  major: v1
 - image: jaeger-collector
   description: Receives spans from agents or directly from clients and saves them in persistent storage.
   since: 0.8
+  major: v1
 - image: jaeger-query
   description: Serves Jaeger UI and an API that retrieves traces from storage.
   since: 0.8
+  major: v1
 - image: jaeger-ingester
   description: An alternative to collector; reads spans from Kafka topic and saves them to storage.
   since: 1.7
+  major: v1
 - image: jaeger-remote-storage
   description: A service that implements the Remote Storage API on top of another supported backend. Can be used to share a single-node storage backend, like `memory`, across multiple Jaeger processes.
   since: 1.37
+  major: v1
 - image: spark-dependencies
   description: An [Apache Spark](http://spark.apache.org/) job that collects Jaeger spans from storage, analyzes links between services, and stores them for later presentation in the Jaeger UI
   latest: latest
   since: 1.3
+  major: v1
 - image: jaeger-operator
   description: A [Kubernetes Operator](https://github.com/operator-framework) for packaging, deploying, and managing Jaeger installation.
   since: 1.6
+  major: v1
 - image: jaeger-cassandra-schema
   description: A utility script used to initialize Cassandra keyspace and schema.
   since: 0.8
+  major: v1
 - image: jaeger-es-index-cleaner
   description: A utility script used to purge old indices from Elasticsearch, since ES does not support data TTL.
   since: 1.3
+  major: v1
+- image: jaeger-agent
+  description: Receives spans from Jaeger clients and forwards to collector. Designed to run as a sidecar or a host agent. **jaeger-agent** is deprecated and no longer recommended for use, see https://github.com/jaegertracing/jaeger/issues/4739.
+  since: 0.8
+  until: 1.62
+  major: v1

--- a/themes/basetheme/layouts/shortcodes/binaries.html
+++ b/themes/basetheme/layouts/shortcodes/binaries.html
@@ -1,8 +1,5 @@
-{{ $latest        := .Site.Params.binariesLatest }}
+{{ $latestXXX        := .Site.Params.binariesLatest }}
 {{ $binaries      := .Site.Data.download.binaries }}
-{{ $releaseUrl    := printf "https://github.com/jaegertracing/jaeger/releases/tag/v%s" $latest }}
-{{ $zipUrl        := printf "https://github.com/jaegertracing/jaeger/archive/v%s.zip" $latest }}
-{{ $tarUrl        := printf "https://github.com/jaegertracing/jaeger/archive/v%s.tar.gz" $latest }}
 {{ $platforms     := $binaries.platforms }}
 <table class="table is-striped">
   <thead>
@@ -16,6 +13,11 @@
     </tr>
   </thead>
   <tbody>
+  {{ $versions := slice .Site.Params.binariesLatestV2 .Site.Params.binariesLatest }}
+  {{ range $latest := $versions }}
+    {{ $releaseUrl    := printf "https://github.com/jaegertracing/jaeger/releases/tag/v%s" $latest }}
+    {{ $zipUrl        := printf "https://github.com/jaegertracing/jaeger/archive/v%s.zip" $latest }}
+    {{ $tarUrl        := printf "https://github.com/jaegertracing/jaeger/archive/v%s.tar.gz" $latest }}
     <tr>
       <td>
         <strong>
@@ -63,5 +65,6 @@
         </p>
       </td>
     </tr>
+  {{ end }}
   </tbody>
 </table>

--- a/themes/basetheme/layouts/shortcodes/dockerImages.html
+++ b/themes/basetheme/layouts/shortcodes/dockerImages.html
@@ -1,23 +1,25 @@
 {{ $dockerImages := site.Data.download.docker }}
-{{ $latest       := site.Params.binariesLatest }}
+{{ $latestV1       := site.Params.binariesLatest }}
+{{ $latestV2       := site.Params.binariesLatestV2 }}
 <table>
   <thead>
     <tr>
       <th>Image</th>
+      <th>Major</th>
       <th>Description</th>
       <th>Since version</th>
     </tr>
   </thead>
   <tbody>
     {{ range $dockerImages }}
-    {{ $org         := "jaegertracing" }}
-    {{ $image       := .image }}
-    {{ $fullImage   := printf "%s/%s" $org $image }}
-    {{ $link        := printf "https://hub.docker.com/r/%s/%s" $org $image }}
-    {{ $description := .description | markdownify }}
-    {{ $since       := .since }}
-    {{ $latestImg   := .latest | default $latest }}
-    {{ $pullCmd     := printf "<code><span class=\"is-dollar\">$</span> docker pull %s:%s</code>" $fullImage $latestImg | safeHTML }}
+    {{ $org       := "jaegertracing" }}
+    {{ $image     := .image }}
+    {{ $major     := .major }}
+    {{ $fullImage := printf "%s/%s" $org $image }}
+    {{ $link      := printf "https://hub.docker.com/r/%s/%s" $org $image }}
+    {{ $since     := .since }}
+    {{ $latest    := cond (eq $major "v2") $latestV2 $latestV1}}
+    {{ $latestImg := .until | default $latest }}
     <tr>
       <td>
         <a href="{{ $link }}">
@@ -25,13 +27,18 @@
         </a>
       </td>
       <td>
-        {{ with $description }}
-        <p>
-          {{ . }}
-        </p>
+        {{ $major }}
+      </td>
+      <td>
+        {{ if .until }}
+          <p>Deprecated 💀💤❌. Latest available version is {{ $latestImg }}.</p>
         {{ end }}
+        <p>{{ .description | markdownify }}</p>
         <div>
-          {{ $pullCmd }}
+          <code><span class="is-dollar">$</span> docker run {{ $fullImage }}:{{ $latestImg }} --help</code>
+        </div>
+        <div>
+          <code><span class="is-dollar">$</span> podman run quay.io/{{ $fullImage }}:{{ $latestImg }} --help</code>
         </div>
       </td>
       <td>

--- a/themes/jaeger-docs/layouts/index.html
+++ b/themes/jaeger-docs/layouts/index.html
@@ -32,7 +32,7 @@
   {{ warnf "Post: %v" $v.title }}
 {{ end }}
 
-{{ partial "home/hero.html" (dict "posts" $posts "title" site.Title "tagline" site.Params.tagline "latestVersion" site.Params.latest) }}
+{{ partial "home/hero.html" (dict "posts" $posts "title" site.Title "tagline" site.Params.tagline "latestVersion" site.Params.latestV2) }}
 {{ partial "home/why.html" . }}
 {{ partial "home/features.html" . }}
 {{ partial "home/articles.html" (dict "posts" $posts "imgLinks" $imgLinks) }}

--- a/themes/jaeger-docs/layouts/partials/navbar.html
+++ b/themes/jaeger-docs/layouts/partials/navbar.html
@@ -77,8 +77,7 @@
               {{ $docVersion := index (split $docPath "/") 1 }}
               <!-- When generating Docs menu for home page, use the latest version, -->
               <!-- when generating menu for pages inside docs/, use same version as the doc -->
-              <!-- TODO: replace with $latestV2 once 2.0 is released -->
-              {{ $matchVersion := cond ($isDocsPage) $majorMinorVersion $latestV1 }}
+              {{ $matchVersion := cond ($isDocsPage) $majorMinorVersion $latestV2 }}
               {{ if and (eq $docVersion $matchVersion) (not .Params.hasparent) }}
                 <a class="navbar-item" href="{{ .RelPermalink }}">
                   {{ .Title }}
@@ -86,8 +85,7 @@
 
                 {{ with .Params.children }}
                   {{ range . }}
-                    <!-- TODO: replace with $latestV2 once 2.0 is released -->
-                    {{ $url := cond $isDocsPage (printf "/docs/%s/%s" $majorMinorVersion .url) (printf "/docs/%s/%s" $latestV1 .url) }}
+                    {{ $url := cond $isDocsPage (printf "/docs/%s/%s" $majorMinorVersion .url) (printf "/docs/%s/%s" $latestV2 .url) }}
                     <a class="navbar-item is-small is-hidden-desktop" href="{{ $url }}">
                       &cir; {{ if .navtitle }}{{ .navtitle }}{{ else }}{{ .title }}{{ end }}
                     </a>


### PR DESCRIPTION
## Description of the changes
- Link home page to v2 docs instead of v1
- Make the navbar Docs menu point to v2 instead of v1
- Update Download page to show v2 binaries
- Fix Makefile bug that was copying client* md files into v2 folders
- Remove 0.0.0.0 overrides from Getting Started as it was fixed for 2.1

## How was this change tested?
- make develop
