### PR TITLE
[chore] Pin jaeger links to corresponding jaeger version

### DIFF
--- a/content/docs/1.33/spm.md
+++ b/content/docs/1.33/spm.md
@@ -185,12 +185,12 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.33.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.33.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L46
 [spanmetrics-config-latency]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L38

--- a/content/docs/1.34/spm.md
+++ b/content/docs/1.34/spm.md
@@ -275,12 +275,12 @@ The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.34.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.34.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L46
 [spanmetrics-config-latency]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L38

--- a/content/docs/1.35/spm.md
+++ b/content/docs/1.35/spm.md
@@ -273,12 +273,12 @@ The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.35.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.35.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L46
 [spanmetrics-config-latency]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L38

--- a/content/docs/1.36/spm.md
+++ b/content/docs/1.36/spm.md
@@ -273,12 +273,12 @@ The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.36.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.36.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L46
 [spanmetrics-config-latency]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L38

--- a/content/docs/1.37/spm.md
+++ b/content/docs/1.37/spm.md
@@ -273,12 +273,12 @@ The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.37.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.37.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L46
 [spanmetrics-config-latency]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L38

--- a/content/docs/1.38/spm.md
+++ b/content/docs/1.38/spm.md
@@ -273,12 +273,12 @@ The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.38.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.38.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L46
 [spanmetrics-config-latency]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L38

--- a/content/docs/1.39/spm.md
+++ b/content/docs/1.39/spm.md
@@ -273,12 +273,12 @@ The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.39.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.39.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L46
 [spanmetrics-config-latency]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L38

--- a/content/docs/1.40/spm.md
+++ b/content/docs/1.40/spm.md
@@ -273,12 +273,12 @@ The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.40.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.40.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L46
 [spanmetrics-config-latency]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L38

--- a/content/docs/1.41/spm.md
+++ b/content/docs/1.41/spm.md
@@ -273,12 +273,12 @@ The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.41.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.41.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L46
 [spanmetrics-config-latency]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L38

--- a/content/docs/1.42/spm.md
+++ b/content/docs/1.42/spm.md
@@ -273,12 +273,12 @@ The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.42.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.42.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L46
 [spanmetrics-config-latency]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L38

--- a/content/docs/1.43/spm.md
+++ b/content/docs/1.43/spm.md
@@ -287,12 +287,12 @@ The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.43.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.43.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L46
 [spanmetrics-config-latency]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L38

--- a/content/docs/1.44/spm.md
+++ b/content/docs/1.44/spm.md
@@ -286,13 +286,13 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.44.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.44.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L46
 [spanmetrics-config-latency]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L38
 

--- a/content/docs/1.45/spm.md
+++ b/content/docs/1.45/spm.md
@@ -286,13 +286,13 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.45.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.45.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L46
 [spanmetrics-config-latency]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/spanmetricsprocessor/testdata/config-full.yaml#L38
 

