### PR TITLE
Replace / resolve any references to jaeger.readthedocs.io, enable full link checking

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -40,10 +40,10 @@ jobs:
       run: |
         go install github.com/wjdp/htmltest@latest
 
-    - name: Strict link check for newer versions
-      run: make check-links
+    - name: Strict link checking for newer versions
+      run: make check-links-external
 
-    - name: Relaxed link check for newer versions
+    - name: Relaxed link checking for older versions
       run: make check-links-older
 
   spellcheck:

--- a/.htmltest.external.yml
+++ b/.htmltest.external.yml
@@ -5,7 +5,7 @@ IgnoreAltMissing: true
 IgnoreDirs:
   - docs/1.*
 IgnoreURLs:
-  - /livereload.js
+  - /livereload.js # cSpell:disable-line
   # Valid URLs, but servers yield 403 or similar errors
   - ^https://(twitter|x).com/[Jj]aeger[Tt]racing
   - ^https://calendar.google.com/
@@ -13,3 +13,8 @@ IgnoreURLs:
   - ^https://war.ukraine.ua/support-ukraine/
   - ^https://www.oracle.com/cloud
   - ^https://stackoverflow.com/questions/tagged/jaeger
+  # Temporary: invalid URLs for which replacements need to be found
+  # Temporary: as we work on https://github.com/jaegertracing/documentation/issues/889
+  - ^https://github.com/jaegertracing/jaeger/(blob|tree)/(v2|main/(internal|model|pkg))
+  - ^https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory
+  - ^https://www.jaegertracing.io/docs/2.6/(cli|operator)/

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ develop: generate
 		--ignoreCache
 
 clean:
