### PR TITLE
[release] Add step to release script for pinning links by jaeger version

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -55,6 +55,12 @@ safe_checkout_main() {
   fi
 }
 
+update_links() {
+  local version=$1
+  local versionTag="v${version}"
+  find ./content/docs/${version} -type f -exec sed -i "s|https://github.com/jaegertracing/jaeger/tree/main|https://github.com/jaegertracing/jaeger/tree/${versionTag}|g" {} \;
+}
+
 gen_cli_docs_v1() {
   local versionMajorMinor=$1
   # we set this as a temp dir with write permissions to everyone to overcome #441
@@ -82,6 +88,8 @@ for version in "${version_v1}" "${version_v2}"; do
     cp -r ./content/docs/next-release/ ./content/docs/${versionMajorMinor}
     gen_cli_docs_v1 ${versionMajorMinor}
   fi
+
+  update_links "${version}"
 
   versions=$(grep -E "versions${var_suffix} *:" "${config_file}")
   if [[ "$versions" == *"$versionMajorMinor"* ]]; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -56,9 +56,10 @@ safe_checkout_main() {
 }
 
 update_links() {
-  local version=$1
+  local versionMajorMinor=$1
+  local version=$2
   local versionTag="v${version}"
-  find ./content/docs/${version} -type f -exec sed -i "s|https://github.com/jaegertracing/jaeger/tree/main|https://github.com/jaegertracing/jaeger/tree/${versionTag}|g" {} \;
+  find ./content/docs/${versionMajorMinor} -type f -exec sed -i "s|https://github.com/jaegertracing/jaeger/tree/main|https://github.com/jaegertracing/jaeger/tree/${versionTag}|g" {} \;
 }
 
 gen_cli_docs_v1() {
@@ -89,7 +90,7 @@ for version in "${version_v1}" "${version_v2}"; do
     gen_cli_docs_v1 ${versionMajorMinor}
   fi
 
-  update_links "${version}"
+  update_links "${versionMajorMinor}" "${version}"
 
   versions=$(grep -E "versions${var_suffix} *:" "${config_file}")
   if [[ "$versions" == *"$versionMajorMinor"* ]]; then


### PR DESCRIPTION
## Which problem is this PR solving?
- Addresses https://github.com/jaegertracing/documentation/pull/840#pullrequestreview-2603959962

## Description of the changes
- Added a step to the release script to replace all instances of `https://github.com/jaegertracing/jaeger/tree/main` in `next-release/` and `next-release-v2/` with `https://github.com/jaegertracing/jaeger/tree/{version}`

## How was this change tested?
- Ran the same sed command when performing the backfill in https://github.com/jaegertracing/documentation/pull/842

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