--- a/content/docs/1.46/spm.md
+++ b/content/docs/1.46/spm.md
@@ -295,14 +295,14 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.46.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [spanmetrics-conn]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.46.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/1.47/spm.md
+++ b/content/docs/1.47/spm.md
@@ -295,14 +295,14 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.47.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [spanmetrics-conn]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.47.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/1.48/spm.md
+++ b/content/docs/1.48/spm.md
@@ -295,14 +295,14 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.48.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [spanmetrics-conn]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.48.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/1.49/spm.md
+++ b/content/docs/1.49/spm.md
@@ -358,14 +358,14 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.49.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [spanmetrics-conn]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.49.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/1.50/spm.md
+++ b/content/docs/1.50/spm.md
@@ -358,14 +358,14 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.50.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [spanmetrics-conn]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.50.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/1.51/spm.md
+++ b/content/docs/1.51/spm.md
@@ -358,14 +358,14 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.51.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [spanmetrics-conn]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.51.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/1.52/spm.md
+++ b/content/docs/1.52/spm.md
@@ -358,14 +358,14 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.52.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [spanmetrics-conn]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.52.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/1.53/spm.md
+++ b/content/docs/1.53/spm.md
@@ -358,14 +358,14 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.53.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [spanmetrics-conn]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.53.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/1.54/spm.md
+++ b/content/docs/1.54/spm.md
@@ -358,14 +358,14 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.54.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [spanmetrics-conn]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.54.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/1.55/spm.md
+++ b/content/docs/1.55/spm.md
@@ -358,14 +358,14 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.55.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [spanmetrics-conn]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.55.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/1.56/spm.md
+++ b/content/docs/1.56/spm.md
@@ -358,14 +358,14 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.56.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [spanmetrics-conn]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.56.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/1.57/spm.md
+++ b/content/docs/1.57/spm.md
@@ -358,14 +358,14 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.57.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [spanmetrics-conn]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.57.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/1.58/spm.md
+++ b/content/docs/1.58/spm.md
@@ -352,14 +352,14 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.58.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [spanmetrics-conn]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.58.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/1.59/spm.md
+++ b/content/docs/1.59/spm.md
@@ -352,14 +352,14 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.59.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [spanmetrics-conn]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.59.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/1.60/spm.md
+++ b/content/docs/1.60/spm.md
@@ -352,14 +352,14 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.60.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [spanmetrics-conn]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.60.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/1.61/spm.md
+++ b/content/docs/1.61/spm.md
@@ -352,14 +352,14 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.61.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [spanmetrics-conn]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.61.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/1.62/spm.md
+++ b/content/docs/1.62/spm.md
@@ -352,14 +352,14 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.62.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [spanmetrics-conn]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.62.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/1.63/spm.md
+++ b/content/docs/1.63/spm.md
@@ -352,14 +352,14 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.63.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [spanmetrics-conn]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.63.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/1.64/spm.md
+++ b/content/docs/1.64/spm.md
@@ -350,14 +350,14 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.64.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [spanmetrics-conn]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.64.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/1.65/spm.md
+++ b/content/docs/1.65/spm.md
@@ -350,14 +350,14 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.65.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [spanmetrics-conn]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.65.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/1.66/spm.md
+++ b/content/docs/1.66/spm.md
@@ -350,14 +350,14 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.66.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [spanmetrics-conn]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.66.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/2.0/configuration.md
+++ b/content/docs/2.0/configuration.md
@@ -5,7 +5,7 @@ weight: 1
 ---
 
 {{< warning >}}