-	rm -rf public
+	rm -rf public/*
 
 netlify-production-build: generate
 	hugo --minify

--- a/content/docs/1.10/frontend-ui.md
+++ b/content/docs/1.10/frontend-ui.md
@@ -37,7 +37,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }
@@ -100,7 +100,7 @@ The following pages support embedded mode:
 
 ### Search Page
 
-To integrate the Search Trace Page to our application we have to indicate to the Jaeger UI that we want to use the embed mode with `uiEmbed=v0`. 
+To integrate the Search Trace Page to our application we have to indicate to the Jaeger UI that we want to use the embed mode with `uiEmbed=v0`.
 
 For example:
 
@@ -142,7 +142,7 @@ http://localhost:16686/search?
 ### Trace Page
 
 
-To integrate the Trace Page to our application we have to indicate to the Jaeger UI that we want to use the embed mode with `uiEmbed=v0`. 
+To integrate the Trace Page to our application we have to indicate to the Jaeger UI that we want to use the embed mode with `uiEmbed=v0`.
 
 For example:
 
@@ -160,7 +160,7 @@ If we have navigated to this view from the search traces page we'll have a butto
 The following query parameters can be used to configure the layout of the trace page :
 
 * `uiTimelineCollapseTitle=1` causes the trace header to start out collapsed, which hides the summary and the minimap.
-  
+
 ```
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
@@ -183,7 +183,7 @@ http://localhost:16686/trace/{trace-id}?
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideSummary=1
-```  
+```
 ![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-summary.png)
 
 We can also combine the options:

--- a/content/docs/1.11/frontend-ui.md
+++ b/content/docs/1.11/frontend-ui.md
@@ -37,7 +37,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }
@@ -100,7 +100,7 @@ The following pages support embedded mode:
 
 ### Search Page
 
-To integrate the Search Trace Page to our application we have to indicate to the Jaeger UI that we want to use the embed mode with `uiEmbed=v0`. 
+To integrate the Search Trace Page to our application we have to indicate to the Jaeger UI that we want to use the embed mode with `uiEmbed=v0`.
 
 For example:
 
@@ -142,7 +142,7 @@ http://localhost:16686/search?
 ### Trace Page
 
 
-To integrate the Trace Page to our application we have to indicate to the Jaeger UI that we want to use the embed mode with `uiEmbed=v0`. 
+To integrate the Trace Page to our application we have to indicate to the Jaeger UI that we want to use the embed mode with `uiEmbed=v0`.
 
 For example:
 
@@ -160,7 +160,7 @@ If we have navigated to this view from the search traces page we'll have a butto
 The following query parameters can be used to configure the layout of the trace page :
 
 * `uiTimelineCollapseTitle=1` causes the trace header to start out collapsed, which hides the summary and the minimap.
-  
+
 ```
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
@@ -183,7 +183,7 @@ http://localhost:16686/trace/{trace-id}?
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideSummary=1
-```  
+```
 ![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-summary.png)
 
 We can also combine the options:

--- a/content/docs/1.12/frontend-ui.md
+++ b/content/docs/1.12/frontend-ui.md
@@ -37,7 +37,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }
@@ -100,7 +100,7 @@ The following pages support embedded mode:
 
 ### Search Page
 
-To integrate the Search Trace Page to our application we have to indicate to the Jaeger UI that we want to use the embed mode with `uiEmbed=v0`. 
+To integrate the Search Trace Page to our application we have to indicate to the Jaeger UI that we want to use the embed mode with `uiEmbed=v0`.
 
 For example:
 
@@ -142,7 +142,7 @@ http://localhost:16686/search?
 ### Trace Page
 
 
-To integrate the Trace Page to our application we have to indicate to the Jaeger UI that we want to use the embed mode with `uiEmbed=v0`. 
+To integrate the Trace Page to our application we have to indicate to the Jaeger UI that we want to use the embed mode with `uiEmbed=v0`.
 
 For example:
 
@@ -160,7 +160,7 @@ If we have navigated to this view from the search traces page we'll have a butto
 The following query parameters can be used to configure the layout of the trace page :
 
 * `uiTimelineCollapseTitle=1` causes the trace header to start out collapsed, which hides the summary and the minimap.
-  
+
 ```
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
@@ -183,7 +183,7 @@ http://localhost:16686/trace/{trace-id}?
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideSummary=1
-```  
+```
 ![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-summary.png)
 
 We can also combine the options:

--- a/content/docs/1.13/frontend-ui.md
+++ b/content/docs/1.13/frontend-ui.md
@@ -38,7 +38,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.14/frontend-ui.md
+++ b/content/docs/1.14/frontend-ui.md
@@ -38,7 +38,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.15/frontend-ui.md
+++ b/content/docs/1.15/frontend-ui.md
@@ -38,7 +38,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.16/frontend-ui.md
+++ b/content/docs/1.16/frontend-ui.md
@@ -38,7 +38,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.17/frontend-ui.md
+++ b/content/docs/1.17/frontend-ui.md
@@ -13,7 +13,7 @@ Several aspects of the UI can be configured:
   * Google Analytics tracking can be enabled / configured
   * Additional menu options can be added to the global nav
   * Search input limits can be configured
-  
+
 These options can be configured by a JSON configuration file. The `--query.ui-config` command line parameter of the query service must then be set to the path to the JSON file when the query service is started.
 
 An example configuration file:
@@ -39,7 +39,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }
@@ -122,7 +122,7 @@ key   | The name of tag/process/log attribute which value will be displayed as a
 url   | The URL where the link should point to, it can be an external site or relative path in Jaeger UI
 text  | The text displayed in the tooltip for the link
 
-Both `url` and `text` can be defined as templates (i.e. using `#{field-name}`) where Jaeger UI will dynamically substitute values based on tags/logs/traces data. 
+Both `url` and `text` can be defined as templates (i.e. using `#{field-name}`) where Jaeger UI will dynamically substitute values based on tags/logs/traces data.
 
 For traces, the supported template fields are: `duration`, `endTime`, `startTime`, `traceName` and `traceID`.
 

--- a/content/docs/1.18/frontend-ui.md
+++ b/content/docs/1.18/frontend-ui.md
@@ -13,7 +13,7 @@ Several aspects of the UI can be configured:
   * Google Analytics tracking can be enabled / configured
   * Additional menu options can be added to the global nav
   * Search input limits can be configured
-  
+
 These options can be configured by a JSON configuration file. The `--query.ui-config` command line parameter of the query service must then be set to the path to the JSON file when the query service is started.
 
 An example configuration file:
@@ -39,7 +39,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }
@@ -122,7 +122,7 @@ key   | The name of tag/process/log attribute which value will be displayed as a
 url   | The URL where the link should point to, it can be an external site or relative path in Jaeger UI
 text  | The text displayed in the tooltip for the link
 
-Both `url` and `text` can be defined as templates (i.e. using `#{field-name}`) where Jaeger UI will dynamically substitute values based on tags/logs/traces data. 
+Both `url` and `text` can be defined as templates (i.e. using `#{field-name}`) where Jaeger UI will dynamically substitute values based on tags/logs/traces data.
 
 For traces, the supported template fields are: `duration`, `endTime`, `startTime`, `traceName` and `traceID`.
 

--- a/content/docs/1.19/frontend-ui.md
+++ b/content/docs/1.19/frontend-ui.md
@@ -13,7 +13,7 @@ Several aspects of the UI can be configured:
   * Google Analytics tracking can be enabled / configured
   * Additional menu options can be added to the global nav
   * Search input limits can be configured
-  
+
 These options can be configured by a JSON configuration file. The `--query.ui-config` command line parameter of the query service must then be set to the path to the JSON file when the query service is started.
 
 An example configuration file:
@@ -39,7 +39,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }
@@ -122,7 +122,7 @@ key   | The name of tag/process/log attribute which value will be displayed as a
 url   | The URL where the link should point to, it can be an external site or relative path in Jaeger UI
 text  | The text displayed in the tooltip for the link
 
-Both `url` and `text` can be defined as templates (i.e. using `#{field-name}`) where Jaeger UI will dynamically substitute values based on tags/logs/traces data. 
+Both `url` and `text` can be defined as templates (i.e. using `#{field-name}`) where Jaeger UI will dynamically substitute values based on tags/logs/traces data.
 
 For traces, the supported template fields are: `duration`, `endTime`, `startTime`, `traceName` and `traceID`.
 

--- a/content/docs/1.20/frontend-ui.md
+++ b/content/docs/1.20/frontend-ui.md
@@ -13,7 +13,7 @@ Several aspects of the UI can be configured:
   * Google Analytics tracking can be enabled / configured
   * Additional menu options can be added to the global nav
   * Search input limits can be configured
-  
+
 These options can be configured by a JSON configuration file. The `--query.ui-config` command line parameter of the query service must then be set to the path to the JSON file when the query service is started.
 
 An example configuration file:
@@ -39,7 +39,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }
@@ -122,7 +122,7 @@ key   | The name of tag/process/log attribute which value will be displayed as a
 url   | The URL where the link should point to, it can be an external site or relative path in Jaeger UI
 text  | The text displayed in the tooltip for the link
 
-Both `url` and `text` can be defined as templates (i.e. using `#{field-name}`) where Jaeger UI will dynamically substitute values based on tags/logs/traces data. 
+Both `url` and `text` can be defined as templates (i.e. using `#{field-name}`) where Jaeger UI will dynamically substitute values based on tags/logs/traces data.
 
 For traces, the supported template fields are: `duration`, `endTime`, `startTime`, `traceName` and `traceID`.
 

--- a/content/docs/1.21/frontend-ui.md
+++ b/content/docs/1.21/frontend-ui.md
@@ -13,7 +13,7 @@ Several aspects of the UI can be configured:
   * Google Analytics tracking can be enabled / configured
   * Additional menu options can be added to the global nav
   * Search input limits can be configured
-  
+
 These options can be configured by a JSON configuration file. The `--query.ui-config` command line parameter of the query service must then be set to the path to the JSON file when the query service is started.
 
 An example configuration file:
@@ -39,7 +39,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }
@@ -122,7 +122,7 @@ key   | The name of tag/process/log attribute which value will be displayed as a
 url   | The URL where the link should point to, it can be an external site or relative path in Jaeger UI
 text  | The text displayed in the tooltip for the link
 
-Both `url` and `text` can be defined as templates (i.e. using `#{field-name}`) where Jaeger UI will dynamically substitute values based on tags/logs/traces data. 
+Both `url` and `text` can be defined as templates (i.e. using `#{field-name}`) where Jaeger UI will dynamically substitute values based on tags/logs/traces data.
 
 For traces, the supported template fields are: `duration`, `endTime`, `startTime`, `traceName` and `traceID`.
 

--- a/content/docs/1.22/frontend-ui.md
+++ b/content/docs/1.22/frontend-ui.md
@@ -13,7 +13,7 @@ Several aspects of the UI can be configured:
   * Google Analytics tracking can be enabled / configured
   * Additional menu options can be added to the global nav
   * Search input limits can be configured
-  
+
 These options can be configured by a JSON configuration file. The `--query.ui-config` command line parameter of the query service must then be set to the path to the JSON file when the query service is started.
 
 An example configuration file:
@@ -39,7 +39,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }
@@ -122,7 +122,7 @@ key   | The name of tag/process/log attribute which value will be displayed as a
 url   | The URL where the link should point to, it can be an external site or relative path in Jaeger UI
 text  | The text displayed in the tooltip for the link
 
-Both `url` and `text` can be defined as templates (i.e. using `#{field-name}`) where Jaeger UI will dynamically substitute values based on tags/logs/traces data. 
+Both `url` and `text` can be defined as templates (i.e. using `#{field-name}`) where Jaeger UI will dynamically substitute values based on tags/logs/traces data.
 
 For traces, the supported template fields are: `duration`, `endTime`, `startTime`, `traceName` and `traceID`.
 

--- a/content/docs/1.23/frontend-ui.md
+++ b/content/docs/1.23/frontend-ui.md
@@ -13,7 +13,7 @@ Several aspects of the UI can be configured:
   * Google Analytics tracking can be enabled / configured
   * Additional menu options can be added to the global nav
   * Search input limits can be configured
-  
+
 These options can be configured by a JSON configuration file. The `--query.ui-config` command line parameter of the query service must then be set to the path to the JSON file when the query service is started.
 
 An example configuration file:
@@ -39,7 +39,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }
@@ -122,7 +122,7 @@ key   | The name of tag/process/log attribute which value will be displayed as a
 url   | The URL where the link should point to, it can be an external site or relative path in Jaeger UI
 text  | The text displayed in the tooltip for the link
 
-Both `url` and `text` can be defined as templates (i.e. using `#{field-name}`) where Jaeger UI will dynamically substitute values based on tags/logs/traces data. 
+Both `url` and `text` can be defined as templates (i.e. using `#{field-name}`) where Jaeger UI will dynamically substitute values based on tags/logs/traces data.
 
 For traces, the supported template fields are: `duration`, `endTime`, `startTime`, `traceName` and `traceID`.
 

--- a/content/docs/1.24/frontend-ui.md
+++ b/content/docs/1.24/frontend-ui.md
@@ -13,7 +13,7 @@ Several aspects of the UI can be configured:
   * Google Analytics tracking can be enabled / configured
   * Additional menu options can be added to the global nav
   * Search input limits can be configured
-  
+
 These options can be configured by a JSON configuration file. The `--query.ui-config` command line parameter of the query service must then be set to the path to the JSON file when the query service is started.
 
 An example configuration file:
@@ -39,7 +39,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }
@@ -122,7 +122,7 @@ key   | The name of tag/process/log attribute which value will be displayed as a
 url   | The URL where the link should point to, it can be an external site or relative path in Jaeger UI
 text  | The text displayed in the tooltip for the link
 
-Both `url` and `text` can be defined as templates (i.e. using `#{field-name}`) where Jaeger UI will dynamically substitute values based on tags/logs/traces data. 
+Both `url` and `text` can be defined as templates (i.e. using `#{field-name}`) where Jaeger UI will dynamically substitute values based on tags/logs/traces data.
 
 For traces, the supported template fields are: `duration`, `endTime`, `startTime`, `traceName` and `traceID`.
 

--- a/content/docs/1.25/frontend-ui.md
+++ b/content/docs/1.25/frontend-ui.md
@@ -13,7 +13,7 @@ Several aspects of the UI can be configured:
   * Google Analytics tracking can be enabled / configured
   * Additional menu options can be added to the global nav
   * Search input limits can be configured
-  
+
 These options can be configured by a JSON configuration file. The `--query.ui-config` command line parameter of the query service must then be set to the path to the JSON file when the query service is started.
 
 An example configuration file:
@@ -39,7 +39,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }
@@ -122,7 +122,7 @@ key   | The name of tag/process/log attribute which value will be displayed as a
 url   | The URL where the link should point to, it can be an external site or relative path in Jaeger UI
 text  | The text displayed in the tooltip for the link
 
-Both `url` and `text` can be defined as templates (i.e. using `#{field-name}`) where Jaeger UI will dynamically substitute values based on tags/logs/traces data. 
+Both `url` and `text` can be defined as templates (i.e. using `#{field-name}`) where Jaeger UI will dynamically substitute values based on tags/logs/traces data.
 
 For traces, the supported template fields are: `duration`, `endTime`, `startTime`, `traceName` and `traceID`.
 

--- a/content/docs/1.26/frontend-ui.md
+++ b/content/docs/1.26/frontend-ui.md
@@ -39,7 +39,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.27/frontend-ui.md
+++ b/content/docs/1.27/frontend-ui.md
@@ -39,7 +39,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.28/frontend-ui.md
+++ b/content/docs/1.28/frontend-ui.md
@@ -39,7 +39,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.29/frontend-ui.md
+++ b/content/docs/1.29/frontend-ui.md
@@ -39,7 +39,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.30/frontend-ui.md
+++ b/content/docs/1.30/frontend-ui.md
@@ -39,7 +39,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.31/frontend-ui.md
+++ b/content/docs/1.31/frontend-ui.md
@@ -39,7 +39,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.32/frontend-ui.md
+++ b/content/docs/1.32/frontend-ui.md
@@ -39,7 +39,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.33/frontend-ui.md
+++ b/content/docs/1.33/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.34/frontend-ui.md
+++ b/content/docs/1.34/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.35/frontend-ui.md
+++ b/content/docs/1.35/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.36/frontend-ui.md
+++ b/content/docs/1.36/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.37/frontend-ui.md
+++ b/content/docs/1.37/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.38/frontend-ui.md
+++ b/content/docs/1.38/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.39/frontend-ui.md
+++ b/content/docs/1.39/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.40/frontend-ui.md
+++ b/content/docs/1.40/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.41/frontend-ui.md
+++ b/content/docs/1.41/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.42/frontend-ui.md
+++ b/content/docs/1.42/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.43/frontend-ui.md
+++ b/content/docs/1.43/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.44/frontend-ui.md
+++ b/content/docs/1.44/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.45/frontend-ui.md
+++ b/content/docs/1.45/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.46/frontend-ui.md
+++ b/content/docs/1.46/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.47/frontend-ui.md
+++ b/content/docs/1.47/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.48/frontend-ui.md
+++ b/content/docs/1.48/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.49/frontend-ui.md
+++ b/content/docs/1.49/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.50/frontend-ui.md
+++ b/content/docs/1.50/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.51/frontend-ui.md
+++ b/content/docs/1.51/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.52/frontend-ui.md
+++ b/content/docs/1.52/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.53/frontend-ui.md
+++ b/content/docs/1.53/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.54/frontend-ui.md
+++ b/content/docs/1.54/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.55/frontend-ui.md
+++ b/content/docs/1.55/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.56/frontend-ui.md
+++ b/content/docs/1.56/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.57/frontend-ui.md
+++ b/content/docs/1.57/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.58/frontend-ui.md
+++ b/content/docs/1.58/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.59/frontend-ui.md
+++ b/content/docs/1.59/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.6/deployment.md
+++ b/content/docs/1.6/deployment.md
@@ -329,7 +329,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.60/frontend-ui.md
+++ b/content/docs/1.60/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.61/frontend-ui.md
+++ b/content/docs/1.61/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.62/frontend-ui.md
+++ b/content/docs/1.62/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.63/frontend-ui.md
+++ b/content/docs/1.63/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.64/frontend-ui.md
+++ b/content/docs/1.64/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.65/frontend-ui.md
+++ b/content/docs/1.65/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.66/frontend-ui.md
+++ b/content/docs/1.66/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.67/frontend-ui.md
+++ b/content/docs/1.67/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.68/frontend-ui.md
+++ b/content/docs/1.68/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.69/frontend-ui.md
+++ b/content/docs/1.69/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.7/deployment.md
+++ b/content/docs/1.7/deployment.md
@@ -329,7 +329,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.8/deployment.md
+++ b/content/docs/1.8/deployment.md
@@ -344,7 +344,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/1.9/frontend-ui.md
+++ b/content/docs/1.9/frontend-ui.md
@@ -37,7 +37,7 @@ An example configuration file:
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }
@@ -100,7 +100,7 @@ The following pages support embedded mode:
 
 ### Search Page
 
-To integrate the Search Trace Page to our application we have to indicate to the Jaeger UI that we want to use the embed mode with `uiEmbed=v0`. 
+To integrate the Search Trace Page to our application we have to indicate to the Jaeger UI that we want to use the embed mode with `uiEmbed=v0`.
 
 For example:
 
@@ -142,7 +142,7 @@ http://localhost:16686/search?
 ### Trace Page
 
 
-To integrate the Trace Page to our application we have to indicate to the Jaeger UI that we want to use the embed mode with `uiEmbed=v0`. 
+To integrate the Trace Page to our application we have to indicate to the Jaeger UI that we want to use the embed mode with `uiEmbed=v0`.
 
 For example:
 
@@ -160,7 +160,7 @@ If we have navigated to this view from the search traces page we'll have a butto
 The following query parameters can be used to configure the layout of the trace page :
 
 * `uiTimelineCollapseTitle=1` causes the trace header to start out collapsed, which hides the summary and the minimap.
-  
+
 ```
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
@@ -183,7 +183,7 @@ http://localhost:16686/trace/{trace-id}?
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideSummary=1
-```  
+```
 ![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-summary.png)
 
 We can also combine the options:

--- a/content/docs/2.0/frontend-ui.md
+++ b/content/docs/2.0/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/2.1/frontend-ui.md
+++ b/content/docs/2.1/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/2.2/frontend-ui.md
+++ b/content/docs/2.2/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/2.3/frontend-ui.md
+++ b/content/docs/2.3/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/2.4/frontend-ui.md
+++ b/content/docs/2.4/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/2.5/frontend-ui.md
+++ b/content/docs/2.5/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/2.6/frontend-ui.md
+++ b/content/docs/2.6/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/next-release-v2/frontend-ui.md
+++ b/content/docs/next-release-v2/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/docs/next-release/frontend-ui.md
+++ b/content/docs/next-release/frontend-ui.md
@@ -43,7 +43,7 @@ An example configuration file (see [complete schema here](https://github.com/jae
         },
         {
           "label": "Docs",
-          "url": "http://jaeger.readthedocs.io/en/latest/"
+          "url": "https://www.jaegertracing.io/docs/latest/"
         }
       ]
     }

--- a/content/news.md
+++ b/content/news.md
@@ -54,7 +54,9 @@ Uber is pleased to announce the open source release of Jaeger, a distributed tra
 
 Jaeger is written in Go, with OpenTracing compatible client libraries in [Go](https://github.com/jaegertracing/jaeger-client-go), [Java](https://github.com/jaegertracing/jaeger-client-java), [Node](https://github.com/jaegertracing/jaeger-client-node), and [Python](https://github.com/jaegertracing/jaeger-client-python). It allows service owners to instrument their services to get insights into what their architecture is doing.
 
-Jaeger is available now on [Github](https://github.com/jaegertracing/jaeger) as a public beta. Try it out by running the complete backend using the [Docker image](http://jaeger.readthedocs.io/en/latest/getting_started/#all-in-one-docker-image) along with a sample application, [HotROD](http://jaeger.readthedocs.io/en/latest/getting_started/#sample-application), to generate interesting traces.
+Jaeger is available now on [Github](https://github.com/jaegertracing/jaeger) as
+a public beta. Try it out by running the complete backend along with a sample
+application, to generate interesting traces.
 
 We hope that other organizations find Jaeger to be a useful tool, and we welcome contributions.
 Keep up to date by subscribing to our [mailing list](https://groups.google.com/forum/#!forum/jaeger-tracing).

--- a/data/refcache.json
+++ b/data/refcache.json
@@ -11,14 +11,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-05-29T19:45:58.088876-04:00"
   },
-  "http://jaeger.readthedocs.io/en/latest/getting_started/#all-in-one-docker-image": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:16.149491-04:00"
-  },
-  "http://jaeger.readthedocs.io/en/latest/getting_started/#sample-application": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:16.239057-04:00"
-  },
   "http://uber.github.io": {
     "StatusCode": 206,
     "LastSeen": "2025-05-29T19:41:09.641622-04:00"


### PR DESCRIPTION
## Which problem is this PR solving?

- #889

## Description of the changes

- Replaces the URL in `"url": "http://jaeger.readthedocs.io/en/latest/"` config excerpts by use of `https://www.jaegertracing.io/docs/latest/`
- Drops in-prose links to jaeger.readthedocs.io. This only happens in the first news entry of 2017
- Adds temporary URL ignore rules as work on #889 progresses incrementally
- Enables **full link checking** of the new versions of the docs via GitHub checks
  - Full link checking takes 3.8 sec in this run: https://github.com/jaegertracing/documentation/actions/runs/15358190795/job/43221310998?pr=890. See the screenshot below.
- Tweaks `clean` make target to delete the _content_ of `public`. This allows us to make `public` a local git repo so that we can track changes to generated site files.
- Changes best [reviewed by **ignoring whitespace** diffs](https://github.com/jaegertracing/documentation/pull/890/files?diff=unified&w=1)

## How was this change tested?

- GitHub ci-test workflow

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added ~unit~ tests for the new functionality
- [x] N/A ~I have run lint and test steps successfully~

---

Full link checking of the new versions of the docs in 3.8 sec:

> <img width="469" alt="image" src="https://github.com/user-attachments/assets/b4881aac-5c99-4247-a0c9-9bda7e86e404" />
