### PR TITLE
Update elasticsearch config link

### DIFF
--- a/content/docs/2.5/elasticsearch.md
+++ b/content/docs/2.5/elasticsearch.md
@@ -18,7 +18,7 @@ Elasticsearch also has the following officially supported resources available fr
 
 ## Configuration
 
-A sample configuration for Jaeger with Elasticsearch backend is available in the Jaeger repository: [config-elasticsearch.yaml](https://github.com/jaegertracing/jaeger/blob/v2.5.0/cmd/jaeger/config-elasticsearch.yaml). In the future the configuration documentation will be auto-generated from the schema. Meanwhile, please refer to [config.go](https://github.com/jaegertracing/jaeger/blob/v2.5.0/pkg/es/config/config.go#L86) as the authoritative source.
+A sample configuration for Jaeger with Elasticsearch backend is available in the Jaeger repository: [config-elasticsearch.yaml](https://github.com/jaegertracing/jaeger/blob/v2.5.0/cmd/jaeger/config-elasticsearch.yaml). In the future the configuration documentation will be auto-generated from the schema. Meanwhile, please refer to [config.go](https://github.com/jaegertracing/jaeger/blob/v2.5.0/internal/storage/elasticsearch/config/config.go#L86) as the authoritative source.
 
 ### Shards and Replicas
 


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes a broken link to the elasticsearch storage backend's config.go file

## Description of the changes
Updated the link to point to the new location of the config.go file

## How was this change tested?
Locally using `make develop`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`

---------

Signed-off-by: Grzegorz Brzeczek <grzegorzbrzeczek1@proton.me>