### PR TITLE
Remove dollar/prompt sign from code blocks

### DIFF
--- a/content/docs/next-release-v2/apis.md
+++ b/content/docs/next-release-v2/apis.md
@@ -136,13 +136,13 @@ Please refer to the [SPM Documentation](../spm/#api)
 Service ports that serve gRPC endpoints enable [gRPC reflection][grpc-reflection]. Unfortunately, the internally used `gogo/protobuf` has a [compatibility issue][gogo-reflection] with the official `golang/protobuf`, and as a result only the `list` reflection command is currently working properly, for example:
 
 ```shell
-$ grpc_cli ls localhost:16685
-grpc.health.v1.Health
-grpc.reflection.v1.ServerReflection
-grpc.reflection.v1alpha.ServerReflection
-jaeger.api_v2.QueryService
-jaeger.api_v2.metrics.MetricsQueryService
-jaeger.api_v3.QueryService
+grpc_cli ls localhost:16685
+  grpc.health.v1.Health
+  grpc.reflection.v1.ServerReflection
+  grpc.reflection.v1alpha.ServerReflection
+  jaeger.api_v2.QueryService
+  jaeger.api_v2.metrics.MetricsQueryService
+  jaeger.api_v3.QueryService
 ```
 
 [otlp.grpc]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlpgrpc

--- a/content/docs/next-release-v2/spm.md
+++ b/content/docs/next-release-v2/spm.md
@@ -248,7 +248,7 @@ service:
 The `/metrics` endpoint on this port can be used to check if UI queries for SPM data are successful: 
 
 ```shell
-$ curl -s http://jaeger:8888/metrics | grep jaeger_metricstore
+curl -s http://jaeger:8888/metrics | grep jaeger_metricstore
 ```
 
 The following metrics are of most interest:


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #495

## Description of the changes
- Only in v2 docs, remove remaining places that use `$` prefix
