### PR TITLE
Backport gRPC documentation to v2.6

### DIFF
--- a/content/docs/2.6/apis.md
+++ b/content/docs/2.6/apis.md
@@ -121,7 +121,22 @@ Jaeger UI communicates with **jaeger-query** Service via JSON API. For example, 
 
 **Status**: Stable
 
-When using the `grpc` storage type (a.k.a. [remote storage](../storage/#remote-storage)), Jaeger components can use custom storage backends as long as those backends implement the gRPC [Remote Storage API][storage.proto].
+When using the `grpc` storage type (a.k.a. [remote storage](../storage/#remote-storage)),
+Jaeger can use custom storage backends as long as those backends implement
+the gRPC Remote Storage API.
+
+To use a remote storage backend, you must deploy a gRPC server that implements
+the following services:
+
+* **[TraceReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/trace_storage.proto)**  
+  Enables Jaeger to read traces from the storage backend.
+* **[DependencyReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/dependency_storage.proto)**  
+  Used to load service dependency graphs from storage.
+* **[TraceService](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/trace/v1/trace_service.proto)**  
+  Allows trace data to be pushed to the storage. This service can run on a separate port if needed.
+
+For more information, please refer to
+[jaeger/internal/storage/v2/grpc](https://github.com/jaegertracing/jaeger/tree/main/internal/storage/v2/grpc).
 
 ## Remote Sampling Configuration
 
@@ -171,4 +186,3 @@ grpc_cli ls localhost:16685
 [sampling.proto]: https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v2/sampling.proto
 [grpc-reflection]: https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md#enable-server-reflection
 [gogo-reflection]: https://jbrandhorst.com/post/gogoproto/#reflection
-[storage.proto]: https://github.com/jaegertracing/jaeger/blob/v2.6.0/internal/storage/v1/grpc/proto/storage.proto

--- a/content/docs/2.6/storage.md
+++ b/content/docs/2.6/storage.md
@@ -26,9 +26,14 @@ For large scale production deployment the Jaeger team [recommends OpenSearch bac
 
 ## Remote Storage
 
-Jaeger supports a gRPC-based [Remote Storage API][storage.proto] that allows extending the Jaeger ecosystem with custom storage backends, not directly supported by the project. These storage backends can be deployed as a remote gRPC server.
+Jaeger supports a gRPC-based Remote Storage API v2 that allows extending the Jaeger
+ecosystem with custom storage backends, not directly supported by the project.
+These storage backends can be deployed as a remote gRPC server.
 
-To use a remote storage as Jaeger storage backend, use `grpc` as the storage type and specify the remote gRPC server address. For more information, please refer to [jaeger/internal/storage/v1/grpc](https://github.com/jaegertracing/jaeger/tree/v2.6.0/internal/storage/v1/grpc).
+To use a remote storage as Jaeger storage backend, use `grpc` as the storage type
+and specify the remote gRPC server address. For more information,
+please refer to
+[jaeger/internal/storage/v2/grpc](https://github.com/jaegertracing/jaeger/tree/v2.6.0/internal/storage/v2/grpc).
 
 Example config for remote storage [can be found here](https://github.com/jaegertracing/jaeger/blob/v2.6.0/cmd/jaeger/config-remote-storage.yaml).
 


### PR DESCRIPTION
## Description of the changes
- Backports the new gRPC documentation to v2.6.0 since most of the changes were in that release
