### PR TITLE
Drop obsolete GA UA ID from Hugo config

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -6,7 +6,6 @@ pygmentsUseClasses: true
 disableKinds: ["taxonomy"]
 canonifyURLs: true
 theme: ["basetheme", "jaeger-docs"]
-googleAnalytics: "UA-148208642-1"
 
 mediaTypes:
   text/netlify:


### PR DESCRIPTION
Contributes to:

- #886