### PR TITLE
[chore] Fix references to `plugin/storage`

### DIFF
--- a/content/docs/next-release-v2/apis.md
+++ b/content/docs/next-release-v2/apis.md
@@ -171,4 +171,4 @@ grpc_cli ls localhost:16685
 [sampling.proto]: https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v2/sampling.proto
 [grpc-reflection]: https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md#enable-server-reflection
 [gogo-reflection]: https://jbrandhorst.com/post/gogoproto/#reflection
-[storage.proto]: https://github.com/jaegertracing/jaeger/blob/main/plugin/storage/grpc/proto/storage.proto
+[storage.proto]: https://github.com/jaegertracing/jaeger/blob/main/internal/storage/v1/grpc/proto/storage.proto

--- a/content/docs/next-release-v2/badger.md
+++ b/content/docs/next-release-v2/badger.md
@@ -19,4 +19,4 @@ See [sample configuration](https://github.com/jaegertracing/jaeger/blob/main/cmd
 
 ## Troubleshooting
 
-* [Badger file permissions as non-root service](https://github.com/jaegertracing/jaeger/blob/main/plugin/storage/badger/docs/storage-file-non-root-permission.md)
+* [Badger file permissions as non-root service](https://github.com/jaegertracing/jaeger/blob/main/internal/storage/v1/badger/docs/storage-file-non-root-permission.md)

--- a/content/docs/next-release-v2/cassandra.md
+++ b/content/docs/next-release-v2/cassandra.md
@@ -39,10 +39,10 @@ extensions:
 
 It is recommended to customize these values to match your needs, for example, for longer retention or higher replication factor.
 
-If `schema.create` is set to `false`, the schema must be initialized manually. There is a script in the [jaeger](https://github.com/jaegertracing/jaeger/blob/main/plugin/storage/cassandra/schema/create.sh) repository that generates the initialization instruction that can be executed using Cassandra's interactive shell [cqlsh][cqlsh]:
+If `schema.create` is set to `false`, the schema must be initialized manually. There is a script in the [jaeger](https://github.com/jaegertracing/jaeger/blob/main/internal/storage/v1/cassandra/schema/create.sh) repository that generates the initialization instruction that can be executed using Cassandra's interactive shell [cqlsh][cqlsh]:
 
 ```sh
-MODE=test sh ./plugin/storage/cassandra/schema/create.sh | cqlsh
+MODE=test sh ./internal/storage/v1/cassandra/schema/create.sh | cqlsh
 ```
 
 The same script is packaged as a container image (make sure to provide the right IP address):
@@ -59,7 +59,7 @@ where `{datacenter}` is the name used in the Cassandra configuration / network t
 The script also allows overriding TTL, keyspace name, replication factor, etc.
 Run the script without arguments to see the full list of recognized parameters.
 
-See [this README](https://github.com/jaegertracing/jaeger/blob/main/plugin/storage/cassandra/schema/README.md) for more details on Cassandra schema management.
+See [this README](https://github.com/jaegertracing/jaeger/blob/main/internal/storage/v1/cassandra/schema/README.md) for more details on Cassandra schema management.
 
 ## TLS support
 
@@ -94,6 +94,6 @@ usercert = ~/.cassandra/client-cert
 
 ## Compatible Backends
 
-* ScyllaDB [can be used](https://github.com/jaegertracing/jaeger/blob/main/plugin/storage/scylladb/README.md) as a drop-in replacement for Cassandra since it uses the same data model and query language.
+* ScyllaDB [can be used](https://github.com/jaegertracing/jaeger/blob/main/internal/storage/v1/scylladb/README.md) as a drop-in replacement for Cassandra since it uses the same data model and query language.
 
 [cqlsh]: http://cassandra.apache.org/doc/latest/tools/cqlsh.html

--- a/content/docs/next-release-v2/deployment.md
+++ b/content/docs/next-release-v2/deployment.md
@@ -97,5 +97,5 @@ In order to display service dependency diagrams, production deployments need an 
 [jaeger-thrift]: https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift
 [model.proto]: https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v2/model.proto
 [thriftrw]: https://www.npmjs.com/package/thriftrw
-[storage.proto]: https://github.com/jaegertracing/jaeger/blob/main/plugin/storage/grpc/proto/storage.proto
+[storage.proto]: https://github.com/jaegertracing/jaeger/blob/main/internal/storage/v1/grpc/proto/storage.proto
 [otlp]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md

--- a/content/docs/next-release-v2/storage.md
+++ b/content/docs/next-release-v2/storage.md
@@ -28,7 +28,7 @@ For large scale production deployment the Jaeger team [recommends OpenSearch bac
 
 Jaeger supports a gRPC-based [Remote Storage API][storage.proto] that allows extending the Jaeger ecosystem with custom storage backends, not directly supported by the project. These storage backends can be deployed as a remote gRPC server.
 
-To use a remote storage as Jaeger storage backend, use `grpc` as the storage type and specify the remote gRPC server address. For more information, please refer to [jaeger/plugin/storage/grpc](https://github.com/jaegertracing/jaeger/tree/master/plugin/storage/grpc).
+To use a remote storage as Jaeger storage backend, use `grpc` as the storage type and specify the remote gRPC server address. For more information, please refer to [jaeger/internal/storage/v1/grpc](https://github.com/jaegertracing/jaeger/tree/master/internal/storage/v1/grpc).
 
 Example config for remote storage [can be found here](https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/config-remote-storage.yaml).
 

--- a/content/docs/next-release/apis.md
+++ b/content/docs/next-release/apis.md
@@ -125,4 +125,4 @@ Please refer to the [SPM Documentation](../spm/#api)
 [sampling.proto]: https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v2/sampling.proto
 [grpc-reflection]: https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md#enable-server-reflection
 [gogo-reflection]: https://jbrandhorst.com/post/gogoproto/#reflection
-[storage.proto]: https://github.com/jaegertracing/jaeger/blob/main/plugin/storage/grpc/proto/storage.proto
+[storage.proto]: https://github.com/jaegertracing/jaeger/blob/main/internal/storage/v1/grpc/proto/storage.proto

--- a/content/docs/next-release/deployment.md
+++ b/content/docs/next-release/deployment.md
@@ -220,8 +220,8 @@ docker run \
   jaegertracing/all-in-one:{{< currentVersion >}}
 ```
 
-* [Upgrade Badger v1 to v3](https://github.com/jaegertracing/jaeger/blob/main/plugin/storage/badger/docs/upgrade-v1-to-v3.md)
-* [Badger file permissions as non-root service](https://github.com/jaegertracing/jaeger/blob/main/plugin/storage/badger/docs/storage-file-non-root-permission.md)
+* [Upgrade Badger v1 to v3](https://github.com/jaegertracing/jaeger/blob/main/internal/storage/v1/badger/docs/upgrade-v1-to-v3.md)
+* [Badger file permissions as non-root service](https://github.com/jaegertracing/jaeger/blob/main/internal/storage/v1/badger/docs/storage-file-non-root-permission.md)
 
 ### Cassandra
 * Supported versions: 4.x, 5.x
@@ -255,7 +255,7 @@ A script is provided to initialize Cassandra keyspace and schema
 using Cassandra's interactive shell [`cqlsh`][cqlsh]:
 
 ```sh
-MODE=test sh ./plugin/storage/cassandra/schema/create.sh | cqlsh
+MODE=test sh ./internal/storage/v1/cassandra/schema/create.sh | cqlsh
 ```
 
 Or using the published Docker image (make sure to provide the right IP address):
@@ -271,7 +271,7 @@ where `{datacenter}` is the name used in the Cassandra configuration / network t
 The script also allows overriding TTL, keyspace name, replication factor, etc.
 Run the script without arguments to see the full list of recognized parameters.
 
-**Note**: See [README](https://github.com/jaegertracing/jaeger/blob/main/plugin/storage/cassandra/schema/README.md) for more details on Cassandra schema management.
+**Note**: See [README](https://github.com/jaegertracing/jaeger/blob/main/internal/storage/v1/cassandra/schema/README.md) for more details on Cassandra schema management.
 
 #### TLS support
 
@@ -316,7 +316,7 @@ usercert = ~/.cassandra/client-cert
 
 #### Compatible Backends
 
-* ScyllaDB [can be used](https://github.com/jaegertracing/jaeger/blob/main/plugin/storage/scylladb/README.md) as a drop-in replacement for Cassandra since it uses the same data model and query language.
+* ScyllaDB [can be used](https://github.com/jaegertracing/jaeger/blob/main/docker-compose/scylladb/README.md) as a drop-in replacement for Cassandra since it uses the same data model and query language.
 
 ### Elasticsearch
 * Supported since Jaeger v0.6.0
@@ -584,7 +584,7 @@ You can find more information about topics and partitions in general in the [off
 
 Jaeger supports a gRPC-based [Remote Storage API][storage.proto] that allows extending the Jaeger ecosystem with custom storage backends, not directly supported by the project. These storage backends can be deployed as a remote gRPC server (since Jaeger v1.30). Older deployment mode as sidecar plugin will not be supported starting from v1.58.
 
-To use a remote storage as Jaeger storage backend, use `grpc` as the storage type and specify the remote gRPC server address. For more information, please refer to [jaeger/plugin/storage/grpc](https://github.com/jaegertracing/jaeger/tree/master/plugin/storage/grpc).
+To use a remote storage as Jaeger storage backend, use `grpc` as the storage type and specify the remote gRPC server address. For more information, please refer to [internal/storage/v1/grpc](https://github.com/jaegertracing/jaeger/tree/main/internal/storage/v1/grpc).
 
 Example:
 ```sh
@@ -655,5 +655,5 @@ Production deployments need an external process that aggregates data and creates
 [jaeger-thrift]: https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift
 [model.proto]: https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v2/model.proto
 [thriftrw]: https://www.npmjs.com/package/thriftrw
-[storage.proto]: https://github.com/jaegertracing/jaeger/blob/main/plugin/storage/grpc/proto/storage.proto
+[storage.proto]: https://github.com/jaegertracing/jaeger/blob/main/internal/storage/v1/grpc/proto/storage.proto
 [otlp]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -486,7 +486,7 @@ spec:
 <3> The options for the `create-schema` job.
 
 {{< info >}}
-The default create-schema job uses `MODE=prod`, which implies a replication factor of `2`, using `NetworkTopologyStrategy` as the class, effectively meaning that at least 3 nodes are required in the Cassandra cluster. If a `SimpleStrategy` is desired, set the mode to `test`, which then sets the replication factor of `1`. Refer to the [create-schema script](https://github.com/jaegertracing/jaeger/blob/main/plugin/storage/cassandra/schema/create.sh) for more details.
+The default create-schema job uses `MODE=prod`, which implies a replication factor of `2`, using `NetworkTopologyStrategy` as the class, effectively meaning that at least 3 nodes are required in the Cassandra cluster. If a `SimpleStrategy` is desired, set the mode to `test`, which then sets the replication factor of `1`. Refer to the [create-schema script](https://github.com/jaegertracing/jaeger/blob/main/internal/storage/v1/cassandra/schema/create.sh) for more details.
 {{< /info >}}
 
 ### Elasticsearch storage


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #837

## Description of the changes
- Fixes references to old package locations from `plugin/storage` to `internal/storage/v1` 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