-We are currently working on expanding this section with more details. [Examples of working configuration files](https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger) can be found in the Jaeger repository. In the future the documentation for all configuration properties will be [auto-generated](https://github.com/jaegertracing/jaeger/issues/6186).
+We are currently working on expanding this section with more details. [Examples of working configuration files](https://github.com/jaegertracing/jaeger/tree/v2.0.0/cmd/jaeger) can be found in the Jaeger repository. In the future the documentation for all configuration properties will be [auto-generated](https://github.com/jaegertracing/jaeger/issues/6186).
 {{< /warning >}}
 
 ## Introduction

--- a/content/docs/2.0/spm.md
+++ b/content/docs/2.0/spm.md
@@ -352,14 +352,14 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v2.0.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [spanmetrics-conn]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v2.0.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/2.1/architecture.md
+++ b/content/docs/2.1/architecture.md
@@ -79,15 +79,15 @@ The Jaeger binary is build on top of the OpenTelemetry Collector framework and i
 
 ### Jaeger Components
 
-* [Jaeger Storage Extension](https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/internal/extension/jaegerstorage) - Extensible hub for storage backends supported in Jaeger. It provides all other Jaeger components access to Jaeger storage implementations.
+* [Jaeger Storage Extension](https://github.com/jaegertracing/jaeger/tree/v2.1.0/cmd/jaeger/internal/extension/jaegerstorage) - Extensible hub for storage backends supported in Jaeger. It provides all other Jaeger components access to Jaeger storage implementations.
 
-* [Jaeger Storage Exporter](https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/internal/extension/jaegerstorage) - Writes spans to storage backend configured in the Jaeger Storage Extension.
+* [Jaeger Storage Exporter](https://github.com/jaegertracing/jaeger/tree/v2.1.0/cmd/jaeger/internal/extension/jaegerstorage) - Writes spans to storage backend configured in the Jaeger Storage Extension.
 
-* [Jaeger Query Extension](https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/internal/extension/jaegerquery) - Run the query APIs and the Jaeger UI.
+* [Jaeger Query Extension](https://github.com/jaegertracing/jaeger/tree/v2.1.0/cmd/jaeger/internal/extension/jaegerquery) - Run the query APIs and the Jaeger UI.
 
-* [Adaptive Sampling Processor](https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/internal/processors/adaptivesampling) - Performs probabilities calculations for [adaptive sampling](../sampling/#adaptive-sampling).
+* [Adaptive Sampling Processor](https://github.com/jaegertracing/jaeger/tree/v2.1.0/cmd/jaeger/internal/processors/adaptivesampling) - Performs probabilities calculations for [adaptive sampling](../sampling/#adaptive-sampling).
 
-* [Remote Sampling Extension](https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/internal/extension/remotesampling) - Serves the endpoints for [Remote Sampling](../sampling/#remote-sampling), based on static configuration file or [adaptive sampling](../sampling/#adaptive-sampling).
+* [Remote Sampling Extension](https://github.com/jaegertracing/jaeger/tree/v2.1.0/cmd/jaeger/internal/extension/remotesampling) - Serves the endpoints for [Remote Sampling](../sampling/#remote-sampling), based on static configuration file or [adaptive sampling](../sampling/#adaptive-sampling).
 
 ### OpenTelemetry Components
 

--- a/content/docs/2.1/configuration.md
+++ b/content/docs/2.1/configuration.md
@@ -5,7 +5,7 @@ weight: 1
 ---
 
 {{< warning >}}
-We are currently working on expanding this section with more details. [Examples of working configuration files](https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger) can be found in the Jaeger repository. In the future the documentation for all configuration properties will be [auto-generated](https://github.com/jaegertracing/jaeger/issues/6186).
+We are currently working on expanding this section with more details. [Examples of working configuration files](https://github.com/jaegertracing/jaeger/tree/v2.1.0/cmd/jaeger) can be found in the Jaeger repository. In the future the documentation for all configuration properties will be [auto-generated](https://github.com/jaegertracing/jaeger/issues/6186).
 {{< /warning >}}
 
 ## Introduction

--- a/content/docs/2.1/spm.md
+++ b/content/docs/2.1/spm.md
@@ -55,7 +55,7 @@ If generating traces manually is preferred, the [Sample App: HotROD](../getting-
 
 ## Configuration
 
-An example configuration is available in the Jaeger repository: [config-spm.yaml](https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/config-spm.yaml). The following steps are required to enable the SPM feature:
+An example configuration is available in the Jaeger repository: [config-spm.yaml](https://github.com/jaegertracing/jaeger/tree/v2.1.0/cmd/jaeger/config-spm.yaml). The following steps are required to enable the SPM feature:
 
 * Enable the [SpanMetrics Connector][spanmetrics-conn] in the pipeline:
 ```yaml
@@ -396,13 +396,13 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v2.1.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics-conn]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/README.md
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v2.1.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/2.2/architecture.md
+++ b/content/docs/2.2/architecture.md
@@ -79,15 +79,15 @@ The Jaeger binary is build on top of the OpenTelemetry Collector framework and i
 
 ### Jaeger Components
 
-* [Jaeger Storage Extension](https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/internal/extension/jaegerstorage) - Extensible hub for storage backends supported in Jaeger. It provides all other Jaeger components access to Jaeger storage implementations.
+* [Jaeger Storage Extension](https://github.com/jaegertracing/jaeger/tree/v2.2.0/cmd/jaeger/internal/extension/jaegerstorage) - Extensible hub for storage backends supported in Jaeger. It provides all other Jaeger components access to Jaeger storage implementations.
 
-* [Jaeger Storage Exporter](https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/internal/extension/jaegerstorage) - Writes spans to storage backend configured in the Jaeger Storage Extension.
+* [Jaeger Storage Exporter](https://github.com/jaegertracing/jaeger/tree/v2.2.0/cmd/jaeger/internal/extension/jaegerstorage) - Writes spans to storage backend configured in the Jaeger Storage Extension.
 
-* [Jaeger Query Extension](https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/internal/extension/jaegerquery) - Run the query APIs and the Jaeger UI.
+* [Jaeger Query Extension](https://github.com/jaegertracing/jaeger/tree/v2.2.0/cmd/jaeger/internal/extension/jaegerquery) - Run the query APIs and the Jaeger UI.
 
-* [Adaptive Sampling Processor](https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/internal/processors/adaptivesampling) - Performs probabilities calculations for [adaptive sampling](../sampling/#adaptive-sampling).
+* [Adaptive Sampling Processor](https://github.com/jaegertracing/jaeger/tree/v2.2.0/cmd/jaeger/internal/processors/adaptivesampling) - Performs probabilities calculations for [adaptive sampling](../sampling/#adaptive-sampling).
 
-* [Remote Sampling Extension](https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/internal/extension/remotesampling) - Serves the endpoints for [Remote Sampling](../sampling/#remote-sampling), based on static configuration file or [adaptive sampling](../sampling/#adaptive-sampling).
+* [Remote Sampling Extension](https://github.com/jaegertracing/jaeger/tree/v2.2.0/cmd/jaeger/internal/extension/remotesampling) - Serves the endpoints for [Remote Sampling](../sampling/#remote-sampling), based on static configuration file or [adaptive sampling](../sampling/#adaptive-sampling).
 
 ### OpenTelemetry Components
 

--- a/content/docs/2.2/configuration.md
+++ b/content/docs/2.2/configuration.md
@@ -5,7 +5,7 @@ weight: 1
 ---
 
 {{< warning >}}
-We are currently working on expanding this section with more details. [Examples of working configuration files](https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger) can be found in the Jaeger repository. In the future the documentation for all configuration properties will be [auto-generated](https://github.com/jaegertracing/jaeger/issues/6186).
+We are currently working on expanding this section with more details. [Examples of working configuration files](https://github.com/jaegertracing/jaeger/tree/v2.2.0/cmd/jaeger) can be found in the Jaeger repository. In the future the documentation for all configuration properties will be [auto-generated](https://github.com/jaegertracing/jaeger/issues/6186).
 {{< /warning >}}
 
 ## Introduction

--- a/content/docs/2.2/spm.md
+++ b/content/docs/2.2/spm.md
@@ -55,7 +55,7 @@ If generating traces manually is preferred, the [Sample App: HotROD](../getting-
 
 ## Configuration
 
-An example configuration is available in the Jaeger repository: [config-spm.yaml](https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/config-spm.yaml). The following steps are required to enable the SPM feature:
+An example configuration is available in the Jaeger repository: [config-spm.yaml](https://github.com/jaegertracing/jaeger/tree/v2.2.0/cmd/jaeger/config-spm.yaml). The following steps are required to enable the SPM feature:
 
 * Enable the [SpanMetrics Connector][spanmetrics-conn] in the pipeline:
 ```yaml
@@ -396,13 +396,13 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v2.2.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics-conn]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/README.md
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v2.2.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/2.3/architecture.md
+++ b/content/docs/2.3/architecture.md
@@ -79,15 +79,15 @@ The Jaeger binary is build on top of the OpenTelemetry Collector framework and i
 
 ### Jaeger Components
 
-* [Jaeger Storage Extension](https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/internal/extension/jaegerstorage) - Extensible hub for storage backends supported in Jaeger. It provides all other Jaeger components access to Jaeger storage implementations.
+* [Jaeger Storage Extension](https://github.com/jaegertracing/jaeger/tree/v2.3.0/cmd/jaeger/internal/extension/jaegerstorage) - Extensible hub for storage backends supported in Jaeger. It provides all other Jaeger components access to Jaeger storage implementations.
 
-* [Jaeger Storage Exporter](https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/internal/extension/jaegerstorage) - Writes spans to storage backend configured in the Jaeger Storage Extension.
+* [Jaeger Storage Exporter](https://github.com/jaegertracing/jaeger/tree/v2.3.0/cmd/jaeger/internal/extension/jaegerstorage) - Writes spans to storage backend configured in the Jaeger Storage Extension.
 
-* [Jaeger Query Extension](https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/internal/extension/jaegerquery) - Run the query APIs and the Jaeger UI.
+* [Jaeger Query Extension](https://github.com/jaegertracing/jaeger/tree/v2.3.0/cmd/jaeger/internal/extension/jaegerquery) - Run the query APIs and the Jaeger UI.
 
-* [Adaptive Sampling Processor](https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/internal/processors/adaptivesampling) - Performs probabilities calculations for [adaptive sampling](../sampling/#adaptive-sampling).
+* [Adaptive Sampling Processor](https://github.com/jaegertracing/jaeger/tree/v2.3.0/cmd/jaeger/internal/processors/adaptivesampling) - Performs probabilities calculations for [adaptive sampling](../sampling/#adaptive-sampling).
 
-* [Remote Sampling Extension](https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/internal/extension/remotesampling) - Serves the endpoints for [Remote Sampling](../sampling/#remote-sampling), based on static configuration file or [adaptive sampling](../sampling/#adaptive-sampling).
+* [Remote Sampling Extension](https://github.com/jaegertracing/jaeger/tree/v2.3.0/cmd/jaeger/internal/extension/remotesampling) - Serves the endpoints for [Remote Sampling](../sampling/#remote-sampling), based on static configuration file or [adaptive sampling](../sampling/#adaptive-sampling).
 
 ### OpenTelemetry Components
 

--- a/content/docs/2.3/configuration.md
+++ b/content/docs/2.3/configuration.md
@@ -5,7 +5,7 @@ weight: 1
 ---
 
 {{< warning >}}
-We are currently working on expanding this section with more details. [Examples of working configuration files](https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger) can be found in the Jaeger repository. In the future the documentation for all configuration properties will be [auto-generated](https://github.com/jaegertracing/jaeger/issues/6186).
+We are currently working on expanding this section with more details. [Examples of working configuration files](https://github.com/jaegertracing/jaeger/tree/v2.3.0/cmd/jaeger) can be found in the Jaeger repository. In the future the documentation for all configuration properties will be [auto-generated](https://github.com/jaegertracing/jaeger/issues/6186).
 {{< /warning >}}
 
 ## Introduction

--- a/content/docs/2.3/spm.md
+++ b/content/docs/2.3/spm.md
@@ -55,7 +55,7 @@ If generating traces manually is preferred, the [Sample App: HotROD](../getting-
 
 ## Configuration
 
-An example configuration is available in the Jaeger repository: [config-spm.yaml](https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/config-spm.yaml). The following steps are required to enable the SPM feature:
+An example configuration is available in the Jaeger repository: [config-spm.yaml](https://github.com/jaegertracing/jaeger/tree/v2.3.0/cmd/jaeger/config-spm.yaml). The following steps are required to enable the SPM feature:
 
 * Enable the [SpanMetrics Connector][spanmetrics-conn] in the pipeline:
 ```yaml
@@ -396,13 +396,13 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v2.3.0/docker-compose/monitor
 [metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
 [openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics-conn]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/README.md
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v2.3.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Addresses https://github.com/jaegertracing/documentation/pull/840#pullrequestreview-2603959962

## Description of the changes
- Wrote a short script and ran it to replace all instances of `https://github.com/jaegertracing/jaeger/tree/main` with `https://github.com/jaegertracing/jaeger/tree/{version}` so that documentation links never go stale. 

## How was this change tested?
- Manually checked the links to ensure they are reachable

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits