### PR TITLE
Fix page cross-version links, drop canonifyURLs, and more

### DIFF
--- a/.htmltest.external.yml
+++ b/.htmltest.external.yml
@@ -6,6 +6,7 @@ IgnoreDirs:
   - docs/1.*
 IgnoreURLs:
   - /livereload.js # cSpell:disable-line
+  - ^https://www.jaegertracing.io/js/lunr
   # Valid URLs, but servers yield 403 or similar errors
   - ^https://(twitter|x).com/[Jj]aeger[Tt]racing
   - ^https://calendar.google.com/

--- a/.htmltest.external.yml
+++ b/.htmltest.external.yml
@@ -17,4 +17,3 @@ IgnoreURLs:
   # Temporary: as we work on https://github.com/jaegertracing/documentation/issues/889
   - ^https://github.com/jaegertracing/jaeger/(blob|tree)/(v2|main/(internal|model|pkg))
   - ^https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory
-  - ^https://www.jaegertracing.io/docs/2.6/(cli|operator)/

--- a/.htmltest.old-versions.yml
+++ b/.htmltest.old-versions.yml
@@ -4,3 +4,5 @@ CheckExternal: false
 IgnoreAltMissing: true
 IgnoreURLs:
   - /livereload.js
+  - ^/docs/latest/ # ignore redirect of latest
+  - ^/docs/1.69/client-(features|libraries)/

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ netlify-branch-deploy: generate
 	--minify
 
 build: clean generate
-	hugo --logLevel info
+	hugo --cleanDestinationDir -e dev --logLevel info
 
 link-checker-setup:
 	curl https://raw.githubusercontent.com/wjdp/htmltest/master/godownloader.sh | bash

--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,20 @@ check-links:
 check-links-older:
 	$(HTMLTEST) --log-level 1 --conf .htmltest.old-versions.yml
 
+# Use --keep-going to ensure that the refcache gets saved even if there are
+# link-checking errors.
 check-links-external:
+	$(MAKE) --keep-going _restore-refcache _check-links-external _save-refcache
+
+_restore-refcache:
 	mkdir -p $(HTMLTEST_DIR)
 	cp data/refcache.json $(HTMLTEST_DIR)/refcache.json
+
+_check-links-external:
 	$(HTMLTEST) --log-level 1 --conf .htmltest.external.yml
+
+_save-refcache:
+	@echo "Saving refcache.json to data/refcache.json"
 	jq . $(HTMLTEST_DIR)/refcache.json > data/refcache.json
 
 check-links-all: check-links check-links-older check-links-external

--- a/Makefile
+++ b/Makefile
@@ -47,12 +47,12 @@ check-links:
 	$(HTMLTEST) --conf .htmltest.yml
 
 check-links-older:
-	$(HTMLTEST) --conf .htmltest.old-versions.yml
+	$(HTMLTEST) --log-level 1 --conf .htmltest.old-versions.yml
 
 check-links-external:
 	mkdir -p $(HTMLTEST_DIR)
 	cp data/refcache.json $(HTMLTEST_DIR)/refcache.json
-	$(HTMLTEST) --conf .htmltest.external.yml
+	$(HTMLTEST) --log-level 1 --conf .htmltest.external.yml
 	jq . $(HTMLTEST_DIR)/refcache.json > data/refcache.json
 
 check-links-all: check-links check-links-older check-links-external

--- a/content/docs/2.0/architecture.md
+++ b/content/docs/2.0/architecture.md
@@ -7,7 +7,7 @@ children:
 - title: Sampling
   url: sampling
 - title: SPM
-  url: SPM
+  url: spm
 - title: Terminology
   url: terminology
 ---

--- a/content/docs/2.1/architecture.md
+++ b/content/docs/2.1/architecture.md
@@ -7,7 +7,7 @@ children:
 - title: Sampling
   url: sampling
 - title: SPM
-  url: SPM
+  url: spm
 - title: Terminology
   url: terminology
 ---

--- a/content/docs/2.2/architecture.md
+++ b/content/docs/2.2/architecture.md
@@ -7,7 +7,7 @@ children:
 - title: Sampling
   url: sampling
 - title: SPM
-  url: SPM
+  url: spm
 - title: Terminology
   url: terminology
 ---

--- a/content/docs/2.3/architecture.md
+++ b/content/docs/2.3/architecture.md
@@ -7,7 +7,7 @@ children:
 - title: Sampling
   url: sampling
 - title: SPM
-  url: SPM
+  url: spm
 - title: Terminology
   url: terminology
 ---

--- a/content/docs/2.4/architecture.md
+++ b/content/docs/2.4/architecture.md
@@ -7,7 +7,7 @@ children:
 - title: Sampling
   url: sampling
 - title: SPM
-  url: SPM
+  url: spm
 - title: Terminology
   url: terminology
 ---

--- a/content/docs/2.5/architecture.md
+++ b/content/docs/2.5/architecture.md
@@ -7,7 +7,7 @@ children:
 - title: Sampling
   url: sampling
 - title: SPM
-  url: SPM
+  url: spm
 - title: Terminology
   url: terminology
 ---

--- a/content/docs/2.6/architecture.md
+++ b/content/docs/2.6/architecture.md
@@ -7,7 +7,7 @@ children:
 - title: Sampling
   url: sampling
 - title: SPM
-  url: SPM
+  url: spm
 - title: Terminology
   url: terminology
 ---

--- a/content/docs/next-release-v2/architecture.md
+++ b/content/docs/next-release-v2/architecture.md
@@ -7,7 +7,7 @@ children:
 - title: Sampling
   url: sampling
 - title: SPM
-  url: SPM
+  url: spm
 - title: Terminology
   url: terminology
 ---

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -1100,7 +1100,7 @@ spec:
 
 This example defines a default sampling strategy that is probabilistic, with a 50% chance of the trace instances being sampled.
 
-Refer to the Jaeger documentation on [Collector Sampling Configuration](/docs/latest/sampling/#collector-sampling-configuration) to see how service and endpoint sampling can be configured. The JSON representation described in that documentation can be used in the operator by converting to YAML.
+Refer to the Jaeger documentation on [Sampling Configuration](</docs/{{% param latest %}}/sampling/>) to see how service and endpoint sampling can be configured. The JSON representation described in that documentation can be used in the operator by converting to YAML.
 
 ## Finer grained configuration
 

--- a/content/get-involved.md
+++ b/content/get-involved.md
@@ -11,7 +11,7 @@ In order to understand the project better and come up with reasonable solutions,
 
 * Go through some Jaeger tutorials, such as [this blog post](https://medium.com/jaegertracing/take-jaeger-for-a-hotrod-ride-233cf43e46c2) or [this video](https://youtu.be/s7IrYt1igSM?si=B3NI6ruohKfSPUCl&t=445).
 * Run the [HotROD demo yourself](https://github.com/jaegertracing/jaeger/blob/main/examples/hotrod/README.md). The blogs and videos may be outdated, it's good to get hands on.
-* Review the [Jaeger architecture](/docs/latest/architecture/) and understand the components.
+* Review the [Jaeger architecture](</docs/{{% param latestV2 %}}/architecture/>) and understand the components.
 * Fork and clone the respective repositories to be able to [build and run the project locally](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md#getting-started).
 * Learn about contributing with the best practices, including how to [sign your code and contribute](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#creating-a-pull-request).
 * Try to solve some of the [simple open issues](./#help-with-coding) that you can find across Jaeger repositories.

--- a/content/mentorship-for-mentees.md
+++ b/content/mentorship-for-mentees.md
@@ -69,7 +69,7 @@ Congratulations on being selected as a Jaeger Mentee! It can be daunting when st
 - Read our contributing guides ([#1](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md),
   [#2](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md)),
   containing instructions on the development workflow.
-- Familiarize yourself with the [Jaeger documentation](/docs/latest/),
+- Familiarize yourself with the [Jaeger documentation](/docs/),
   which provides an architecture overview of Jaeger, a comprehensive list of all
   CLI flags, among others.
 - Carefully read through the Github issue to get a firm understanding of the requirements.

--- a/data/refcache.json
+++ b/data/refcache.json
@@ -3971,14 +3971,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-05-29T19:40:14.097927-04:00"
   },
-  "https://www.jaegertracing.io/docs/2.6/SPM": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.320058-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/SPM/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:37.480527-04:00"
-  },
   "https://www.jaegertracing.io/docs/2.6/apis": {
     "StatusCode": 206,
     "LastSeen": "2025-05-29T19:40:14.245142-04:00"

--- a/data/refcache.json
+++ b/data/refcache.json
@@ -4535,13 +4535,13 @@
     "StatusCode": 206,
     "LastSeen": "2025-05-29T19:40:19.249095-04:00"
   },
+  "https://www.jaegertracing.io/get-in-touch/#open-issue-or-discussion-on-github": {
+    "StatusCode": 206,
+    "LastSeen": "2025-05-29T19:40:18.763058-04:00"
+  },
   "https://www.jaegertracing.io/get-in-touch/#project-video-meetings": {
     "StatusCode": 206,
     "LastSeen": "2025-05-29T19:40:18.732783-04:00"
-  },
-  "https://www.jaegertracing.io/get-in-touch/#report-issues-on-github": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:18.763058-04:00"
   },
   "https://www.jaegertracing.io/get-in-touch/#via-chat": {
     "StatusCode": 206,

--- a/data/refcache.json
+++ b/data/refcache.json
@@ -1,4762 +1,1962 @@
 {
-  "http://cassandra.apache.org/doc/latest/tools/cqlsh.html": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:16:43.843546-04:00"
-  },
   "http://cncf.io": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:45:58.246106-04:00"
+    "LastSeen": "2025-05-31T11:27:45.695273-04:00"
   },
   "http://events.linuxfoundation.org/events/open-source-summit-north-america": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:45:58.088876-04:00"
+    "LastSeen": "2025-05-31T11:27:45.541192-04:00"
   },
   "http://uber.github.io": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:09.641622-04:00"
+    "LastSeen": "2025-05-31T11:26:06.435472-04:00"
   },
   "http://www.eweek.com/cloud/uber-and-lyft-bring-open-source-cloud-projects-to-cncf": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:02.838812-04:00"
+    "LastSeen": "2025-05-31T11:27:50.136912-04:00"
   },
   "http://www.zdnet.com/article/lyft-and-uber-travel-the-same-open-source-road/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:03.793495-04:00"
+    "LastSeen": "2025-05-31T11:27:52.204922-04:00"
   },
   "https://1password.com/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:40:25.478193-04:00"
+    "LastSeen": "2025-05-31T11:25:36.169148-04:00"
   },
   "https://artifacthub.io/packages/helm/bitnami/cassandra": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:53.181638-04:00"
+    "LastSeen": "2025-05-31T11:26:33.695704-04:00"
   },
   "https://artifacthub.io/packages/helm/bitnami/kafka": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:51.741913-04:00"
+    "LastSeen": "2025-05-31T11:26:31.619009-04:00"
   },
   "https://artifacthub.io/packages/helm/elastic/elasticsearch": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:42:34.87336-04:00"
+    "LastSeen": "2025-05-31T11:26:37.692796-04:00"
   },
   "https://artifacthub.io/packages/helm/opensearch-project-helm-charts/opensearch": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:19.175358-04:00"
+    "LastSeen": "2025-05-31T11:26:14.927814-04:00"
   },
   "https://base64.guru/converter/encode/hex": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:17.942176-04:00"
+    "LastSeen": "2025-05-31T11:26:13.668184-04:00"
   },
   "https://blog.openshift.com/openshift-commons-briefing-82-distributed-tracing-with-jaeger-prometheus-on-kubernetes/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:43:55.786639-04:00"
+    "LastSeen": "2025-05-31T11:27:06.945019-04:00"
   },
   "https://cassandra.apache.org/doc/latest/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:52.997564-04:00"
+    "LastSeen": "2025-05-31T11:26:33.478234-04:00"
   },
   "https://cassandra.apache.org/doc/latest/cassandra/managing/tools/cqlsh.html": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T20:21:09.095549-04:00"
+    "LastSeen": "2025-05-31T11:26:52.804955-04:00"
   },
   "https://cdn-images-1.medium.com/max/1000/1*jJm7BHkMListmocakAMcqA.png": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:23.757177-04:00"
+    "LastSeen": "2025-05-31T11:25:33.523768-04:00"
   },
   "https://cdn-images-1.medium.com/max/1024/0*iu_PaG5VWUVR2vRz": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:40:22.600408-04:00"
+    "LastSeen": "2025-05-31T11:25:30.833114-04:00"
   },
   "https://cdn-images-1.medium.com/max/1024/1*NKMqp96KpCm1hyhDyGP7fg.jpeg": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:24.098094-04:00"
+    "LastSeen": "2025-05-31T11:25:34.89259-04:00"
   },
   "https://cdn-images-1.medium.com/max/1024/1*T1FPdT_GcTo_2loOgrLyUA.png": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:23.937167-04:00"
+    "LastSeen": "2025-05-31T11:25:34.289296-04:00"
   },
   "https://cdn-images-1.medium.com/max/1024/1*b-RsMFPGcTtpxKaL2oRMEg.png": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:22.899028-04:00"
+    "LastSeen": "2025-05-31T11:25:32.285226-04:00"
   },
   "https://cdn-images-1.medium.com/max/1024/1*ccqn-B5CfJhwNkjFjqAFLg.jpeg": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:22.142285-04:00"
+    "LastSeen": "2025-05-31T11:25:29.505939-04:00"
   },
   "https://cdn-images-1.medium.com/max/1024/1*iFJFYZsdPvaFuwaAoZ1HRQ.jpeg": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:23.602685-04:00"
+    "LastSeen": "2025-05-31T11:25:32.895128-04:00"
   },
   "https://cdn-images-1.medium.com/max/1024/1*kHD8sLyWsbEcR0lqMhFFNA.png": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:24.281371-04:00"
+    "LastSeen": "2025-05-31T11:25:35.588248-04:00"
   },
   "https://cdn-images-1.medium.com/max/1024/1*nrY-UQFxXoQEjKKXDzHwSw.png": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:22.757839-04:00"
+    "LastSeen": "2025-05-31T11:25:31.591364-04:00"
   },
   "https://cdn-images-1.medium.com/max/1024/1*z0FkGABfi6lK35ojlFqLjQ.png": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:21.976293-04:00"
+    "LastSeen": "2025-05-31T11:25:28.900171-04:00"
   },
   "https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:01.321849-04:00"
+    "LastSeen": "2025-05-31T11:26:01.499347-04:00"
   },
   "https://cert-manager.io/docs/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:08.041683-04:00"
+    "LastSeen": "2025-05-31T11:27:17.76616-04:00"
   },
   "https://cert-manager.io/v1.6-docs/installation/#default-static-install": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:08.529762-04:00"
+    "LastSeen": "2025-05-31T11:27:18.428956-04:00"
   },
   "https://cloud-native.slack.com/archives/CGG7NFUJ3": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:40:17.638135-04:00"
+    "LastSeen": "2025-05-31T11:25:22.89823-04:00"
   },
   "https://cncf.io/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:09.820717-04:00"
+    "LastSeen": "2025-05-31T11:26:06.625885-04:00"
   },
   "https://code.jquery.com/jquery-3.3.1.min.js": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:19.056971-04:00"
+    "LastSeen": "2025-05-31T11:25:24.750524-04:00"
   },
   "https://code.visualstudio.com/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:28.383525-04:00"
+    "LastSeen": "2025-05-31T11:26:24.47204-04:00"
   },
   "https://contribute.cncf.io/contributors/getting-started/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:42.743866-04:00"
+    "LastSeen": "2025-05-31T11:25:52.432668-04:00"
   },
   "https://creativecommons.org/licenses/by/4.0": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:18.839239-04:00"
+    "LastSeen": "2025-05-31T11:25:24.256698-04:00"
   },
   "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:43.455432-04:00"
+    "LastSeen": "2025-05-31T11:26:44.987964-04:00"
   },
   "https://developers.google.com/protocol-buffers/docs/proto3#json": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:05.746303-04:00"
+    "LastSeen": "2025-05-31T11:26:04.74352-04:00"
   },
   "https://devops.com/cncf-advances-jaeger-distributed-tracing-project/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:45:51.881093-04:00"
+    "LastSeen": "2025-05-31T11:27:40.189667-04:00"
   },
   "https://docs.google.com/document/d/1ZuBAwTJvQN7xkWVvEFXj5WU9_JmS5TPiNbxCJSvPqX0/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:40:21.802036-04:00"
+    "LastSeen": "2025-05-31T11:25:28.64766-04:00"
   },
   "https://docs.google.com/document/d/1lAL0iHHozXZoIL4W0qiOWyXVPo9a6lUTeH9cz95O6Kg/edit": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:46:37.089444-04:00"
+    "LastSeen": "2025-05-31T11:28:26.751714-04:00"
   },
   "https://docs.google.com/document/d/1z4QrNtB9dMgT5SHNx-7Vc38XPLqnjmM2jFIupvkAEHo/view": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:42:34.354993-04:00"
+    "LastSeen": "2025-05-31T11:26:37.354602-04:00"
   },
   "https://docs.openshift.com/container-platform/4.2/logging/config/cluster-logging-elasticsearch.html": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:44:21.108663-04:00"
+    "LastSeen": "2025-05-31T11:27:26.579858-04:00"
   },
   "https://en.wikipedia.org/wiki/Clock_skew": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:54.677971-04:00"
+    "LastSeen": "2025-05-31T11:26:34.339698-04:00"
   },
   "https://fonts.googleapis.com/icon?family=Material+Icons": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:40:13.975764-04:00"
+    "LastSeen": "2025-05-31T11:25:20.545997-04:00"
   },
   "https://github.com/Ankit152": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:18.954731-04:00"
+    "LastSeen": "2025-05-31T11:28:08.181135-04:00"
   },
   "https://github.com/Ashmita152": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:34.308761-04:00"
+    "LastSeen": "2025-05-31T11:28:24.232523-04:00"
   },
   "https://github.com/ClickHouse/ClickHouse": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:38.201395-04:00"
+    "LastSeen": "2025-05-31T11:25:47.605413-04:00"
   },
   "https://github.com/FlamingSaint": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:23.227408-04:00"
+    "LastSeen": "2025-05-31T11:28:11.9746-04:00"
   },
   "https://github.com/GLVSKiriti": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:32.382773-04:00"
+    "LastSeen": "2025-05-31T11:28:22.046243-04:00"
   },
   "https://github.com/Manik2708": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:17.817532-04:00"
+    "LastSeen": "2025-05-31T11:28:06.757198-04:00"
   },
   "https://github.com/MarckK": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:35.026309-04:00"
+    "LastSeen": "2025-05-31T11:28:25.023695-04:00"
   },
   "https://github.com/PikBot": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:34.819298-04:00"
+    "LastSeen": "2025-05-31T11:28:24.73132-04:00"
   },
   "https://github.com/Pushkarm029": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:27.511745-04:00"
+    "LastSeen": "2025-05-31T11:28:16.958653-04:00"
   },
   "https://github.com/Wise-Wizard": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:24.415521-04:00"
+    "LastSeen": "2025-05-31T11:28:13.218136-04:00"
   },
   "https://github.com/afzal442": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:31.22845-04:00"
+    "LastSeen": "2025-05-31T11:28:20.607363-04:00"
   },
   "https://github.com/akagami-harsh": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:26.254301-04:00"
+    "LastSeen": "2025-05-31T11:28:15.752247-04:00"
   },
   "https://github.com/anshgoyalevil": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:27.828593-04:00"
+    "LastSeen": "2025-05-31T11:28:17.30579-04:00"
   },
   "https://github.com/cncf/artwork/tree/master/projects/jaeger": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:16.100496-04:00"
+    "LastSeen": "2025-05-31T11:25:21.420942-04:00"
   },
   "https://github.com/cncf/foundation/blob/main/code-of-conduct.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:35.388192-04:00"
+    "LastSeen": "2025-05-31T11:28:25.519779-04:00"
   },
   "https://github.com/cncf/foundation/blob/master/code-of-conduct.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:50.024364-04:00"
+    "LastSeen": "2025-05-31T11:25:57.418555-04:00"
   },
   "https://github.com/cncf/toc/blob/main/projects/jaeger/jaeger-graduation-proposal.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T20:16:44.82433-04:00"
+    "LastSeen": "2025-05-31T11:27:38.624865-04:00"
   },
   "https://github.com/dgraph-io/badger": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:23.975005-04:00"
+    "LastSeen": "2025-05-31T11:26:21.217642-04:00"
   },
   "https://github.com/go-delve/delve": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:28.287865-04:00"
+    "LastSeen": "2025-05-31T11:26:24.402415-04:00"
   },
   "https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md#enable-server-reflection": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:09.475616-04:00"
+    "LastSeen": "2025-05-31T11:26:05.925285-04:00"
   },
   "https://github.com/gsoria": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:34.538472-04:00"
+    "LastSeen": "2025-05-31T11:28:24.477849-04:00"
   },
   "https://github.com/haanhvu": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:33.413015-04:00"
+    "LastSeen": "2025-05-31T11:28:23.014995-04:00"
   },
   "https://github.com/hari45678": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:18.146891-04:00"
+    "LastSeen": "2025-05-31T11:28:07.289007-04:00"
   },
   "https://github.com/hellspawn679": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:20.314705-04:00"
+    "LastSeen": "2025-05-31T11:28:09.225815-04:00"
   },
   "https://github.com/jaegertracing/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:44.74594-04:00"
+    "LastSeen": "2025-05-31T11:25:54.804342-04:00"
   },
   "https://github.com/jaegertracing/documentation": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:17.073667-04:00"
+    "LastSeen": "2025-05-31T11:25:22.312104-04:00"
   },
   "https://github.com/jaegertracing/documentation/issues/250": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:11.153999-04:00"
+    "LastSeen": "2025-05-31T11:27:19.788792-04:00"
   },
   "https://github.com/jaegertracing/helm-charts/tree/v2": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:33.9152-04:00"
+    "LastSeen": "2025-05-31T11:26:37.029201-04:00"
   },
   "https://github.com/jaegertracing/jaeger": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:16.564035-04:00"
+    "LastSeen": "2025-05-31T11:25:21.871383-04:00"
   },
   "https://github.com/jaegertracing/jaeger-analytics": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:15.326977-04:00"
+    "LastSeen": "2025-05-31T11:26:11.252197-04:00"
   },
   "https://github.com/jaegertracing/jaeger-clickhouse": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:11.959428-04:00"
+    "LastSeen": "2025-05-31T11:26:08.355986-04:00"
   },
   "https://github.com/jaegertracing/jaeger-client-go": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:04.421047-04:00"
+    "LastSeen": "2025-05-31T11:27:52.850533-04:00"
   },
   "https://github.com/jaegertracing/jaeger-client-java": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:04.9061-04:00"
+    "LastSeen": "2025-05-31T11:27:53.448604-04:00"
   },
   "https://github.com/jaegertracing/jaeger-client-node": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:05.481954-04:00"
+    "LastSeen": "2025-05-31T11:27:53.935354-04:00"
   },
   "https://github.com/jaegertracing/jaeger-client-python": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:05.994921-04:00"
+    "LastSeen": "2025-05-31T11:27:54.547552-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:58.797139-04:00"
+    "LastSeen": "2025-05-31T11:27:10.104626-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/05fe64e9c305526901f70ff692030b388787e388/proto/api_v2/model.proto#L97": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:17.280883-04:00"
+    "LastSeen": "2025-05-31T11:26:12.925281-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/05fe64e9c305526901f70ff692030b388787e388/thrift/jaeger.thrift#L53": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:16.959382-04:00"
+    "LastSeen": "2025-05-31T11:26:12.622313-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v2/collector.proto": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:03.692217-04:00"
+    "LastSeen": "2025-05-31T11:26:03.557364-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v2/model.proto": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:03.027997-04:00"
+    "LastSeen": "2025-05-31T11:27:14.638013-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v2/query.proto": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:53.765163-04:00"
+    "LastSeen": "2025-05-31T11:27:05.142248-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v2/sampling.proto": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:05.43724-04:00"
+    "LastSeen": "2025-05-31T11:26:04.322624-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v3/query_service.proto": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:07.445815-04:00"
+    "LastSeen": "2025-05-31T11:26:05.395124-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/main/swagger/api_v3/query_service.swagger.json": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:40.828924-04:00"
+    "LastSeen": "2025-05-31T11:26:42.827816-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/main/thrift/jaeger.thrift": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:04.117756-04:00"
+    "LastSeen": "2025-05-31T11:26:03.922287-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/master/proto/api_v2/query.proto": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:04.265701-04:00"
+    "LastSeen": "2025-05-31T11:27:15.853736-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/master/proto/zipkin.proto": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:58.396989-04:00"
+    "LastSeen": "2025-05-31T11:27:09.697364-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:02.733122-04:00"
+    "LastSeen": "2025-05-31T11:27:14.311248-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/zipkincore.thrift": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:58.004646-04:00"
+    "LastSeen": "2025-05-31T11:27:09.296487-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/tree/main/proto/api_v2": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:08.673501-04:00"
+    "LastSeen": "2025-05-31T11:26:05.638884-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/dependency_storage.proto": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:41.641176-04:00"
+    "LastSeen": "2025-05-31T11:26:43.546171-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/trace_storage.proto": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:41.260514-04:00"
+    "LastSeen": "2025-05-31T11:26:43.188961-04:00"
   },
   "https://github.com/jaegertracing/jaeger-kubernetes": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:01.964417-04:00"
+    "LastSeen": "2025-05-31T11:27:13.446751-04:00"
   },
   "https://github.com/jaegertracing/jaeger-openshift": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:02.403475-04:00"
+    "LastSeen": "2025-05-31T11:27:13.950904-04:00"
   },
   "https://github.com/jaegertracing/jaeger-operator": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:23.046341-04:00"
+    "LastSeen": "2025-05-31T11:26:20.3511-04:00"
   },
   "https://github.com/jaegertracing/jaeger-operator#compatibility-matrix": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:08.464628-04:00"
+    "LastSeen": "2025-05-31T11:27:18.209842-04:00"
   },
   "https://github.com/jaegertracing/jaeger-operator#jager-v2-operator": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:33.503291-04:00"
+    "LastSeen": "2025-05-31T11:26:36.568317-04:00"
   },
   "https://github.com/jaegertracing/jaeger-operator/blob/main/examples/business-application-injected-sidecar.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:22.784601-04:00"
+    "LastSeen": "2025-05-31T11:27:28.778783-04:00"
   },
   "https://github.com/jaegertracing/jaeger-operator/issues/294": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:21.757394-04:00"
+    "LastSeen": "2025-05-31T11:27:27.229561-04:00"
   },
   "https://github.com/jaegertracing/jaeger-operator/issues/750": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:22.530655-04:00"
+    "LastSeen": "2025-05-31T11:27:28.429723-04:00"
   },
   "https://github.com/jaegertracing/jaeger-operator/releases/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:06.971493-04:00"
+    "LastSeen": "2025-05-31T11:27:17.275843-04:00"
   },
   "https://github.com/jaegertracing/jaeger-operator/tree/main/examples": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:11.59611-04:00"
+    "LastSeen": "2025-05-31T11:27:20.023644-04:00"
   },
   "https://github.com/jaegertracing/jaeger-operator/tree/main/examples/statefulset-manual-sidecar.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:23.125887-04:00"
+    "LastSeen": "2025-05-31T11:27:29.290786-04:00"
   },
   "https://github.com/jaegertracing/jaeger-ui/blob/main/packages/jaeger-ui/src/types/config.tsx": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:13.493054-04:00"
+    "LastSeen": "2025-05-31T11:26:09.681365-04:00"
   },
   "https://github.com/jaegertracing/jaeger-ui/blob/master/packages/jaeger-ui/src/utils/tracking/README.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:13.970618-04:00"
+    "LastSeen": "2025-05-31T11:26:10.137599-04:00"
   },
   "https://github.com/jaegertracing/jaeger-ui/issues": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:20.743005-04:00"
+    "LastSeen": "2025-05-31T11:25:26.812465-04:00"
   },
   "https://github.com/jaegertracing/jaeger-ui/issues/1288": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:33.13952-04:00"
+    "LastSeen": "2025-05-31T11:28:22.724768-04:00"
   },
   "https://github.com/jaegertracing/jaeger-ui/issues/1466": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:29.90304-04:00"
+    "LastSeen": "2025-05-31T11:28:19.481702-04:00"
   },
   "https://github.com/jaegertracing/jaeger-ui/issues/197": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:56.82884-04:00"
+    "LastSeen": "2025-05-31T11:26:35.741805-04:00"
   },
   "https://github.com/jaegertracing/jaeger-ui/issues/998": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:28.854212-04:00"
+    "LastSeen": "2025-05-31T11:28:18.590693-04:00"
   },
   "https://github.com/jaegertracing/jaeger-ui/labels/good%20first%20issue": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:49.012326-04:00"
+    "LastSeen": "2025-05-31T11:25:56.410793-04:00"
   },
   "https://github.com/jaegertracing/jaeger-ui/labels/help%20wanted": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:49.583522-04:00"
+    "LastSeen": "2025-05-31T11:25:56.945091-04:00"
   },
   "https://github.com/jaegertracing/jaeger/archive/v1.69.0.tar.gz": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:46:09.207416-04:00"
+    "LastSeen": "2025-05-31T11:27:57.312974-04:00"
   },
   "https://github.com/jaegertracing/jaeger/archive/v1.69.0.zip": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:46:08.955416-04:00"
+    "LastSeen": "2025-05-31T11:27:57.045474-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/7872d1b07439c3f2d316065b1fd53e885b26a66f/model/ids.go#L82": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:16.498538-04:00"
+    "LastSeen": "2025-05-31T11:26:12.265708-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:36.532346-04:00"
+    "LastSeen": "2025-05-31T11:28:26.385537-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md#getting-started": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:43.80406-04:00"
+    "LastSeen": "2025-05-31T11:25:53.82935-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:49.677848-04:00"
+    "LastSeen": "2025-05-31T11:25:57.018227-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#assigning-issues": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:50.108263-04:00"
+    "LastSeen": "2025-05-31T11:25:57.496924-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#creating-a-pull-request": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:44.072591-04:00"
+    "LastSeen": "2025-05-31T11:25:54.108977-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/GOVERNANCE.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:24.501884-04:00"
+    "LastSeen": "2025-05-31T11:25:35.828301-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/GOVERNANCE.md#becoming-a-maintainer": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:24.893594-04:00"
+    "LastSeen": "2025-05-31T11:25:35.904605-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/config-badger.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:48.115657-04:00"
+    "LastSeen": "2025-05-31T11:27:02.983903-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/config-cassandra.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:45.704917-04:00"
+    "LastSeen": "2025-05-31T11:27:02.352491-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/config-elasticsearch.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:47.279085-04:00"
+    "LastSeen": "2025-05-31T11:27:02.646913-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/config-kafka-collector.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:45.069457-04:00"
+    "LastSeen": "2025-05-31T11:27:01.655113-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/config-kafka-ingester.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:45.405878-04:00"
+    "LastSeen": "2025-05-31T11:27:01.988422-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/config-opensearch.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:41.611771-04:00"
+    "LastSeen": "2025-05-31T11:26:58.674059-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/config-remote-storage.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:43.404135-04:00"
+    "LastSeen": "2025-05-31T11:26:59.908378-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/config-tail-sampling-always-sample.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:41.940063-04:00"
+    "LastSeen": "2025-05-31T11:26:58.989031-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/config-tail-sampling-service-name-policy.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:42.239341-04:00"
+    "LastSeen": "2025-05-31T11:26:59.254038-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/config.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:43.10783-04:00"
+    "LastSeen": "2025-05-31T11:26:59.560753-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/internal/extension/jaegerquery/config.go#L16": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:39.906701-04:00"
+    "LastSeen": "2025-05-31T11:26:57.200757-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/docker-compose/scylladb/README.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:05.380276-04:00"
+    "LastSeen": "2025-05-31T11:27:16.155404-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/examples/hotrod/README.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:43.399457-04:00"
+    "LastSeen": "2025-05-31T11:25:53.515722-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/go.mod": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:57.539117-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/main/internal/storage/elasticsearch/config/config.go#L86": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:47.673702-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/main/internal/storage/v1/api/spanstore/interface.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:35.266885-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/main/internal/storage/v1/badger/docs/storage-file-non-root-permission.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:48.450452-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/main/internal/storage/v1/badger/docs/upgrade-v1-to-v3.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:04.913-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/main/internal/storage/v1/cassandra/schema/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:46.659193-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/main/internal/storage/v1/cassandra/schema/create.sh": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:46.325589-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/main/internal/storage/v1/grpc/proto/storage.proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:54.112712-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/main/internal/storage/v1/scylladb/README.md": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:10.849711-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/main/model/adjuster/clockskew.go": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:11.219045-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:10.990652-04:00"
+    "LastSeen": "2025-05-31T11:27:08.80692-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/monitoring/jaeger-mixin/dashboard-for-grafana.json": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:06.107866-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/main/pkg/cassandra/config/config.go#L21": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:10.552952-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.0.0/cmd/jaeger/config-badger.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:37.035552-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.0.0/cmd/jaeger/config-cassandra.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:53.961808-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.0.0/cmd/jaeger/config-elasticsearch.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:35.629131-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.0.0/cmd/jaeger/config-kafka-collector.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:52.143568-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.0.0/cmd/jaeger/config-kafka-ingester.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:52.431957-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.0.0/cmd/jaeger/config-opensearch.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:19.896563-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.0.0/cmd/jaeger/config-remote-storage.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:49:44.086253-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.0.0/cmd/jaeger/config-tail-sampling-always-sample.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:26.420087-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.0.0/cmd/jaeger/config-tail-sampling-service-name-policy.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:26.913858-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.0.0/cmd/jaeger/config.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:27.206522-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.0.0/examples/hotrod/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:51.346241-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.0.0/model/adjuster/clockskew.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:54.937691-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.0.0/model/proto/metrics/metricsquery.proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:02.451648-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.0.0/monitoring/jaeger-mixin/dashboard-for-grafana.json": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:49:44.513711-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.0.0/plugin/storage/badger/docs/storage-file-non-root-permission.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:37.396556-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.0.0/plugin/storage/cassandra/schema/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:54.276683-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.0.0/plugin/storage/grpc/proto/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:09.197298-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.0.0/plugin/storage/scylladb/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:54.557514-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.1.0/cmd/jaeger/config-badger.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:30.842589-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.1.0/cmd/jaeger/config-cassandra.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:27.478481-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.1.0/cmd/jaeger/config-elasticsearch.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:30.074176-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.1.0/cmd/jaeger/config-kafka-collector.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:26.855142-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.1.0/cmd/jaeger/config-kafka-ingester.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:27.1177-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.1.0/cmd/jaeger/config-opensearch.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:23.16203-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.1.0/cmd/jaeger/config-remote-storage.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:24.715299-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.1.0/cmd/jaeger/config-tail-sampling-always-sample.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:23.49507-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.1.0/cmd/jaeger/config-tail-sampling-service-name-policy.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:23.790233-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.1.0/cmd/jaeger/config.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:24.104063-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.1.0/cmd/jaeger/internal/extension/jaegerquery/config.go#L16": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:29.361597-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.1.0/examples/hotrod/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:26.50121-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.1.0/model/adjuster/clockskew.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:29.734416-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.1.0/model/proto/metrics/metricsquery.proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:22.355674-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.1.0/pkg/cassandra/config/config.go#L21": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:27.801452-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.1.0/pkg/es/config/config.go#L86": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:30.412486-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.1.0/plugin/storage/badger/docs/storage-file-non-root-permission.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:31.237441-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.1.0/plugin/storage/cassandra/schema/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:28.627247-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.1.0/plugin/storage/cassandra/schema/create.sh": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:28.160914-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.1.0/plugin/storage/grpc/proto/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:22.790824-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.1.0/plugin/storage/scylladb/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:29.011577-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.2.0/cmd/jaeger/config-badger.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:30.405728-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.2.0/cmd/jaeger/config-cassandra.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:26.670186-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.2.0/cmd/jaeger/config-elasticsearch.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:29.425203-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.2.0/cmd/jaeger/config-kafka-collector.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:26.065699-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.2.0/cmd/jaeger/config-kafka-ingester.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:26.348226-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.2.0/cmd/jaeger/config-opensearch.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:22.301561-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.2.0/cmd/jaeger/config-remote-storage.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:23.925769-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.2.0/cmd/jaeger/config-tail-sampling-always-sample.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:22.603448-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.2.0/cmd/jaeger/config-tail-sampling-service-name-policy.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:22.881692-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.2.0/cmd/jaeger/config.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:23.204499-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.2.0/cmd/jaeger/internal/extension/jaegerquery/config.go#L16": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:28.678688-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.2.0/examples/hotrod/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:25.64553-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.2.0/model/adjuster/clockskew.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:29.094637-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.2.0/model/proto/metrics/metricsquery.proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:21.511015-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.2.0/pkg/cassandra/config/config.go#L21": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:27.044862-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.2.0/pkg/es/config/config.go#L86": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:29.774206-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.2.0/plugin/storage/badger/docs/storage-file-non-root-permission.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:30.767053-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.2.0/plugin/storage/cassandra/schema/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:28.022394-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.2.0/plugin/storage/cassandra/schema/create.sh": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:27.461983-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.2.0/plugin/storage/grpc/proto/storage.proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:21.934217-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.2.0/plugin/storage/scylladb/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:28.380786-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.3.0/cmd/jaeger/config-badger.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:11.537004-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.3.0/cmd/jaeger/config-cassandra.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:08.370598-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.3.0/cmd/jaeger/config-elasticsearch.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:10.688148-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.3.0/cmd/jaeger/config-kafka-collector.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:07.711502-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.3.0/cmd/jaeger/config-kafka-ingester.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:08.045115-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.3.0/cmd/jaeger/config-opensearch.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:04.294705-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.3.0/cmd/jaeger/config-remote-storage.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:05.824493-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.3.0/cmd/jaeger/config-tail-sampling-always-sample.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:04.629154-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.3.0/cmd/jaeger/config-tail-sampling-service-name-policy.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:04.884291-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.3.0/cmd/jaeger/config.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:05.198494-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.3.0/cmd/jaeger/internal/extension/jaegerquery/config.go#L16": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:10.001202-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.3.0/examples/hotrod/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:07.380793-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.3.0/model/adjuster/clockskew.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:10.376662-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.3.0/model/proto/metrics/metricsquery.proto": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:12.32761-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.3.0/pkg/cassandra/config/config.go#L21": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:08.702726-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.3.0/pkg/es/config/config.go#L86": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:11.085909-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.3.0/plugin/storage/badger/docs/storage-file-non-root-permission.md": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:14.144486-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.3.0/plugin/storage/cassandra/schema/README.md": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:13.573746-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.3.0/plugin/storage/cassandra/schema/create.sh": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:13.338432-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.3.0/plugin/storage/grpc/proto/storage.proto": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:12.62944-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.3.0/plugin/storage/scylladb/README.md": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:13.827396-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.4.0/cmd/jaeger/config-badger.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:53.993545-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.4.0/cmd/jaeger/config-cassandra.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:50.651802-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.4.0/cmd/jaeger/config-elasticsearch.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:53.201938-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.4.0/cmd/jaeger/config-kafka-collector.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:50.038314-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.4.0/cmd/jaeger/config-kafka-ingester.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:50.309772-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.4.0/cmd/jaeger/config-opensearch.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:46.456783-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.4.0/cmd/jaeger/config-remote-storage.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:48.054969-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.4.0/cmd/jaeger/config-tail-sampling-always-sample.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:46.748402-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.4.0/cmd/jaeger/config-tail-sampling-service-name-policy.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:47.029335-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.4.0/cmd/jaeger/config.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:47.391471-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.4.0/cmd/jaeger/internal/extension/jaegerquery/config.go#L16": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:52.514724-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.4.0/examples/hotrod/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:49.682244-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.4.0/internal/storage/v1/badger/docs/storage-file-non-root-permission.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:54.336025-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.4.0/internal/storage/v1/cassandra/schema/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:51.868136-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.4.0/internal/storage/v1/cassandra/schema/create.sh": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:51.331244-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.4.0/internal/storage/v1/grpc/proto/storage.proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:46.081985-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.4.0/internal/storage/v1/scylladb/README.md": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:11.967434-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.4.0/model/adjuster/clockskew.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:52.798591-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.4.0/model/proto/metrics/metricsquery.proto": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:11.570911-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.4.0/pkg/cassandra/config/config.go#L21": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:50.967497-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.4.0/pkg/es/config/config.go#L86": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:53.536946-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.5.0/cmd/jaeger/config-badger.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:48.817631-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.5.0/cmd/jaeger/config-cassandra.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:45.641287-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.5.0/cmd/jaeger/config-elasticsearch.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:47.845017-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.5.0/cmd/jaeger/config-kafka-collector.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:45.031178-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.5.0/cmd/jaeger/config-kafka-ingester.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:45.346036-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.5.0/cmd/jaeger/config-opensearch.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:41.67772-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.5.0/cmd/jaeger/config-remote-storage.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:43.246536-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.5.0/cmd/jaeger/config-tail-sampling-always-sample.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:41.985006-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.5.0/cmd/jaeger/config-tail-sampling-service-name-policy.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:42.267776-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.5.0/cmd/jaeger/config.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:42.614821-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.5.0/cmd/jaeger/internal/extension/jaegerquery/config.go#L16": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:47.28152-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.5.0/examples/hotrod/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:44.770068-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.5.0/internal/storage/elasticsearch/config/config.go#L86": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:48.172832-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.5.0/internal/storage/v1/badger/docs/storage-file-non-root-permission.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:49.177521-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.5.0/internal/storage/v1/cassandra/schema/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:46.703915-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.5.0/internal/storage/v1/cassandra/schema/create.sh": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:46.34245-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.5.0/internal/storage/v1/grpc/proto/storage.proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:41.323609-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.5.0/internal/storage/v1/scylladb/README.md": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:15.561605-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.5.0/model/adjuster/clockskew.go": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:15.828035-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.5.0/model/proto/metrics/metricsquery.proto": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:14.729644-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.5.0/pkg/cassandra/config/config.go#L21": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:15.240906-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.6.0/cmd/jaeger/config-badger.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:12.639894-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.6.0/cmd/jaeger/config-cassandra.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:09.700673-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.6.0/cmd/jaeger/config-elasticsearch.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:11.839502-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.6.0/cmd/jaeger/config-kafka-collector.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:08.394831-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.6.0/cmd/jaeger/config-kafka-ingester.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:08.730463-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.6.0/cmd/jaeger/config-opensearch.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:44.458717-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.6.0/cmd/jaeger/config-remote-storage.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:46.102619-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.6.0/cmd/jaeger/config-tail-sampling-always-sample.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:44.819618-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.6.0/cmd/jaeger/config-tail-sampling-service-name-policy.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:45.185498-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.6.0/cmd/jaeger/config.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:45.522593-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.6.0/cmd/jaeger/internal/extension/jaegerquery/config.go#L16": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:38.668705-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.6.0/examples/hotrod/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:08.089938-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.6.0/internal/storage/elasticsearch/config/config.go#L86": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:12.163606-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.6.0/internal/storage/v1/badger/docs/storage-file-non-root-permission.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:12.996639-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.6.0/internal/storage/v1/cassandra/schema/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:10.790639-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.6.0/internal/storage/v1/cassandra/schema/create.sh": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:10.404944-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.6.0/internal/storage/v1/scylladb/README.md": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:09.358248-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.6.0/model/adjuster/clockskew.go": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:07.907641-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.6.0/model/proto/metrics/metricsquery.proto": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:08.302058-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/blob/v2.6.0/pkg/cassandra/config/config.go#L21": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:08.902697-04:00"
+    "LastSeen": "2025-05-31T11:27:16.616166-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:18.418867-04:00"
+    "LastSeen": "2025-05-31T11:25:23.744028-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/1537": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:10.699817-04:00"
+    "LastSeen": "2025-05-31T11:27:19.33749-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/1639": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:41.955284-04:00"
+    "LastSeen": "2025-05-31T11:25:51.408473-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/166": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:16.094142-04:00"
+    "LastSeen": "2025-05-31T11:26:11.958429-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/1718": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:56.619977-04:00"
+    "LastSeen": "2025-05-31T11:27:07.943446-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/2534": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:18.592882-04:00"
+    "LastSeen": "2025-05-31T11:28:07.77856-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/3381": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:32.062345-04:00"
+    "LastSeen": "2025-05-31T11:28:21.527144-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/355": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:42.537942-04:00"
+    "LastSeen": "2025-05-31T11:25:51.943814-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/4196": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:34.113074-04:00"
+    "LastSeen": "2025-05-31T11:28:23.996203-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/4600": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:30.904299-04:00"
+    "LastSeen": "2025-05-31T11:28:20.315968-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/4708": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:39.892263-04:00"
+    "LastSeen": "2025-05-31T11:25:49.179704-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/4739": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:14.834236-04:00"
+    "LastSeen": "2025-05-31T11:28:03.154884-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/4868": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:22.287223-04:00"
+    "LastSeen": "2025-05-31T11:28:11.014374-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/5058": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:39.077987-04:00"
+    "LastSeen": "2025-05-31T11:25:48.465922-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/5084": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:26.89864-04:00"
+    "LastSeen": "2025-05-31T11:28:16.447803-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/5632": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:24.011165-04:00"
+    "LastSeen": "2025-05-31T11:28:12.874933-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/5633": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:25.498973-04:00"
+    "LastSeen": "2025-05-31T11:28:14.977607-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/5766": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:20.013799-04:00"
+    "LastSeen": "2025-05-31T11:28:08.943948-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/5767": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:21.149326-04:00"
+    "LastSeen": "2025-05-31T11:28:09.956814-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/5910": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:40.336177-04:00"
+    "LastSeen": "2025-05-31T11:25:49.709294-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/6186": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:59.920514-04:00"
+    "LastSeen": "2025-05-31T11:26:00.069553-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/6321": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:07.508303-04:00"
+    "LastSeen": "2025-05-31T11:27:55.625844-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/638": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:24.873552-04:00"
+    "LastSeen": "2025-05-31T11:26:22.028094-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/6458": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:37.852347-04:00"
+    "LastSeen": "2025-05-31T11:25:47.280784-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/6628": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:38.380035-04:00"
+    "LastSeen": "2025-05-31T11:26:42.132631-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/6641": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:17.57185-04:00"
+    "LastSeen": "2025-05-31T11:28:06.492219-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/729": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:41.122406-04:00"
+    "LastSeen": "2025-05-31T11:25:50.73533-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/961#issuecomment-453925244": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:56.0661-04:00"
+    "LastSeen": "2025-05-31T11:26:34.998874-04:00"
   },
   "https://github.com/jaegertracing/jaeger/labels/good%20first%20issue": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:45.187004-04:00"
+    "LastSeen": "2025-05-31T11:25:55.413302-04:00"
   },
   "https://github.com/jaegertracing/jaeger/labels/help%20wanted": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:45.746534-04:00"
+    "LastSeen": "2025-05-31T11:25:55.874193-04:00"
   },
   "https://github.com/jaegertracing/jaeger/releases/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:10.95703-04:00"
+    "LastSeen": "2025-05-31T11:27:58.91335-04:00"
   },
   "https://github.com/jaegertracing/jaeger/releases/download/v1.69.0/jaeger-1.69.0-darwin-amd64.tar.gz": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:09.497993-04:00"
+    "LastSeen": "2025-05-31T11:27:57.623656-04:00"
   },
   "https://github.com/jaegertracing/jaeger/releases/download/v1.69.0/jaeger-1.69.0-linux-amd64.tar.gz": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:09.722503-04:00"
+    "LastSeen": "2025-05-31T11:27:57.951819-04:00"
   },
   "https://github.com/jaegertracing/jaeger/releases/download/v1.69.0/jaeger-1.69.0-windows-amd64.tar.gz": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:09.966481-04:00"
+    "LastSeen": "2025-05-31T11:27:58.178996-04:00"
   },
   "https://github.com/jaegertracing/jaeger/releases/download/v1.69.0/jaeger-2.6.0-darwin-amd64.tar.gz": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:08.241168-04:00"
+    "LastSeen": "2025-05-31T11:27:56.311955-04:00"
   },
   "https://github.com/jaegertracing/jaeger/releases/download/v1.69.0/jaeger-2.6.0-linux-amd64.tar.gz": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:08.469638-04:00"
+    "LastSeen": "2025-05-31T11:27:56.533224-04:00"
   },
   "https://github.com/jaegertracing/jaeger/releases/download/v1.69.0/jaeger-2.6.0-windows-amd64.tar.gz": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:08.703425-04:00"
+    "LastSeen": "2025-05-31T11:27:56.738984-04:00"
   },
   "https://github.com/jaegertracing/jaeger/releases/tag/v1.22.0": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:36.189378-04:00"
+    "LastSeen": "2025-05-31T11:26:39.511882-04:00"
   },
   "https://github.com/jaegertracing/jaeger/releases/tag/v1.39.0": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:15.279608-04:00"
+    "LastSeen": "2025-05-31T11:28:03.638054-04:00"
   },
   "https://github.com/jaegertracing/jaeger/releases/tag/v1.69.0": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:07.92688-04:00"
+    "LastSeen": "2025-05-31T11:27:56.023416-04:00"
   },
   "https://github.com/jaegertracing/jaeger/security/advisories": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:17.337244-04:00"
+    "LastSeen": "2025-05-31T11:25:22.570571-04:00"
   },
   "https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:39.619216-04:00"
+    "LastSeen": "2025-05-31T11:26:56.857361-04:00"
   },
   "https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/config-spm.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:40.874105-04:00"
+    "LastSeen": "2025-05-31T11:26:58.046126-04:00"
   },
   "https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/internal/extension/jaegerquery": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:44.058542-04:00"
+    "LastSeen": "2025-05-31T11:27:00.613028-04:00"
   },
   "https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/internal/extension/jaegerstorage": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:43.688581-04:00"
+    "LastSeen": "2025-05-31T11:27:00.244406-04:00"
   },
   "https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/internal/extension/remotesampling": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:44.743354-04:00"
+    "LastSeen": "2025-05-31T11:27:01.336249-04:00"
   },
   "https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/internal/processors/adaptivesampling": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:44.356284-04:00"
+    "LastSeen": "2025-05-31T11:27:00.921266-04:00"
   },
   "https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:40.524215-04:00"
+    "LastSeen": "2025-05-31T11:26:57.535262-04:00"
   },
   "https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:41.249852-04:00"
+    "LastSeen": "2025-05-31T11:26:58.127574-04:00"
   },
   "https://github.com/jaegertracing/jaeger/tree/main/examples/hotrod": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:11.918096-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/main/internal/storage/v1/grpc": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:05.782526-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/main/internal/storage/v2/api/tracestore": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:35.549089-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/main/internal/storage/v2/grpc": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:42.20731-04:00"
+    "LastSeen": "2025-05-31T11:27:59.805268-04:00"
   },
   "https://github.com/jaegertracing/jaeger/tree/main/monitoring/jaeger-mixin": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:06.458766-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.0.0/cmd/jaeger": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:59.36006-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.0.0/docker-compose/monitor": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:00.682059-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.0.0/docker-compose/monitor#http-api": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:02.536977-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.0.0/monitoring/jaeger-mixin": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:32.947142-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.0.0/plugin/storage/grpc": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:29.457194-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.1.0/cmd/jaeger": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:21.182992-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.1.0/cmd/jaeger/config-spm.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:22.044416-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.1.0/cmd/jaeger/internal/extension/jaegerquery": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:25.274849-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.1.0/cmd/jaeger/internal/extension/jaegerstorage": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:25.009354-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.1.0/cmd/jaeger/internal/extension/remotesampling": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:25.820185-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.1.0/cmd/jaeger/internal/processors/adaptivesampling": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:25.525694-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.1.0/docker-compose/monitor": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:21.57993-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.1.0/docker-compose/monitor#http-api": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:22.424745-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.1.0/plugin/storage/grpc": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:24.441326-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.2.0/cmd/jaeger": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:20.2902-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.2.0/cmd/jaeger/config-spm.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:21.194742-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.2.0/cmd/jaeger/internal/extension/jaegerquery": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:24.565862-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.2.0/cmd/jaeger/internal/extension/jaegerstorage": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:24.274611-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.2.0/cmd/jaeger/internal/extension/remotesampling": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:25.127733-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.2.0/cmd/jaeger/internal/processors/adaptivesampling": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:24.831069-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.2.0/docker-compose/monitor": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:20.672168-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.2.0/docker-compose/monitor#http-api": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:21.607436-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.2.0/plugin/storage/grpc": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:23.572037-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.3.0/cmd/jaeger": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:02.396932-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.3.0/cmd/jaeger/config-spm.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:03.270649-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.3.0/cmd/jaeger/internal/extension/jaegerquery": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:06.435885-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.3.0/cmd/jaeger/internal/extension/jaegerstorage": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:06.167027-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.3.0/cmd/jaeger/internal/extension/remotesampling": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:07.043705-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.3.0/cmd/jaeger/internal/processors/adaptivesampling": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:06.715501-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.3.0/docker-compose/monitor": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:02.860854-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.3.0/docker-compose/monitor#http-api": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:03.617225-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.3.0/plugin/storage/grpc": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:13.007718-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.4.0/cmd/jaeger": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:44.389293-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.4.0/cmd/jaeger/config-spm.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:45.321488-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.4.0/cmd/jaeger/internal/extension/jaegerquery": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:48.723913-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.4.0/cmd/jaeger/internal/extension/jaegerstorage": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:48.420496-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.4.0/cmd/jaeger/internal/extension/remotesampling": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:49.295052-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.4.0/cmd/jaeger/internal/processors/adaptivesampling": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:48.9863-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.4.0/docker-compose/monitor": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:44.834445-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.4.0/docker-compose/monitor#http-api": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:45.688625-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.4.0/internal/storage/v1/grpc": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:47.734522-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.5.0/cmd/jaeger": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:39.83997-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.5.0/cmd/jaeger/config-spm.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:40.628481-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.5.0/cmd/jaeger/internal/extension/jaegerquery": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:43.90638-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.5.0/cmd/jaeger/internal/extension/jaegerstorage": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:43.554506-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.5.0/cmd/jaeger/internal/extension/remotesampling": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:44.428731-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.5.0/cmd/jaeger/internal/processors/adaptivesampling": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:44.163636-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.5.0/docker-compose/monitor": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:40.240324-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.5.0/docker-compose/monitor#http-api": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:41.008755-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.5.0/internal/storage/v1/grpc": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:42.967864-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.6.0/cmd/jaeger": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:37.820911-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.6.0/cmd/jaeger/config-spm.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:39.728859-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.6.0/cmd/jaeger/internal/extension/jaegerquery": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:46.837438-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.6.0/cmd/jaeger/internal/extension/jaegerstorage": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:46.543081-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.6.0/cmd/jaeger/internal/extension/remotesampling": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:47.382564-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.6.0/cmd/jaeger/internal/processors/adaptivesampling": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:47.06222-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.6.0/docker-compose/monitor": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:39.308496-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.6.0/docker-compose/monitor#http-api": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:40.47027-04:00"
-  },
-  "https://github.com/jaegertracing/jaeger/tree/v2.6.0/internal/storage/v2/grpc": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:45.837634-04:00"
+    "LastSeen": "2025-05-31T11:27:16.876109-04:00"
   },
   "https://github.com/jaegertracing/spark-dependencies": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:14.827036-04:00"
+    "LastSeen": "2025-05-31T11:26:10.585283-04:00"
   },
   "https://github.com/james-ryans": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:27.118055-04:00"
+    "LastSeen": "2025-05-31T11:28:16.671636-04:00"
   },
   "https://github.com/joeyyy09": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:21.576951-04:00"
+    "LastSeen": "2025-05-31T11:28:10.274188-04:00"
   },
   "https://github.com/k8ssandra/cass-operator": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:53.546597-04:00"
+    "LastSeen": "2025-05-31T11:26:34.088948-04:00"
   },
   "https://github.com/kubernetes/charts/tree/master/incubator/jaeger": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:23.429498-04:00"
+    "LastSeen": "2025-05-31T11:26:20.645734-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:36.984299-04:00"
+    "LastSeen": "2025-05-31T11:25:46.232379-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:51.922435-04:00"
+    "LastSeen": "2025-05-31T11:26:50.639345-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/README.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:40.04774-04:00"
+    "LastSeen": "2025-05-31T11:26:42.513085-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:02.046184-04:00"
+    "LastSeen": "2025-05-31T11:26:02.216961-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:02.124813-04:00"
+    "LastSeen": "2025-05-31T11:26:02.294191-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/kafkaexporter/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:50.735162-04:00"
+    "LastSeen": "2025-05-31T11:26:49.537601-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/tailsamplingprocessor/README.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:50.835615-04:00"
+    "LastSeen": "2025-05-31T11:26:31.354979-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:02.832557-04:00"
+    "LastSeen": "2025-05-31T11:26:02.601114-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/kafkaexporter/README.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:09.061193-04:00"
+    "LastSeen": "2025-05-31T11:26:52.263523-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusexporter": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:51.050511-04:00"
+    "LastSeen": "2025-05-31T11:26:49.796596-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckv2extension": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:07.192949-04:00"
+    "LastSeen": "2025-05-31T11:26:51.294525-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/pprofextension": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:07.768828-04:00"
+    "LastSeen": "2025-05-31T11:26:51.852584-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/attributesprocessor": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:49.534991-04:00"
+    "LastSeen": "2025-05-31T11:26:48.364823-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:49.785995-04:00"
+    "LastSeen": "2025-05-31T11:26:48.590816-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:25.9751-04:00"
+    "LastSeen": "2025-05-31T11:26:23.45405-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/jaegerreceiver": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:47.873378-04:00"
+    "LastSeen": "2025-05-31T11:26:46.434654-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kafkareceiver": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:48.150312-04:00"
+    "LastSeen": "2025-05-31T11:26:46.735403-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kafkareceiver/README.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:09.448637-04:00"
+    "LastSeen": "2025-05-31T11:26:52.657133-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/zipkinreceiver": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:48.43609-04:00"
+    "LastSeen": "2025-05-31T11:26:47.116005-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md#client-configuration": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:11.013449-04:00"
+    "LastSeen": "2025-05-31T11:26:53.101627-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/blob/main/connector/forwardconnector/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:26.153359-04:00"
+    "LastSeen": "2025-05-31T11:26:50.971435-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:06.101264-04:00"
+    "LastSeen": "2025-05-31T11:26:05.120935-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/debugexporter": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:51.336539-04:00"
+    "LastSeen": "2025-05-31T11:26:50.023872-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/nopexporter": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:51.56008-04:00"
+    "LastSeen": "2025-05-31T11:26:50.302042-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:50.03393-04:00"
+    "LastSeen": "2025-05-31T11:26:48.877648-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:50.284877-04:00"
+    "LastSeen": "2025-05-31T11:26:49.088589-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/zpagesextension": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:07.481909-04:00"
+    "LastSeen": "2025-05-31T11:26:51.612363-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:48.982937-04:00"
+    "LastSeen": "2025-05-31T11:26:47.69827-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:49.246871-04:00"
+    "LastSeen": "2025-05-31T11:26:47.966056-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/nopreceiver": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:48.687289-04:00"
+    "LastSeen": "2025-05-31T11:26:47.428865-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/otlpreceiver": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:47.645049-04:00"
+    "LastSeen": "2025-05-31T11:26:46.194626-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-cpp": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:34.156693-04:00"
+    "LastSeen": "2025-05-31T11:25:44.509207-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:33.514569-04:00"
+    "LastSeen": "2025-05-31T11:25:43.798897-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Shims.OpenTracing": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:33.78376-04:00"
+    "LastSeen": "2025-05-31T11:25:44.104326-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-go": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:31.06554-04:00"
+    "LastSeen": "2025-05-31T11:25:41.060786-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-go-contrib/pull/936": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:32.67765-04:00"
+    "LastSeen": "2025-05-31T11:25:43.063112-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-go/tree/main/bridge/opentracing": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:32.995346-04:00"
+    "LastSeen": "2025-05-31T11:25:43.41132-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-java": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:28.420996-04:00"
+    "LastSeen": "2025-05-31T11:25:38.66836-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-java/tree/main/opentracing-shim": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:28.995692-04:00"
+    "LastSeen": "2025-05-31T11:25:39.19469-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/jaeger-remote-sampler": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:28.650684-04:00"
+    "LastSeen": "2025-05-31T11:25:38.962518-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-js": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:30.299242-04:00"
+    "LastSeen": "2025-05-31T11:25:40.415015-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-shim-opentracing": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:30.581356-04:00"
+    "LastSeen": "2025-05-31T11:25:40.720458-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:05.829427-04:00"
+    "LastSeen": "2025-05-31T11:26:04.81851-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlpgrpc": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:03.317995-04:00"
+    "LastSeen": "2025-05-31T11:26:03.102055-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlphttp": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:03.400571-04:00"
+    "LastSeen": "2025-05-31T11:26:03.179552-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/trace/v1/trace_service.proto": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:41.919901-04:00"
+    "LastSeen": "2025-05-31T11:26:43.903087-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-python": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:29.589983-04:00"
+    "LastSeen": "2025-05-31T11:25:39.653683-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-python/tree/main/shim/opentelemetry-opentracing-shim": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:29.880141-04:00"
+    "LastSeen": "2025-05-31T11:25:39.966323-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:27.608975-04:00"
+    "LastSeen": "2025-05-31T11:26:23.750114-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#span": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:43.115332-04:00"
+    "LastSeen": "2025-05-31T11:26:44.632423-04:00"
   },
   "https://github.com/opensearch-project/opensearch-k8s-operator": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:19.618888-04:00"
+    "LastSeen": "2025-05-31T11:26:15.332157-04:00"
   },
   "https://github.com/openshift/elasticsearch-operator": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:35.282999-04:00"
+    "LastSeen": "2025-05-31T11:26:38.117125-04:00"
   },
   "https://github.com/opentracing/specification/blob/master/specification.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:12.797313-04:00"
+    "LastSeen": "2025-05-31T11:26:08.829387-04:00"
   },
   "https://github.com/opentracing/specification/blob/master/specification.md#references-between-spans": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:23.50703-04:00"
+    "LastSeen": "2025-05-31T11:26:20.722065-04:00"
   },
   "https://github.com/openzipkin/zipkin-api": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:59.257971-04:00"
+    "LastSeen": "2025-05-31T11:27:10.542741-04:00"
   },
   "https://github.com/openzipkin/zipkin-api/blob/master/thrift/zipkinCore.thrift": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:59.600477-04:00"
+    "LastSeen": "2025-05-31T11:27:10.891939-04:00"
   },
   "https://github.com/openzipkin/zipkin-api/blob/master/zipkin.proto": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:59.8603-04:00"
+    "LastSeen": "2025-05-31T11:27:11.154511-04:00"
   },
   "https://github.com/operator-framework/operator-lifecycle-manager": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:36.026812-04:00"
+    "LastSeen": "2025-05-31T11:27:31.537258-04:00"
   },
   "https://github.com/orgs/jaegertracing/discussions": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:20.186968-04:00"
+    "LastSeen": "2025-05-31T11:25:26.259836-04:00"
   },
   "https://github.com/orgs/jaegertracing/projects/4/views/1": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:34.943547-04:00"
+    "LastSeen": "2025-05-31T11:25:45.884372-04:00"
   },
   "https://github.com/orgs/jaegertracing/repositories": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:21.282478-04:00"
+    "LastSeen": "2025-05-31T11:25:27.218529-04:00"
   },
   "https://github.com/pipiland2612": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:16.883827-04:00"
+    "LastSeen": "2025-05-31T11:28:05.803509-04:00"
   },
   "https://github.com/pmuls99": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:30.169516-04:00"
+    "LastSeen": "2025-05-31T11:28:19.709348-04:00"
   },
   "https://github.com/prathamesh-mutkure": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:29.116801-04:00"
+    "LastSeen": "2025-05-31T11:28:18.891198-04:00"
   },
   "https://github.com/robbert229/jaeger-postgresql": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:44.872491-04:00"
+    "LastSeen": "2025-05-31T11:26:25.557886-04:00"
   },
   "https://github.com/search": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:44.268158-04:00"
+    "LastSeen": "2025-05-31T11:25:54.368612-04:00"
   },
   "https://github.com/uber-go/zap": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:25.429661-04:00"
+    "LastSeen": "2025-05-31T11:26:22.570462-04:00"
   },
   "https://github.com/w3c/distributed-tracing": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:34.623897-04:00"
+    "LastSeen": "2025-05-31T11:25:45.200287-04:00"
   },
   "https://github.com/yurishkuro/microsim": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:01.112539-04:00"
+    "LastSeen": "2025-05-31T11:26:00.587333-04:00"
   },
   "https://github.com/yurishkuro/opentracing-tutorial/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:54.455179-04:00"
+    "LastSeen": "2025-05-31T11:27:05.59347-04:00"
   },
   "https://golang.org/doc/install": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:43:57.227007-04:00"
+    "LastSeen": "2025-05-31T11:27:08.471418-04:00"
   },
   "https://golangforall.com/en/post/go-docker-delve-remote-debug.html": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:28.829777-04:00"
+    "LastSeen": "2025-05-31T11:26:24.972585-04:00"
   },
   "https://groups.google.com/forum/#!forum/jaeger-tracing": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:40:17.739345-04:00"
+    "LastSeen": "2025-05-31T11:25:23.068057-04:00"
   },
   "https://hub.docker.com/_/cassandra": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:53.11579-04:00"
+    "LastSeen": "2025-05-31T11:26:33.619626-04:00"
   },
   "https://hub.docker.com/_/elasticsearch": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:42:34.794111-04:00"
+    "LastSeen": "2025-05-31T11:26:37.621642-04:00"
   },
   "https://hub.docker.com/r/apache/kafka": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:51.655642-04:00"
+    "LastSeen": "2025-05-31T11:26:31.538195-04:00"
   },
   "https://hub.docker.com/r/jaegertracing": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:44:00.054126-04:00"
+    "LastSeen": "2025-05-31T11:27:11.373086-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:46:11.179424-04:00"
+    "LastSeen": "2025-05-31T11:27:59.10542-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/all-in-one": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:46:11.454527-04:00"
+    "LastSeen": "2025-05-31T11:27:59.345327-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/all-in-one/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:44:00.453842-04:00"
+    "LastSeen": "2025-05-31T11:27:11.891187-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/example-hotrod": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:46:11.611164-04:00"
+    "LastSeen": "2025-05-31T11:27:59.472205-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:46:11.319872-04:00"
+    "LastSeen": "2025-05-31T11:27:59.256171-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger-agent": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:46:13.789948-04:00"
+    "LastSeen": "2025-05-31T11:28:01.645764-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger-cassandra-schema": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:46:13.514881-04:00"
+    "LastSeen": "2025-05-31T11:28:01.379754-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger-collector": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:46:12.675841-04:00"
+    "LastSeen": "2025-05-31T11:28:00.578199-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger-collector/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:44:00.673205-04:00"
+    "LastSeen": "2025-05-31T11:27:12.095372-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger-es-index-cleaner": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:46:13.656276-04:00"
+    "LastSeen": "2025-05-31T11:28:01.51746-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger-ingester": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:46:12.971119-04:00"
+    "LastSeen": "2025-05-31T11:28:00.836544-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger-ingester/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:44:01.147176-04:00"
+    "LastSeen": "2025-05-31T11:27:12.560954-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger-operator": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:46:13.379309-04:00"
+    "LastSeen": "2025-05-31T11:28:01.245601-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger-query": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:46:12.829344-04:00"
+    "LastSeen": "2025-05-31T11:28:00.703567-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger-query/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:44:00.918564-04:00"
+    "LastSeen": "2025-05-31T11:27:12.319674-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger-remote-storage": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:46:13.101056-04:00"
+    "LastSeen": "2025-05-31T11:28:00.974793-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger-remote-storage/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:44:01.396992-04:00"
+    "LastSeen": "2025-05-31T11:27:12.795119-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/spark-dependencies": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:46:13.246303-04:00"
+    "LastSeen": "2025-05-31T11:28:01.116099-04:00"
   },
   "https://hub.docker.com/r/opensearchproject/opensearch": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:19.000934-04:00"
+    "LastSeen": "2025-05-31T11:26:14.755115-04:00"
   },
   "https://istio.io/faq/distributed-tracing/#no-tracing": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:27.90845-04:00"
+    "LastSeen": "2025-05-31T11:26:24.005962-04:00"
   },
   "https://istio.io/latest/docs/tasks/observability/distributed-tracing/jaeger/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:55.85312-04:00"
+    "LastSeen": "2025-05-31T11:27:07.18078-04:00"
   },
   "https://jbrandhorst.com/post/gogoproto/#reflection": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:09.555489-04:00"
+    "LastSeen": "2025-05-31T11:26:06.285823-04:00"
   },
   "https://kafka.apache.org/documentation/#intro_topics": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:52.606215-04:00"
+    "LastSeen": "2025-05-31T11:26:32.724472-04:00"
   },
   "https://kafka.apache.org/documentation/#quickstart_createtopic": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:52.463214-04:00"
+    "LastSeen": "2025-05-31T11:26:32.695609-04:00"
   },
   "https://kubernetes.github.io/ingress-nginx/deploy/#verify-installation": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:34.507199-04:00"
+    "LastSeen": "2025-05-31T11:27:30.981205-04:00"
   },
   "https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:24.549359-04:00"
+    "LastSeen": "2025-05-31T11:27:29.480953-04:00"
   },
   "https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:28.076162-04:00"
+    "LastSeen": "2025-05-31T11:27:29.967775-04:00"
   },
   "https://kubernetes.io/docs/concepts/configuration/secret/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:35.565192-04:00"
+    "LastSeen": "2025-05-31T11:27:31.125519-04:00"
   },
   "https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:29.426034-04:00"
+    "LastSeen": "2025-05-31T11:27:30.154359-04:00"
   },
   "https://kubernetes.io/docs/concepts/extend-kubernetes/operator/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:07.828011-04:00"
+    "LastSeen": "2025-05-31T11:27:17.560848-04:00"
   },
   "https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:25.65732-04:00"
+    "LastSeen": "2025-05-31T11:27:29.626598-04:00"
   },
   "https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:26.718572-04:00"
+    "LastSeen": "2025-05-31T11:27:29.77873-04:00"
   },
   "https://kubernetes.io/docs/concepts/services-networking/ingress/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:34.279791-04:00"
+    "LastSeen": "2025-05-31T11:27:30.886481-04:00"
   },
   "https://kubernetes.io/docs/concepts/storage/volumes/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:30.507148-04:00"
+    "LastSeen": "2025-05-31T11:27:30.300126-04:00"
   },
   "https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:31.330684-04:00"
+    "LastSeen": "2025-05-31T11:27:30.445688-04:00"
   },
   "https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-image-pull-secret-to-service-account%29": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:33.219413-04:00"
+    "LastSeen": "2025-05-31T11:27:30.741125-04:00"
   },
   "https://kubernetes.io/docs/tasks/configure-pod-container/security-context/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:32.38968-04:00"
+    "LastSeen": "2025-05-31T11:27:30.587528-04:00"
   },
   "https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:10.075852-04:00"
+    "LastSeen": "2025-05-31T11:27:18.787774-04:00"
   },
   "https://kubernetes.io/docs/tasks/tools/install-minikube/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:09.551987-04:00"
+    "LastSeen": "2025-05-31T11:27:18.740577-04:00"
   },
   "https://medium.com/@YuriShkuro/take-opentracing-for-a-hotrod-ride-f6e3141f7941": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:46:12.538003-04:00"
+    "LastSeen": "2025-05-31T11:28:00.443629-04:00"
   },
   "https://medium.com/@larsmilland01/secure-architecture-for-jaeger-with-apache-httpd-reverse-proxy-on-openshift-f31983fad400": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:42:44.143781-04:00"
+    "LastSeen": "2025-05-31T11:26:45.615492-04:00"
   },
   "https://medium.com/@saransh.shankar/my-journey-as-an-lfx-mentee-with-cncf-jaeger-b001f136ca0b": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:46:25.892231-04:00"
+    "LastSeen": "2025-05-31T11:28:15.454854-04:00"
   },
   "https://medium.com/jaegertracing": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:40:18.676333-04:00"
+    "LastSeen": "2025-05-31T11:25:24.050956-04:00"
   },
   "https://medium.com/jaegertracing/adaptive-sampling-in-jaeger-50f336f4334": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:40:24.020167-04:00"
+    "LastSeen": "2025-05-31T11:25:34.804898-04:00"
   },
   "https://medium.com/jaegertracing/announcing-jaeger-1-0-37b5990cc59b": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:45:53.232745-04:00"
+    "LastSeen": "2025-05-31T11:27:42.246841-04:00"
   },
   "https://medium.com/jaegertracing/better-alignment-with-opentelemetry-by-focusing-on-otlp-f3688939073f": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:40:23.527579-04:00"
+    "LastSeen": "2025-05-31T11:25:32.831953-04:00"
   },
   "https://medium.com/jaegertracing/deployment-strategies-for-the-jaeger-agent-1d6f91796d09": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:48.613883-04:00"
+    "LastSeen": "2025-05-31T11:26:28.600521-04:00"
   },
   "https://medium.com/jaegertracing/experiment-migrating-opentracing-based-application-in-go-to-use-the-opentelemetry-sdk-29b09fe2fbc4": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:40:22.832303-04:00"
+    "LastSeen": "2025-05-31T11:25:32.199881-04:00"
   },
   "https://medium.com/jaegertracing/grafana-labs-teams-observed-query-performance-improvements-up-to-10x-with-jaeger-cec84b0e3609": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:46.097393-04:00"
+    "LastSeen": "2025-05-31T11:26:26.402923-04:00"
   },
   "https://medium.com/jaegertracing/how-to-maximize-span-ingestion-while-limiting-writes-per-second-to-scylla-with-jaeger-3bcda5608841": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:50.022446-04:00"
+    "LastSeen": "2025-05-31T11:26:30.310768-04:00"
   },
   "https://medium.com/jaegertracing/introducing-native-support-for-opentelemetry-in-jaeger-eb661be8183c": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:40:23.679506-04:00"
+    "LastSeen": "2025-05-31T11:25:33.448959-04:00"
   },
   "https://medium.com/jaegertracing/jaeger-and-multitenancy-99dfa1d49dc0": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:47.780375-04:00"
+    "LastSeen": "2025-05-31T11:26:28.147851-04:00"
   },
   "https://medium.com/jaegertracing/jaeger-and-opentelemetry-1846f701d9f2": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:42:42.556205-04:00"
+    "LastSeen": "2025-05-31T11:26:44.283867-04:00"
   },
   "https://medium.com/jaegertracing/jaeger-tracing-a-friendly-guide-for-beginners-7b53a4a568ca": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:40:23.854922-04:00"
+    "LastSeen": "2025-05-31T11:25:34.204199-04:00"
   },
   "https://medium.com/jaegertracing/jaeger-v2-released-09a6033d1b10": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:40:22.065645-04:00"
+    "LastSeen": "2025-05-31T11:25:29.41848-04:00"
   },
   "https://medium.com/jaegertracing/latest": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:40:15.440605-04:00"
+    "LastSeen": "2025-05-31T11:25:21.001488-04:00"
   },
   "https://medium.com/jaegertracing/learning-from-lfx-mentorship-cncf-jaeger-3fc3463adcea": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:40:21.89393-04:00"
+    "LastSeen": "2025-05-31T11:25:28.820201-04:00"
   },
   "https://medium.com/jaegertracing/making-design-decisions-for-clickhouse-as-a-core-storage-backend-in-jaeger-62bf90a979d": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:40:22.688304-04:00"
+    "LastSeen": "2025-05-31T11:25:31.514915-04:00"
   },
   "https://medium.com/jaegertracing/migrating-from-jaeger-client-to-opentelemetry-sdk-bd337d796759": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:40:24.210172-04:00"
+    "LastSeen": "2025-05-31T11:25:35.508919-04:00"
   },
   "https://medium.com/jaegertracing/protecting-jaeger-ui-with-an-oauth-sidecar-proxy-34205cca4bb1": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:18.017018-04:00"
+    "LastSeen": "2025-05-31T11:26:14.25971-04:00"
   },
   "https://medium.com/jaegertracing/running-jaeger-agent-on-bare-metal-d1fc47d31fab": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:47.25653-04:00"
+    "LastSeen": "2025-05-31T11:26:27.634439-04:00"
   },
   "https://medium.com/jaegertracing/take-jaeger-for-a-hotrod-ride-233cf43e46c2": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:40:42.822854-04:00"
+    "LastSeen": "2025-05-31T11:25:52.939124-04:00"
   },
   "https://medium.com/jaegertracing/the-life-of-a-span-ee508410200b": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:46.730546-04:00"
+    "LastSeen": "2025-05-31T11:26:27.530644-04:00"
   },
   "https://medium.com/jaegertracing/ticketmaster-traces-100-million-transactions-per-day-with-jaeger-38ec6cf599f0": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:46.619305-04:00"
+    "LastSeen": "2025-05-31T11:26:27.012989-04:00"
   },
   "https://medium.com/jaegertracing/towards-jaeger-v2-moar-opentelemetry-2f8239bee48e": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:40:22.223845-04:00"
+    "LastSeen": "2025-05-31T11:25:30.462401-04:00"
   },
   "https://medium.com/jaegertracing/trace-comparisons-arrive-in-jaeger-1-7-a97ad5e2d05d": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:45.036692-04:00"
+    "LastSeen": "2025-05-31T11:26:25.697909-04:00"
   },
   "https://medium.com/jaegertracing/using-elasticsearch-rollover-to-manage-indices-8b3d0c77915d": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:22.415206-04:00"
+    "LastSeen": "2025-05-31T11:26:19.801534-04:00"
   },
   "https://medium.com/jaegertracing/weaveworks-combines-jaeger-tracing-with-logs-and-metrics-for-a-troubleshooting-swiss-army-knife-5afc0f42b22e": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:45.532706-04:00"
+    "LastSeen": "2025-05-31T11:26:26.314371-04:00"
   },
   "https://medium.com/jaegertracing/where-did-all-my-spans-go-a-guide-to-diagnosing-dropped-spans-in-jaeger-10d9697f8182": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:50.114601-04:00"
+    "LastSeen": "2025-05-31T11:26:31.063482-04:00"
   },
   "https://medium.com/opentracing/tracing-http-request-latency-in-go-with-opentracing-7cc1282a100a": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:43:55.200264-04:00"
+    "LastSeen": "2025-05-31T11:27:05.686287-04:00"
   },
   "https://mentorship.lfx.linuxfoundation.org/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:16.648557-04:00"
+    "LastSeen": "2025-05-31T11:28:05.563702-04:00"
   },
   "https://nssm.cc/download": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:07.262886-04:00"
+    "LastSeen": "2025-05-31T11:26:36.254593-04:00"
   },
   "https://nssm.cc/usage": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:42:17.484466-04:00"
+    "LastSeen": "2025-05-31T11:26:36.476755-04:00"
   },
   "https://opensearch.org/docs/latest/api-reference/index-apis/rollover/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:22.057771-04:00"
+    "LastSeen": "2025-05-31T11:26:17.734964-04:00"
   },
   "https://opensearch.org/downloads.html": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:18.853695-04:00"
+    "LastSeen": "2025-05-31T11:26:14.5463-04:00"
   },
   "https://opentelemetry.io": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:51.015332-04:00"
+    "LastSeen": "2025-05-31T11:26:31.392171-04:00"
   },
   "https://opentelemetry.io/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:26.81061-04:00"
+    "LastSeen": "2025-05-31T11:25:37.857372-04:00"
   },
   "https://opentelemetry.io/docs/collector/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:46.153653-04:00"
+    "LastSeen": "2025-05-31T11:26:45.908336-04:00"
   },
   "https://opentelemetry.io/docs/collector/configuration/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:00.158213-04:00"
+    "LastSeen": "2025-05-31T11:26:00.145202-04:00"
   },
   "https://opentelemetry.io/docs/collector/internal-telemetry/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:11.520501-04:00"
+    "LastSeen": "2025-05-31T11:26:53.289429-04:00"
   },
   "https://opentelemetry.io/docs/collector/scaling/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:12.377634-04:00"
+    "LastSeen": "2025-05-31T11:26:08.535273-04:00"
   },
   "https://opentelemetry.io/docs/collector/troubleshooting/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:02.861086-04:00"
+    "LastSeen": "2025-05-31T11:26:02.732237-04:00"
   },
   "https://opentelemetry.io/docs/concepts/sampling/#head-sampling": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:25.569607-04:00"
+    "LastSeen": "2025-05-31T11:26:22.937127-04:00"
   },
   "https://opentelemetry.io/docs/concepts/sampling/#tail-sampling": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:25.700883-04:00"
+    "LastSeen": "2025-05-31T11:26:23.082694-04:00"
   },
   "https://opentelemetry.io/docs/concepts/signals/traces/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:12.82758-04:00"
+    "LastSeen": "2025-05-31T11:26:09.031264-04:00"
   },
   "https://opentelemetry.io/docs/migration/opentracing/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:26.873733-04:00"
+    "LastSeen": "2025-05-31T11:25:38.068648-04:00"
   },
   "https://opentelemetry.io/docs/reference/specification/protocol/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:26.846076-04:00"
+    "LastSeen": "2025-05-31T11:25:37.971505-04:00"
   },
   "https://opentelemetry.io/docs/specs/otel/protocol/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:44.536074-04:00"
+    "LastSeen": "2025-05-31T11:26:45.770452-04:00"
   },
   "https://opentracing.io/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:10.59705-04:00"
+    "LastSeen": "2025-05-31T11:26:07.879451-04:00"
   },
   "https://opentracing.io/specification/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:42.863874-04:00"
+    "LastSeen": "2025-05-31T11:26:44.351399-04:00"
   },
   "https://operatorhub.io/operator/elastic-cloud-eck": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:11.920063-04:00"
+    "LastSeen": "2025-05-31T11:27:20.404343-04:00"
   },
   "https://opster.com/guides/opensearch/opensearch-capacity-planning/how-to-choose-the-correct-number-of-shards-per-index-in-opensearch": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:21.368243-04:00"
+    "LastSeen": "2025-05-31T11:26:17.129616-04:00"
   },
   "https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:01.256028-04:00"
+    "LastSeen": "2025-05-31T11:26:00.88012-04:00"
   },
   "https://prometheus.io/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:25.021675-04:00"
+    "LastSeen": "2025-05-31T11:26:22.104181-04:00"
   },
   "https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:01.729889-04:00"
+    "LastSeen": "2025-05-31T11:26:01.95583-04:00"
   },
   "https://prometheus.io/docs/guides/tls-encryption/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:56.963989-04:00"
+    "LastSeen": "2025-05-31T11:26:35.909583-04:00"
   },
   "https://promlabs.com/blog/2020/11/26/an-update-on-promql-compatibility-across-vendors": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:01.480544-04:00"
+    "LastSeen": "2025-05-31T11:26:01.742262-04:00"
   },
   "https://quay.io/organization/jaegertracing": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:44:00.329607-04:00"
+    "LastSeen": "2025-05-31T11:27:11.758424-04:00"
   },
   "https://quay.io/repository/jaegertracing/all-in-one": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:44:00.545311-04:00"
+    "LastSeen": "2025-05-31T11:27:11.990921-04:00"
   },
   "https://quay.io/repository/jaegertracing/jaeger-collector": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:44:00.780956-04:00"
+    "LastSeen": "2025-05-31T11:27:12.191323-04:00"
   },
   "https://quay.io/repository/jaegertracing/jaeger-ingester": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:44:01.25227-04:00"
+    "LastSeen": "2025-05-31T11:27:12.678081-04:00"
   },
   "https://quay.io/repository/jaegertracing/jaeger-query": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:44:01.009524-04:00"
+    "LastSeen": "2025-05-31T11:27:12.421883-04:00"
   },
   "https://quay.io/repository/jaegertracing/jaeger-remote-storage": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:44:01.499739-04:00"
+    "LastSeen": "2025-05-31T11:27:12.886421-04:00"
   },
   "https://shkuro.com": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:09.988698-04:00"
+    "LastSeen": "2025-05-31T11:26:07.502819-04:00"
   },
   "https://shkuro.com/books/2019-mastering-distributed-tracing/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:10.104248-04:00"
+    "LastSeen": "2025-05-31T11:26:07.705004-04:00"
   },
   "https://siliconangle.com/2017/09/13/ride-sharing-firms-lyft-uber-donate-microservices-tech-open-source-community/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:00.990582-04:00"
+    "LastSeen": "2025-05-31T11:27:47.569727-04:00"
   },
   "https://slack.cncf.io": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:40:19.832837-04:00"
+    "LastSeen": "2025-05-31T11:25:25.783542-04:00"
   },
   "https://slack.cncf.io/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:46:36.231924-04:00"
-  },
-  "https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:11.301993-04:00"
+    "LastSeen": "2025-05-31T11:28:26.149293-04:00"
   },
   "https://strimzi.io/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:51.861222-04:00"
+    "LastSeen": "2025-05-31T11:26:31.873517-04:00"
   },
   "https://summerofcode.withgoogle.com/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:46:15.771388-04:00"
-  },
-  "https://thenewstack.io/cncf-adds-oracle-onboards-envoy-jaeger-projects/": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:01:33.247151-04:00"
-  },
-  "https://thenewstack.io/jaeger-graduates-cncf-sees-a-future-without-native-jaeger-clients/": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:01:32.894386-04:00"
+    "LastSeen": "2025-05-31T11:28:04.328726-04:00"
   },
   "https://use.fontawesome.com/releases/v5.0.7/js/all.js": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:19.099459-04:00"
+    "LastSeen": "2025-05-31T11:25:24.81626-04:00"
   },
   "https://web.archive.org/web/20241212124714/https://thenewstack.io/cncf-adds-oracle-onboards-envoy-jaeger-projects/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T20:16:47.589808-04:00"
+    "LastSeen": "2025-05-31T11:27:48.681827-04:00"
   },
   "https://web.archive.org/web/20250426221351/https://thenewstack.io/jaeger-graduates-cncf-sees-a-future-without-native-jaeger-clients//": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T20:16:46.400447-04:00"
+    "LastSeen": "2025-05-31T11:27:41.415761-04:00"
   },
   "https://www.aspecto.io/blog/how-to-deploy-jaeger-on-aws-a-comprehensive-step-by-step-guide/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:41:49.559075-04:00"
+    "LastSeen": "2025-05-31T11:26:29.732443-04:00"
   },
   "https://www.cncf.io/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:25.397625-04:00"
+    "StatusCode": 200,
+    "LastSeen": "2025-05-31T11:25:36.097019-04:00"
   },
   "https://www.cncf.io/announcement/2019/10/31/cloud-native-computing-foundation-announces-jaeger-graduation/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:45:50.800955-04:00"
+    "LastSeen": "2025-05-31T11:27:38.909986-04:00"
   },
   "https://www.cncf.io/blog/2017/09/13/cncf-hosts-jaeger/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:45:59.772668-04:00"
+    "LastSeen": "2025-05-31T11:27:46.777783-04:00"
   },
   "https://www.codecov.io/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:25.828665-04:00"
+    "StatusCode": 200,
+    "LastSeen": "2025-05-31T11:25:36.565196-04:00"
   },
   "https://www.confluent.io/blog/how-to-choose-the-number-of-topicspartitions-in-a-kafka-cluster/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:52.681935-04:00"
+    "LastSeen": "2025-05-31T11:26:33.298481-04:00"
   },
   "https://www.dosu.dev/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:40:26.360293-04:00"
+    "LastSeen": "2025-05-31T11:25:37.276084-04:00"
   },
   "https://www.elastic.co/blog/how-many-shards-should-i-have-in-my-elasticsearch-cluster": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:35.735426-04:00"
+    "StatusCode": 200,
+    "LastSeen": "2025-05-31T11:26:38.244684-04:00"
   },
   "https://www.elastic.co/docs/deploy-manage/upgrade/deployment-or-cluster": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:55:04.814092-04:00"
+    "LastSeen": "2025-05-31T11:26:40.36581-04:00"
   },
   "https://www.elastic.co/downloads/elasticsearch": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:34.646322-04:00"
+    "StatusCode": 200,
+    "LastSeen": "2025-05-31T11:26:37.491357-04:00"
   },
   "https://www.elastic.co/guide/en/elasticsearch/reference/5.6/heap-size.html": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:21.880033-04:00"
-  },
-  "https://www.elastic.co/guide/en/elasticsearch/reference/current//setup-upgrade.html": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T19:54:03.88622-04:00"
+    "LastSeen": "2025-05-31T11:27:27.55241-04:00"
   },
   "https://www.elastic.co/guide/en/elasticsearch/reference/current/index-lifecycle-management.html": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:36.531606-04:00"
+    "LastSeen": "2025-05-31T11:26:40.108463-04:00"
   },
   "https://www.elastic.co/guide/en/elasticsearch/reference/master/common-options.html#byte-units": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:22.328497-04:00"
+    "LastSeen": "2025-05-31T11:26:19.224025-04:00"
   },
   "https://www.elastic.co/guide/en/elasticsearch/reference/master/common-options.html#time-units": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:22.19559-04:00"
+    "LastSeen": "2025-05-31T11:26:18.811569-04:00"
   },
   "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:35.862935-04:00"
+    "LastSeen": "2025-05-31T11:26:39.016963-04:00"
   },
   "https://www.github.com/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:26.5149-04:00"
+    "LastSeen": "2025-05-31T11:25:37.453131-04:00"
   },
   "https://www.google.com/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:40:26.666114-04:00"
+    "LastSeen": "2025-05-31T11:25:37.55558-04:00"
   },
   "https://www.jaegertracing.io/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.038819-04:00"
-  },
-  "https://www.jaegertracing.io/1.69/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:51.384578-04:00"
-  },
-  "https://www.jaegertracing.io/2.6/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:51.284723-04:00"
-  },
-  "https://www.jaegertracing.io/css/style.ef9a0a808867e6c9162c0e279c43705ccc7a3a3bac3db8b6796c4e609335c848.css": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.008592-04:00"
-  },
-  "https://www.jaegertracing.io/css/tocbot.css": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:50.306691-04:00"
-  },
-  "https://www.jaegertracing.io/docs": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:50.194958-04:00"
+    "LastSeen": "2025-05-31T11:25:28.718973-04:00"
   },
   "https://www.jaegertracing.io/docs/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:50.276406-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.57": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:51.126459-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.58": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:51.086842-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.59": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:51.048926-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.60": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:51.010555-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.61": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:50.972557-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.62": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:50.936796-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.63": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:50.898793-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.64": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:50.86318-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.65": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:50.764771-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.66": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:50.726185-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.67": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:50.687535-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.68": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:50.650875-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:50.612654-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:09.59222-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/apis/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:03.026491-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/architecture/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:50.153167-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/badger/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:36.750833-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/cassandra/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:52.860571-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/cli/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:56.677731-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/configuration/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:59.02385-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/deployment/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:54.594298-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/elasticsearch/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:34.530032-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/external-guides/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:44.945864-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/faq/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:14.294861-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/features/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:22.482831-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/frontend-ui/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:13.097628-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/getting-started": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:50.229086-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/getting-started/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:50.898493-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/kafka/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:51.539005-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/kubernetes/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:33.138234-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/memory/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:12.213664-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/migration/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:34.014708-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/monitoring/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:17.667736-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/opensearch/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:18.218671-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/operations/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:28.973385-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/operator/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:06.510956-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/performance-tuning/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:12.281938-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/sampling/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:25.490822-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/security/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:43.494533-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/spm/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:00.259296-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/storage/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:29.090642-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/terminology/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:12.506145-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/tools/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:02.953027-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/troubleshooting/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:27.291922-04:00"
-  },
-  "https://www.jaegertracing.io/docs/1.69/windows/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:57.0318-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:50.574506-04:00"
+    "LastSeen": "2025-05-31T11:25:58.086374-04:00"
   },
   "https://www.jaegertracing.io/docs/2.0/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:51.680986-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/SPM": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:53.479349-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/SPM/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:58.46319-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/apis": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:52.976654-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/apis/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:58.365117-04:00"
+    "LastSeen": "2025-05-31T11:25:58.275344-04:00"
   },
   "https://www.jaegertracing.io/docs/2.0/architecture/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:52.767621-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/badger": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:55.512769-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/badger/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:58.64448-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/cassandra": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:55.729308-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/cassandra/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:58.68143-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/configuration": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:54.130594-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/configuration/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:51.631125-04:00"
+    "LastSeen": "2025-05-31T11:25:58.420685-04:00"
   },
   "https://www.jaegertracing.io/docs/2.0/deployment/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:54.057902-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/elasticsearch": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:56.052013-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/elasticsearch/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:58.709046-04:00"
+    "LastSeen": "2025-05-31T11:25:58.622809-04:00"
   },
   "https://www.jaegertracing.io/docs/2.0/external-guides/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:58.240301-04:00"
+    "LastSeen": "2025-05-31T11:25:59.322601-04:00"
   },
   "https://www.jaegertracing.io/docs/2.0/faq/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:57.977891-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/features": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:52.204372-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/features/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:58.301943-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/frontend-ui": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:54.435092-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/frontend-ui/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:58.525041-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/getting-started": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:51.954933-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/getting-started/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:58.270503-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/kafka": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:56.375271-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/kafka/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:58.736652-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/kubernetes": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:54.65071-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/kubernetes/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:58.555152-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/memory": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:55.283176-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/memory/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:58.615699-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/migration": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:52.527202-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/migration/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:58.334863-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/monitoring": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:57.123525-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/monitoring/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:58.795796-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/opensearch": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:56.662048-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/opensearch/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:58.764262-04:00"
+    "LastSeen": "2025-05-31T11:25:59.147965-04:00"
   },
   "https://www.jaegertracing.io/docs/2.0/operations/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:56.830213-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/performance-tuning": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:57.548803-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/performance-tuning/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:58.855767-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/sampling": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:53.253528-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/sampling/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:58.3923-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/spm/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:00.192275-04:00"
+    "LastSeen": "2025-05-31T11:25:58.949569-04:00"
   },
   "https://www.jaegertracing.io/docs/2.0/storage/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:55.033845-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/terminology": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:53.761278-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/terminology/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:58.490717-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/tools": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:57.821848-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/tools/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:58.883366-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/troubleshooting": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:57.350656-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/troubleshooting/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:58.825984-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/windows": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:54.863326-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/windows/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:58.585372-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:50.537575-04:00"
+    "LastSeen": "2025-05-31T11:25:58.789506-04:00"
   },
   "https://www.jaegertracing.io/docs/2.1/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:13.383507-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/SPM": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:14.694375-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/SPM/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:20.392339-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/apis": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:14.126056-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/apis/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:20.252307-04:00"
+    "LastSeen": "2025-05-31T11:26:53.591247-04:00"
   },
   "https://www.jaegertracing.io/docs/2.1/architecture/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:13.910062-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/badger": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:17.346542-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/badger/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:20.59815-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/cassandra": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:17.602459-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/cassandra/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:20.625735-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/configuration": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:15.303232-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/configuration/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:13.258867-04:00"
+    "LastSeen": "2025-05-31T11:26:53.86419-04:00"
   },
   "https://www.jaegertracing.io/docs/2.1/deployment/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:15.143231-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/elasticsearch": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:17.882114-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/elasticsearch/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:20.654548-04:00"
+    "LastSeen": "2025-05-31T11:26:54.076727-04:00"
   },
   "https://www.jaegertracing.io/docs/2.1/external-guides/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:19.912309-04:00"
+    "LastSeen": "2025-05-31T11:26:54.892513-04:00"
   },
   "https://www.jaegertracing.io/docs/2.1/faq/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:19.673277-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/features": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:13.760411-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/features/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:20.224591-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/frontend-ui": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:15.662857-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/frontend-ui/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:20.453996-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/getting-started": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:13.527886-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/getting-started/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:20.195809-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/kafka": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:18.103414-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/kafka/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:20.692678-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/kubernetes": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:16.050052-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/kubernetes/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:20.482937-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/memory": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:17.069744-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/memory/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:20.569192-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/migration": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:20.156416-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/migration/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:20.865394-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/monitoring": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:18.793641-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/monitoring/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:20.747877-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/opensearch": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:18.370328-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/opensearch/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:20.720389-04:00"
+    "LastSeen": "2025-05-31T11:26:54.678497-04:00"
   },
   "https://www.jaegertracing.io/docs/2.1/operations/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:18.562568-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/performance-tuning": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:19.208251-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/performance-tuning/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:20.803747-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/sampling": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:14.375434-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/sampling/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:20.279395-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/security": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:16.612931-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/security/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:20.540799-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/spm/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:21.221095-04:00"
+    "LastSeen": "2025-05-31T11:26:54.513047-04:00"
   },
   "https://www.jaegertracing.io/docs/2.1/storage/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:16.771867-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/terminology": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:14.917607-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/terminology/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:20.423715-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/tools": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:19.508824-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/tools/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:20.833858-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/troubleshooting": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:18.99053-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/troubleshooting/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:20.776115-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/windows": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:16.375335-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/windows/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:20.511855-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:50.499502-04:00"
+    "LastSeen": "2025-05-31T11:26:54.337338-04:00"
   },
   "https://www.jaegertracing.io/docs/2.2/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:12.580024-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/SPM": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:14.214352-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/SPM/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:19.534042-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/apis": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:13.643526-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/apis/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:19.433044-04:00"
+    "LastSeen": "2025-05-31T11:27:35.065468-04:00"
   },
   "https://www.jaegertracing.io/docs/2.2/architecture/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:13.278539-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/badger": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:16.6387-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/badger/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:19.741743-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/cassandra": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:16.907181-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/cassandra/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:19.772012-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/configuration": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:14.804724-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/configuration/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:12.548616-04:00"
+    "LastSeen": "2025-05-31T11:27:35.254501-04:00"
   },
   "https://www.jaegertracing.io/docs/2.2/deployment/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:14.727172-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/elasticsearch": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:17.129342-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/elasticsearch/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:19.799663-04:00"
+    "LastSeen": "2025-05-31T11:27:35.436773-04:00"
   },
   "https://www.jaegertracing.io/docs/2.2/external-guides/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:19.137115-04:00"
+    "LastSeen": "2025-05-31T11:27:36.066294-04:00"
   },
   "https://www.jaegertracing.io/docs/2.2/faq/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:18.949927-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/features": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:13.095818-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/features/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:19.40413-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/frontend-ui": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:15.033063-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/frontend-ui/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:19.595759-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/getting-started": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:12.841295-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/getting-started/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:19.37126-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/kafka": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:17.410313-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/kafka/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:19.826549-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/kubernetes": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:15.376288-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/kubernetes/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:19.62461-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/memory": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:16.408949-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/memory/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:19.712815-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/migration": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:19.342377-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/migration/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:19.994508-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/monitoring": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:18.067801-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/monitoring/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:19.882083-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/opensearch": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:17.645784-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/opensearch/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:19.853315-04:00"
+    "LastSeen": "2025-05-31T11:27:35.919191-04:00"
   },
   "https://www.jaegertracing.io/docs/2.2/operations/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:17.821669-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/performance-tuning": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:18.549297-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/performance-tuning/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:19.940034-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/sampling": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:13.938899-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/sampling/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:19.461696-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/security": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:15.975179-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/security/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:19.682595-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/spm/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:20.326712-04:00"
+    "LastSeen": "2025-05-31T11:27:35.761796-04:00"
   },
   "https://www.jaegertracing.io/docs/2.2/storage/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:16.191089-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/terminology": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:14.450178-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/terminology/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:19.566929-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/tools": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:18.773977-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/tools/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:19.96644-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/troubleshooting": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:18.319585-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/troubleshooting/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:19.911118-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/windows": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:15.658624-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/windows/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:19.655067-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:50.460601-04:00"
+    "LastSeen": "2025-05-31T11:27:35.610133-04:00"
   },
   "https://www.jaegertracing.io/docs/2.3/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:54.593031-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/SPM": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:56.229589-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/SPM/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:01.565614-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/apis": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:55.617546-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/apis/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:01.457289-04:00"
+    "LastSeen": "2025-05-31T11:27:33.377179-04:00"
   },
   "https://www.jaegertracing.io/docs/2.3/architecture/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:55.349786-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/badger": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:58.556249-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/badger/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:01.765165-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/cassandra": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:58.683367-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/cassandra/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:01.795319-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/configuration": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:56.784048-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/configuration/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:54.563667-04:00"
+    "LastSeen": "2025-05-31T11:27:33.538542-04:00"
   },
   "https://www.jaegertracing.io/docs/2.3/deployment/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:56.707911-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/elasticsearch": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:58.895243-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/elasticsearch/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:01.822956-04:00"
+    "LastSeen": "2025-05-31T11:27:33.69239-04:00"
   },
   "https://www.jaegertracing.io/docs/2.3/external-guides/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:01.1501-04:00"
+    "LastSeen": "2025-05-31T11:27:34.586946-04:00"
   },
   "https://www.jaegertracing.io/docs/2.3/faq/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:00.963628-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/features": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:55.131681-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/features/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:01.42713-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/frontend-ui": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:57.027468-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/frontend-ui/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:01.623432-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/getting-started": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:54.897917-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/getting-started/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:01.398292-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/kafka": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:59.242323-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/kafka/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:01.851916-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/kubernetes": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:57.323986-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/kubernetes/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:01.649761-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/memory": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:58.43145-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/memory/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:01.736557-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/migration": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:01.36945-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/migration/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:02.037321-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/monitoring": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:00.038478-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/monitoring/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:01.909723-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/opensearch": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:59.532787-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/opensearch/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:01.879514-04:00"
+    "LastSeen": "2025-05-31T11:27:34.357373-04:00"
   },
   "https://www.jaegertracing.io/docs/2.3/operations/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:59.739065-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/performance-tuning": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:00.529651-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/performance-tuning/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:01.96649-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/sampling": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:55.932443-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/sampling/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:01.487761-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/security": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:57.886255-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/security/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:01.706223-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/spm/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:02.436431-04:00"
+    "LastSeen": "2025-05-31T11:27:34.174942-04:00"
   },
   "https://www.jaegertracing.io/docs/2.3/storage/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:58.076972-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/terminology": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:56.461891-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/terminology/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:01.594567-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/tools": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:00.776013-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/tools/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:01.995304-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/troubleshooting": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:00.312736-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/troubleshooting/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:01.937665-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/windows": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:57.556582-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/windows/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:01.677304-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:50.423818-04:00"
+    "LastSeen": "2025-05-31T11:27:33.962161-04:00"
   },
   "https://www.jaegertracing.io/docs/2.4/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:36.317408-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/SPM": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:37.906322-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/SPM/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:43.567991-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/apis": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:37.373663-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/apis/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:43.452021-04:00"
+    "LastSeen": "2025-05-31T11:27:31.806397-04:00"
   },
   "https://www.jaegertracing.io/docs/2.4/architecture/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:37.06909-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/badger": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:40.36096-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/badger/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:43.778952-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/cassandra": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:40.651796-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/cassandra/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:43.809487-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/configuration": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:38.473087-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/configuration/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:36.286945-04:00"
+    "LastSeen": "2025-05-31T11:27:31.966382-04:00"
   },
   "https://www.jaegertracing.io/docs/2.4/deployment/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:38.373277-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/elasticsearch": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:40.964683-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/elasticsearch/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:43.838585-04:00"
+    "LastSeen": "2025-05-31T11:27:32.206867-04:00"
   },
   "https://www.jaegertracing.io/docs/2.4/external-guides/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:43.176476-04:00"
+    "LastSeen": "2025-05-31T11:27:32.893868-04:00"
   },
   "https://www.jaegertracing.io/docs/2.4/faq/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:42.996634-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/features": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:36.753243-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/features/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:43.421916-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/frontend-ui": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:38.923138-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/frontend-ui/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:43.629879-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/getting-started": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:36.532565-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/getting-started/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:43.394232-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/kafka": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:41.188972-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/kafka/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:43.867688-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/kubernetes": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:39.128201-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/kubernetes/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:43.658848-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/memory": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:40.161551-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/memory/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:43.748732-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/migration": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:43.364135-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/migration/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:44.04926-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/monitoring": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:42.01219-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/monitoring/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:43.926887-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/opensearch": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:41.511762-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/opensearch/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:43.89795-04:00"
+    "LastSeen": "2025-05-31T11:27:32.727196-04:00"
   },
   "https://www.jaegertracing.io/docs/2.4/operations/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:41.72303-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/performance-tuning": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:42.539691-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/performance-tuning/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:43.982039-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/sampling": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:37.662246-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/sampling/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:43.481024-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/security": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:39.821187-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/security/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:43.718406-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/spm/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:44.425849-04:00"
+    "LastSeen": "2025-05-31T11:27:32.536561-04:00"
   },
   "https://www.jaegertracing.io/docs/2.4/storage/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:40.018125-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/terminology": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:38.179166-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/terminology/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:43.598179-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/tools": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:42.780253-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/tools/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:44.021427-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/troubleshooting": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:42.28648-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/troubleshooting/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:43.955748-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/windows": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:39.446616-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/windows/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:43.689108-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:50.384468-04:00"
+    "LastSeen": "2025-05-31T11:27:32.370966-04:00"
   },
   "https://www.jaegertracing.io/docs/2.5/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:31.083246-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/SPM": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:32.838608-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/SPM/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:39.066823-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/apis": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:32.27651-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/apis/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:38.947287-04:00"
+    "LastSeen": "2025-05-31T11:27:36.598979-04:00"
   },
   "https://www.jaegertracing.io/docs/2.5/architecture/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:31.982588-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/badger": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:35.506392-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/badger/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:39.270072-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/cassandra": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:35.720806-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/cassandra/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:39.299133-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/configuration": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:33.330961-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/configuration/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:31.051277-04:00"
+    "LastSeen": "2025-05-31T11:27:36.76948-04:00"
   },
   "https://www.jaegertracing.io/docs/2.5/deployment/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:33.248194-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/elasticsearch": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:36.067959-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/elasticsearch/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:39.329183-04:00"
+    "LastSeen": "2025-05-31T11:27:37.025876-04:00"
   },
   "https://www.jaegertracing.io/docs/2.5/external-guides/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:38.259231-04:00"
+    "LastSeen": "2025-05-31T11:27:37.750615-04:00"
   },
   "https://www.jaegertracing.io/docs/2.5/faq/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:38.112077-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/features": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:31.78955-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/features/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:38.916937-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/frontend-ui": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:33.552788-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/frontend-ui/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:39.126022-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/getting-started": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:31.454411-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/getting-started/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:38.886918-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/kafka": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:36.268865-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/kafka/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:39.359455-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/kubernetes": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:33.892097-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/kubernetes/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:39.154963-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/memory": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:34.95188-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/memory/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:39.242179-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/migration": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:38.854984-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/migration/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:39.528658-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/monitoring": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:37.072273-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/monitoring/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:39.417776-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/opensearch": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:36.580111-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/opensearch/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:39.388472-04:00"
+    "LastSeen": "2025-05-31T11:27:37.586301-04:00"
   },
   "https://www.jaegertracing.io/docs/2.5/operations/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:36.795386-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/performance-tuning": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:37.598404-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/performance-tuning/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:39.474367-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/sampling": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:32.594155-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/sampling/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:38.977529-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/security": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:34.410961-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/security/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:39.211794-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/spm/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:39.877459-04:00"
+    "LastSeen": "2025-05-31T11:27:37.41686-04:00"
   },
   "https://www.jaegertracing.io/docs/2.5/storage/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:34.583874-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/terminology": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:33.032958-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/terminology/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:39.097213-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/tools": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:37.887214-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/tools/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:39.500639-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/troubleshooting": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:37.303134-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/troubleshooting/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:39.446605-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/windows": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:34.203211-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/windows/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:39.183837-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:50.344942-04:00"
+    "LastSeen": "2025-05-31T11:27:37.23588-04:00"
   },
   "https://www.jaegertracing.io/docs/2.6/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.097927-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/apis": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.245142-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/apis/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:02.98958-04:00"
+    "LastSeen": "2025-05-31T11:26:40.502226-04:00"
   },
   "https://www.jaegertracing.io/docs/2.6/architecture/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.207019-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/badger": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.723727-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/badger/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:36.679863-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/cassandra": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.760509-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/cassandra/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:52.717388-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/cli/": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:11.123259-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/configuration": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.42097-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/configuration/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:58.912315-04:00"
+    "LastSeen": "2025-05-31T11:26:40.723204-04:00"
   },
   "https://www.jaegertracing.io/docs/2.6/deployment/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.382868-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/elasticsearch": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.799983-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/elasticsearch/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:34.391526-04:00"
+    "LastSeen": "2025-05-31T11:26:40.79161-04:00"
   },
   "https://www.jaegertracing.io/docs/2.6/external-guides/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:15.124487-04:00"
+    "LastSeen": "2025-05-31T11:26:41.524938-04:00"
   },
   "https://www.jaegertracing.io/docs/2.6/faq/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:15.091577-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/features": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.176814-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/features/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:22.453847-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/frontend-ui": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.469706-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/frontend-ui/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:13.070091-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/getting-started": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.13638-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/getting-started/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:50.868363-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/kafka": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.835606-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/kafka/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:51.383951-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/kubernetes": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.536609-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/kubernetes/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:32.988569-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/memory": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.688282-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/memory/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:12.063891-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/migration": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:15.162894-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/migration/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:33.951634-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/monitoring": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.942041-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/monitoring/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:17.636156-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/opensearch": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.874809-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/opensearch/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:18.063785-04:00"
+    "LastSeen": "2025-05-31T11:26:41.278303-04:00"
   },
   "https://www.jaegertracing.io/docs/2.6/operations/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.903903-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/operator/": {
-    "StatusCode": 404,
-    "LastSeen": "2025-05-29T20:21:11.271105-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/performance-tuning": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:15.019614-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/performance-tuning/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:12.250373-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/sampling": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.283247-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/sampling/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:25.463172-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/security": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.621953-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/security/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:37.507951-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/spm/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:00.230148-04:00"
+    "LastSeen": "2025-05-31T11:26:41.112837-04:00"
   },
   "https://www.jaegertracing.io/docs/2.6/storage/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.648882-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/terminology": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.355313-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/terminology/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:12.415578-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/tools": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:15.06302-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/tools/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:02.922862-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/troubleshooting": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.981503-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/troubleshooting/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:27.26296-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/windows": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.577276-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/windows/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:57.001482-04:00"
-  },
-  "https://www.jaegertracing.io/docs/latest/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:36.58059-04:00"
-  },
-  "https://www.jaegertracing.io/docs/latest/architecture/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:43.437628-04:00"
-  },
-  "https://www.jaegertracing.io/docs/latest/sampling/#collector-sampling-configuration": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:23.187315-04:00"
+    "LastSeen": "2025-05-31T11:26:40.952693-04:00"
   },
   "https://www.jaegertracing.io/docs/next-release-v2/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:31.663236-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/SPM": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:33.293823-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/SPM/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:38.85421-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/apis": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:32.721872-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/apis/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:38.749656-04:00"
+    "LastSeen": "2025-05-31T11:26:55.373965-04:00"
   },
   "https://www.jaegertracing.io/docs/next-release-v2/architecture/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:32.379206-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/badger": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:35.749865-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/badger/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:39.050536-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/cassandra": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:35.935109-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/cassandra/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:39.078119-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/configuration": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:33.852227-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/configuration/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:31.48857-04:00"
+    "LastSeen": "2025-05-31T11:26:55.535892-04:00"
   },
   "https://www.jaegertracing.io/docs/next-release-v2/deployment/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:33.774502-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/elasticsearch": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:36.261879-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/elasticsearch/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:39.106993-04:00"
+    "LastSeen": "2025-05-31T11:26:55.70258-04:00"
   },
   "https://www.jaegertracing.io/docs/next-release-v2/external-guides/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:38.427865-04:00"
+    "LastSeen": "2025-05-31T11:26:56.589313-04:00"
   },
   "https://www.jaegertracing.io/docs/next-release-v2/faq/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:38.249128-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/features": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:32.18638-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/features/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:38.722239-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/frontend-ui": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:34.067505-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/frontend-ui/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:38.912032-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/getting-started": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:31.976935-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/getting-started/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:38.695825-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/kafka": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:36.490215-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/kafka/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:39.134658-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/kubernetes": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:34.282759-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/kubernetes/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:38.938335-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/memory": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:35.444033-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/memory/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:39.024327-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/migration": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:38.661847-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/migration/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:39.317203-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/monitoring": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:37.254694-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/monitoring/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:39.202948-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/opensearch": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:36.792723-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/opensearch/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:39.163587-04:00"
+    "LastSeen": "2025-05-31T11:26:56.417457-04:00"
   },
   "https://www.jaegertracing.io/docs/next-release-v2/operations/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:36.960762-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/performance-tuning": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:37.756798-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/performance-tuning/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:39.259541-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/sampling": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:33.048709-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/sampling/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:38.777319-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/security": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:34.837383-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/security/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:38.994835-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/spm/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:40.231701-04:00"
+    "LastSeen": "2025-05-31T11:26:56.144865-04:00"
   },
   "https://www.jaegertracing.io/docs/next-release-v2/storage/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:35.086726-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/terminology": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:33.601126-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/terminology/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:38.883176-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/tools": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:38.0877-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/tools/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:39.289533-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/troubleshooting": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:37.520198-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/troubleshooting/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:39.230507-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/windows": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:34.526292-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/windows/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:38.965917-04:00"
+    "LastSeen": "2025-05-31T11:26:55.996536-04:00"
   },
   "https://www.jaegertracing.io/docs/next-release/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:48.95207-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/apis": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:49.742325-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/apis/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:53.238046-04:00"
+    "LastSeen": "2025-05-31T11:27:03.166109-04:00"
   },
   "https://www.jaegertracing.io/docs/next-release/architecture/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:49.451119-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/cli": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:51.346716-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/cli/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:53.353762-04:00"
+    "LastSeen": "2025-05-31T11:27:03.50168-04:00"
   },
   "https://www.jaegertracing.io/docs/next-release/deployment/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:50.143946-04:00"
+    "LastSeen": "2025-05-31T11:27:03.722116-04:00"
   },
   "https://www.jaegertracing.io/docs/next-release/external-guides/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:53.171163-04:00"
+    "LastSeen": "2025-05-31T11:27:04.856109-04:00"
   },
   "https://www.jaegertracing.io/docs/next-release/faq/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:52.782591-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/features": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:49.221244-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/features/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:53.200068-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/frontend-ui": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:50.98317-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/frontend-ui/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:53.326179-04:00"
+    "LastSeen": "2025-05-31T11:27:04.52532-04:00"
   },
   "https://www.jaegertracing.io/docs/next-release/getting-started/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:49.286876-04:00"
+    "LastSeen": "2025-05-31T11:27:03.335584-04:00"
   },
   "https://www.jaegertracing.io/docs/next-release/monitoring/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:52.235331-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/operator": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:50.696437-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/operator/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:53.297258-04:00"
+    "LastSeen": "2025-05-31T11:27:03.939977-04:00"
   },
   "https://www.jaegertracing.io/docs/next-release/performance-tuning/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:52.392739-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/sampling": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:50.046844-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/sampling/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:53.26699-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/security": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:51.612987-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/security/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:53.382674-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/spm": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:51.986025-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/spm/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:48.783636-04:00"
+    "LastSeen": "2025-05-31T11:27:04.176205-04:00"
   },
   "https://www.jaegertracing.io/docs/next-release/tools/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:52.99008-04:00"
+    "LastSeen": "2025-05-31T11:27:04.692041-04:00"
   },
   "https://www.jaegertracing.io/docs/next-release/troubleshooting/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:52.555572-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/windows": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:51.871557-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/windows/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:53.412941-04:00"
-  },
-  "https://www.jaegertracing.io/download": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:15.20362-04:00"
+    "LastSeen": "2025-05-31T11:27:04.357527-04:00"
   },
   "https://www.jaegertracing.io/download/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:06.725385-04:00"
-  },
-  "https://www.jaegertracing.io/favicon.ico": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:13.907436-04:00"
-  },
-  "https://www.jaegertracing.io/get-in-touch": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:15.521126-04:00"
+    "LastSeen": "2025-05-31T11:27:54.710517-04:00"
   },
   "https://www.jaegertracing.io/get-in-touch/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:19.249095-04:00"
-  },
-  "https://www.jaegertracing.io/get-in-touch/#open-issue-or-discussion-on-github": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:18.763058-04:00"
-  },
-  "https://www.jaegertracing.io/get-in-touch/#project-video-meetings": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:18.732783-04:00"
-  },
-  "https://www.jaegertracing.io/get-in-touch/#via-chat": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:18.704475-04:00"
-  },
-  "https://www.jaegertracing.io/get-involved": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:15.483003-04:00"
+    "LastSeen": "2025-05-31T11:25:24.992053-04:00"
   },
   "https://www.jaegertracing.io/get-involved/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:24.530779-04:00"
-  },
-  "https://www.jaegertracing.io/img/architecture-otel.png": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:56.823926-04:00"
-  },
-  "https://www.jaegertracing.io/img/architecture-v1-2023.png": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:56.760895-04:00"
-  },
-  "https://www.jaegertracing.io/img/architecture-v2-2023.png": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:56.79237-04:00"
-  },
-  "https://www.jaegertracing.io/img/architecture-v2-2024.png": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:50.220463-04:00"
-  },
-  "https://www.jaegertracing.io/img/architecture-v2-binary.png": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:46.245631-04:00"
-  },
-  "https://www.jaegertracing.io/img/architecture-v2-kafka-2024.png": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:50.28738-04:00"
-  },
-  "https://www.jaegertracing.io/img/architecture-v2-otel.png": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:50.366419-04:00"
-  },
-  "https://www.jaegertracing.io/img/cncf-graduated-color.svg": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:25.426907-04:00"
-  },
-  "https://www.jaegertracing.io/img/context-prop-2023.png": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:43:56.854198-04:00"
-  },
-  "https://www.jaegertracing.io/img/frontend-ui/embed-open-icon.png": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:13.99949-04:00"
-  },
-  "https://www.jaegertracing.io/img/frontend-ui/embed-search-traces-hide-graph.png": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:14.060003-04:00"
-  },
-  "https://www.jaegertracing.io/img/frontend-ui/embed-search-traces.png": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:14.028504-04:00"
-  },
-  "https://www.jaegertracing.io/img/frontend-ui/embed-trace-view-with-back-button.png": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:14.121748-04:00"
-  },
-  "https://www.jaegertracing.io/img/frontend-ui/embed-trace-view-with-collapse.png": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:14.153897-04:00"
-  },
-  "https://www.jaegertracing.io/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:14.259394-04:00"
-  },
-  "https://www.jaegertracing.io/img/frontend-ui/embed-trace-view-with-hide-minimap.png": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:14.194996-04:00"
-  },
-  "https://www.jaegertracing.io/img/frontend-ui/embed-trace-view-with-hide-summary.png": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:14.227949-04:00"
-  },
-  "https://www.jaegertracing.io/img/frontend-ui/embed-trace-view.png": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:14.091551-04:00"
-  },
-  "https://www.jaegertracing.io/img/frontend-ui/spm.png": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:00.29078-04:00"
-  },
-  "https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:18.451487-04:00"
-  },
-  "https://www.jaegertracing.io/img/jaeger-logo.png": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:14.066426-04:00"
-  },
-  "https://www.jaegertracing.io/img/spans-traces.png": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:12.856196-04:00"
-  },
-  "https://www.jaegertracing.io/img/trace-detail-ss.png": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:12.024612-04:00"
-  },
-  "https://www.jaegertracing.io/img/traces-ss.png": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:11.994473-04:00"
-  },
-  "https://www.jaegertracing.io/img/ukraine_flag.svg": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:17.111737-04:00"
-  },
-  "https://www.jaegertracing.io/js/anchor.min.min.33e32d05ea13525a24ccefc19b0bb3334b089162d04bbbf2950a8d5e533c8d4c.js": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:19.157235-04:00"
-  },
-  "https://www.jaegertracing.io/js/app.min.6b5bec6e4541f788a0b0793d7bf3da60ea017e463bc840d66b8df8da0baa2743.js": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:19.214945-04:00"
-  },
-  "https://www.jaegertracing.io/js/jquery-ui-1.9.1.custom.min.min.56b1b88f05a2db8dc79a219da1e49076e0228cdd44a79cc6a07f3df73e6cc0d2.js": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:19.129625-04:00"
-  },
-  "https://www.jaegertracing.io/js/lunr-2.3.6.min.min.75c5f3760b859d71427e97d5c01905be3413c8dfc56bc5fdea0515e02203d2e2.js": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:51.413316-04:00"
-  },
-  "https://www.jaegertracing.io/js/tocbot.min.min.f154e96efef24f5e2b409a4bead0c6c39c4249ffeca7fc4b18edb03cd0f53093.js": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:19.185957-04:00"
-  },
-  "https://www.jaegertracing.io/mentorship": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:15.560588-04:00"
-  },
-  "https://www.jaegertracing.io/mentorship-for-mentees": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:15.598178-04:00"
+    "LastSeen": "2025-05-31T11:25:52.14917-04:00"
   },
   "https://www.jaegertracing.io/mentorship-for-mentees/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:46:35.148778-04:00"
-  },
-  "https://www.jaegertracing.io/mentorship-for-mentors": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:15.637477-04:00"
+    "LastSeen": "2025-05-31T11:28:25.28604-04:00"
   },
   "https://www.jaegertracing.io/mentorship-for-mentors/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:50.142399-04:00"
+    "LastSeen": "2025-05-31T11:25:57.750324-04:00"
   },
   "https://www.jaegertracing.io/mentorship/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:24.559662-04:00"
-  },
-  "https://www.jaegertracing.io/news": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:15.675642-04:00"
+    "LastSeen": "2025-05-31T11:28:03.914818-04:00"
   },
   "https://www.jaegertracing.io/news/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:45:49.207944-04:00"
-  },
-  "https://www.jaegertracing.io/report-security-issue": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:16.13932-04:00"
+    "LastSeen": "2025-05-31T11:27:38.245542-04:00"
   },
   "https://www.jaegertracing.io/report-security-issue/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:13.877222-04:00"
-  },
-  "https://www.jaegertracing.io/roadmap": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:15.71426-04:00"
+    "LastSeen": "2025-05-31T11:25:20.457984-04:00"
   },
   "https://www.jaegertracing.io/roadmap/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:34.673594-04:00"
+    "LastSeen": "2025-05-31T11:25:45.614215-04:00"
   },
   "https://www.jaegertracing.io/sdk-migration/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:26.742341-04:00"
+    "LastSeen": "2025-05-31T11:25:37.779868-04:00"
   },
   "https://www.jetbrains.com/go/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:28.732363-04:00"
+    "LastSeen": "2025-05-31T11:26:24.818044-04:00"
   },
   "https://www.linkedin.com/posts/harshith-mente_lfxmentorship-jaeger-opentelemetry-activity-7235573030997934080-0Id1": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:46:23.012509-04:00"
+    "LastSeen": "2025-05-31T11:28:11.722101-04:00"
   },
   "https://www.linuxfoundation.org/blog/blog/lyft-and-uber-on-stage-together-at-open-source-summit-in-l-a": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:46:00.502062-04:00"
+    "LastSeen": "2025-05-31T11:27:46.967493-04:00"
   },
   "https://www.linuxfoundation.org/trademark-usage": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:40:19.015545-04:00"
+    "LastSeen": "2025-05-31T11:25:24.712371-04:00"
   },
   "https://www.netlify.com/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:40:26.709537-04:00"
+    "LastSeen": "2025-05-31T11:25:37.619602-04:00"
   },
   "https://www.nginx.com/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:44:04.10872-04:00"
+    "LastSeen": "2025-05-31T11:27:15.682242-04:00"
   },
   "https://www.outreachy.org/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:46:15.606356-04:00"
+    "LastSeen": "2025-05-31T11:28:04.211681-04:00"
   },
   "https://www.shkuro.com/talks/2018-01-16-introducing-jaeger-1.0/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:42:42.457759-04:00"
+    "LastSeen": "2025-05-31T11:26:44.193197-04:00"
   },
   "https://www.w3.org/TR/baggage/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-29T19:41:13.037357-04:00"
+    "LastSeen": "2025-05-31T11:26:09.233028-04:00"
   },
   "https://youtu.be/s7IrYt1igSM": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-29T19:40:43.035351-04:00"
+    "LastSeen": "2025-05-31T11:25:53.188221-04:00"
   }
 }

--- a/data/refcache.json
+++ b/data/refcache.json
@@ -1,1962 +1,1650 @@
 {
   "http://cncf.io": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:45.695273-04:00"
+    "StatusCode": 206,
+    "LastSeen": "2025-05-31T11:50:30.926116-04:00"
   },
   "http://events.linuxfoundation.org/events/open-source-summit-north-america": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:45.541192-04:00"
+    "LastSeen": "2025-05-31T11:50:30.876086-04:00"
   },
   "http://uber.github.io": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:06.435472-04:00"
+    "LastSeen": "2025-05-31T11:49:20.771871-04:00"
   },
   "http://www.eweek.com/cloud/uber-and-lyft-bring-open-source-cloud-projects-to-cncf": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:50.136912-04:00"
+    "LastSeen": "2025-05-31T11:50:32.77285-04:00"
   },
   "http://www.zdnet.com/article/lyft-and-uber-travel-the-same-open-source-road/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:52.204922-04:00"
+    "LastSeen": "2025-05-31T11:50:32.95222-04:00"
   },
   "https://1password.com/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:36.169148-04:00"
+    "LastSeen": "2025-05-31T11:48:55.951926-04:00"
   },
   "https://artifacthub.io/packages/helm/bitnami/cassandra": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:33.695704-04:00"
+    "LastSeen": "2025-05-31T11:49:42.482668-04:00"
   },
   "https://artifacthub.io/packages/helm/bitnami/kafka": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:31.619009-04:00"
+    "LastSeen": "2025-05-31T11:49:41.716453-04:00"
   },
   "https://artifacthub.io/packages/helm/elastic/elasticsearch": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:37.692796-04:00"
+    "LastSeen": "2025-05-31T11:49:46.484222-04:00"
   },
   "https://artifacthub.io/packages/helm/opensearch-project-helm-charts/opensearch": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:14.927814-04:00"
+    "LastSeen": "2025-05-31T11:49:28.325149-04:00"
   },
   "https://base64.guru/converter/encode/hex": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:13.668184-04:00"
+    "LastSeen": "2025-05-31T11:49:27.151985-04:00"
   },
   "https://blog.openshift.com/openshift-commons-briefing-82-distributed-tracing-with-jaeger-prometheus-on-kubernetes/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:06.945019-04:00"
+    "LastSeen": "2025-05-31T11:50:06.462235-04:00"
   },
   "https://cassandra.apache.org/doc/latest/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:33.478234-04:00"
+    "LastSeen": "2025-05-31T11:49:42.236926-04:00"
   },
   "https://cassandra.apache.org/doc/latest/cassandra/managing/tools/cqlsh.html": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:52.804955-04:00"
+    "LastSeen": "2025-05-31T11:49:58.523025-04:00"
   },
   "https://cdn-images-1.medium.com/max/1000/1*jJm7BHkMListmocakAMcqA.png": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:33.523768-04:00"
+    "LastSeen": "2025-05-31T11:48:53.06915-04:00"
   },
   "https://cdn-images-1.medium.com/max/1024/0*iu_PaG5VWUVR2vRz": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:30.833114-04:00"
+    "LastSeen": "2025-05-31T11:48:50.587292-04:00"
   },
   "https://cdn-images-1.medium.com/max/1024/1*NKMqp96KpCm1hyhDyGP7fg.jpeg": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:34.89259-04:00"
+    "LastSeen": "2025-05-31T11:48:54.417564-04:00"
   },
   "https://cdn-images-1.medium.com/max/1024/1*T1FPdT_GcTo_2loOgrLyUA.png": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:34.289296-04:00"
+    "LastSeen": "2025-05-31T11:48:53.775158-04:00"
   },
   "https://cdn-images-1.medium.com/max/1024/1*b-RsMFPGcTtpxKaL2oRMEg.png": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:32.285226-04:00"
+    "LastSeen": "2025-05-31T11:48:52.044907-04:00"
   },
   "https://cdn-images-1.medium.com/max/1024/1*ccqn-B5CfJhwNkjFjqAFLg.jpeg": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:29.505939-04:00"
+    "LastSeen": "2025-05-31T11:48:49.355485-04:00"
   },
   "https://cdn-images-1.medium.com/max/1024/1*iFJFYZsdPvaFuwaAoZ1HRQ.jpeg": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:32.895128-04:00"
+    "LastSeen": "2025-05-31T11:48:52.533352-04:00"
   },
   "https://cdn-images-1.medium.com/max/1024/1*kHD8sLyWsbEcR0lqMhFFNA.png": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:35.588248-04:00"
+    "LastSeen": "2025-05-31T11:48:55.086626-04:00"
   },
   "https://cdn-images-1.medium.com/max/1024/1*nrY-UQFxXoQEjKKXDzHwSw.png": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:31.591364-04:00"
+    "LastSeen": "2025-05-31T11:48:51.238322-04:00"
   },
   "https://cdn-images-1.medium.com/max/1024/1*z0FkGABfi6lK35ojlFqLjQ.png": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:28.900171-04:00"
+    "LastSeen": "2025-05-31T11:48:48.804083-04:00"
   },
   "https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:01.499347-04:00"
+    "LastSeen": "2025-05-31T11:49:16.450811-04:00"
   },
   "https://cert-manager.io/docs/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:17.76616-04:00"
+    "LastSeen": "2025-05-31T11:50:16.300858-04:00"
   },
   "https://cert-manager.io/v1.6-docs/installation/#default-static-install": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:18.428956-04:00"
+    "LastSeen": "2025-05-31T11:50:16.736629-04:00"
   },
   "https://cloud-native.slack.com/archives/CGG7NFUJ3": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:22.89823-04:00"
+    "LastSeen": "2025-05-31T11:48:43.710244-04:00"
   },
   "https://cncf.io/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:06.625885-04:00"
+    "LastSeen": "2025-05-31T11:49:21.005717-04:00"
   },
   "https://code.jquery.com/jquery-3.3.1.min.js": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:24.750524-04:00"
+    "LastSeen": "2025-05-31T11:48:44.905019-04:00"
   },
   "https://code.visualstudio.com/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:24.47204-04:00"
+    "LastSeen": "2025-05-31T11:49:34.852334-04:00"
   },
   "https://contribute.cncf.io/contributors/getting-started/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:52.432668-04:00"
+    "LastSeen": "2025-05-31T11:49:10.270789-04:00"
   },
   "https://creativecommons.org/licenses/by/4.0": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:24.256698-04:00"
+    "LastSeen": "2025-05-31T11:48:44.632643-04:00"
   },
   "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:44.987964-04:00"
+    "LastSeen": "2025-05-31T11:49:51.397464-04:00"
   },
   "https://developers.google.com/protocol-buffers/docs/proto3#json": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:04.74352-04:00"
+    "LastSeen": "2025-05-31T11:49:19.241579-04:00"
   },
   "https://devops.com/cncf-advances-jaeger-distributed-tracing-project/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:40.189667-04:00"
+    "LastSeen": "2025-05-31T11:50:27.801922-04:00"
   },
   "https://docs.google.com/document/d/1ZuBAwTJvQN7xkWVvEFXj5WU9_JmS5TPiNbxCJSvPqX0/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:28.64766-04:00"
+    "LastSeen": "2025-05-31T11:48:48.60732-04:00"
   },
   "https://docs.google.com/document/d/1lAL0iHHozXZoIL4W0qiOWyXVPo9a6lUTeH9cz95O6Kg/edit": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:28:26.751714-04:00"
+    "LastSeen": "2025-05-31T11:51:03.908868-04:00"
   },
   "https://docs.google.com/document/d/1z4QrNtB9dMgT5SHNx-7Vc38XPLqnjmM2jFIupvkAEHo/view": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:37.354602-04:00"
+    "LastSeen": "2025-05-31T11:49:46.170485-04:00"
   },
   "https://docs.openshift.com/container-platform/4.2/logging/config/cluster-logging-elasticsearch.html": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:26.579858-04:00"
+    "LastSeen": "2025-05-31T11:50:21.769709-04:00"
   },
   "https://en.wikipedia.org/wiki/Clock_skew": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:34.339698-04:00"
+    "LastSeen": "2025-05-31T11:49:42.955992-04:00"
   },
   "https://fonts.googleapis.com/icon?family=Material+Icons": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:20.545997-04:00"
+    "LastSeen": "2025-05-31T11:48:41.359894-04:00"
   },
   "https://github.com/Ankit152": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:08.181135-04:00"
+    "LastSeen": "2025-05-31T11:50:46.573546-04:00"
   },
   "https://github.com/Ashmita152": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:24.232523-04:00"
+    "LastSeen": "2025-05-31T11:51:01.657426-04:00"
   },
   "https://github.com/ClickHouse/ClickHouse": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:47.605413-04:00"
+    "LastSeen": "2025-05-31T11:49:05.516663-04:00"
   },
   "https://github.com/FlamingSaint": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:11.9746-04:00"
+    "LastSeen": "2025-05-31T11:50:50.597499-04:00"
   },
   "https://github.com/GLVSKiriti": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:22.046243-04:00"
+    "LastSeen": "2025-05-31T11:50:59.88141-04:00"
   },
   "https://github.com/Manik2708": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:06.757198-04:00"
+    "LastSeen": "2025-05-31T11:50:45.479189-04:00"
   },
   "https://github.com/MarckK": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:25.023695-04:00"
+    "LastSeen": "2025-05-31T11:51:02.359911-04:00"
   },
   "https://github.com/PikBot": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:24.73132-04:00"
+    "LastSeen": "2025-05-31T11:51:02.170445-04:00"
   },
   "https://github.com/Pushkarm029": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:16.958653-04:00"
+    "LastSeen": "2025-05-31T11:50:54.473972-04:00"
   },
   "https://github.com/Wise-Wizard": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:13.218136-04:00"
+    "LastSeen": "2025-05-31T11:50:51.740773-04:00"
   },
   "https://github.com/afzal442": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:20.607363-04:00"
+    "LastSeen": "2025-05-31T11:50:58.785763-04:00"
   },
   "https://github.com/akagami-harsh": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:15.752247-04:00"
+    "LastSeen": "2025-05-31T11:50:53.271552-04:00"
   },
   "https://github.com/anshgoyalevil": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:17.30579-04:00"
+    "LastSeen": "2025-05-31T11:50:54.789927-04:00"
   },
   "https://github.com/cncf/artwork/tree/master/projects/jaeger": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:21.420942-04:00"
+    "LastSeen": "2025-05-31T11:48:42.18698-04:00"
   },
   "https://github.com/cncf/foundation/blob/main/code-of-conduct.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:25.519779-04:00"
+    "LastSeen": "2025-05-31T11:51:02.690599-04:00"
   },
   "https://github.com/cncf/foundation/blob/master/code-of-conduct.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:57.418555-04:00"
+    "LastSeen": "2025-05-31T11:49:14.894655-04:00"
   },
   "https://github.com/cncf/toc/blob/main/projects/jaeger/jaeger-graduation-proposal.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:38.624865-04:00"
+    "LastSeen": "2025-05-31T11:50:27.396517-04:00"
   },
   "https://github.com/dgraph-io/badger": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:21.217642-04:00"
+    "LastSeen": "2025-05-31T11:49:32.187446-04:00"
   },
   "https://github.com/go-delve/delve": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:24.402415-04:00"
+    "LastSeen": "2025-05-31T11:49:34.798768-04:00"
   },
   "https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md#enable-server-reflection": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:05.925285-04:00"
+    "LastSeen": "2025-05-31T11:49:20.339155-04:00"
   },
   "https://github.com/gsoria": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:24.477849-04:00"
+    "LastSeen": "2025-05-31T11:51:01.913462-04:00"
   },
   "https://github.com/haanhvu": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:23.014995-04:00"
+    "LastSeen": "2025-05-31T11:51:00.817229-04:00"
   },
   "https://github.com/hari45678": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:07.289007-04:00"
+    "LastSeen": "2025-05-31T11:50:45.888177-04:00"
   },
   "https://github.com/hellspawn679": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:09.225815-04:00"
+    "LastSeen": "2025-05-31T11:50:47.61643-04:00"
   },
   "https://github.com/jaegertracing/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:54.804342-04:00"
+    "LastSeen": "2025-05-31T11:49:12.615286-04:00"
   },
   "https://github.com/jaegertracing/documentation": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:22.312104-04:00"
+    "LastSeen": "2025-05-31T11:48:43.134197-04:00"
   },
   "https://github.com/jaegertracing/documentation/issues/250": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:19.788792-04:00"
+    "LastSeen": "2025-05-31T11:50:18.089894-04:00"
   },
   "https://github.com/jaegertracing/helm-charts/tree/v2": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:37.029201-04:00"
+    "LastSeen": "2025-05-31T11:49:45.676975-04:00"
   },
   "https://github.com/jaegertracing/jaeger": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:21.871383-04:00"
+    "LastSeen": "2025-05-31T11:48:42.574708-04:00"
   },
   "https://github.com/jaegertracing/jaeger-analytics": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:11.252197-04:00"
+    "LastSeen": "2025-05-31T11:49:24.392795-04:00"
   },
   "https://github.com/jaegertracing/jaeger-clickhouse": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:08.355986-04:00"
+    "LastSeen": "2025-05-31T11:49:22.129046-04:00"
   },
   "https://github.com/jaegertracing/jaeger-client-go": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:52.850533-04:00"
+    "LastSeen": "2025-05-31T11:50:33.439446-04:00"
   },
   "https://github.com/jaegertracing/jaeger-client-java": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:53.448604-04:00"
+    "LastSeen": "2025-05-31T11:50:33.864648-04:00"
   },
   "https://github.com/jaegertracing/jaeger-client-node": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:53.935354-04:00"
+    "LastSeen": "2025-05-31T11:50:34.535708-04:00"
   },
   "https://github.com/jaegertracing/jaeger-client-python": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:54.547552-04:00"
+    "LastSeen": "2025-05-31T11:50:35.016149-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:10.104626-04:00"
+    "LastSeen": "2025-05-31T11:50:09.114345-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/05fe64e9c305526901f70ff692030b388787e388/proto/api_v2/model.proto#L97": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:12.925281-04:00"
+    "LastSeen": "2025-05-31T11:49:26.469394-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/05fe64e9c305526901f70ff692030b388787e388/thrift/jaeger.thrift#L53": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:12.622313-04:00"
+    "LastSeen": "2025-05-31T11:49:26.206903-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v2/collector.proto": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:03.557364-04:00"
+    "LastSeen": "2025-05-31T11:49:18.121463-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v2/model.proto": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:14.638013-04:00"
+    "LastSeen": "2025-05-31T11:50:13.320004-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v2/query.proto": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:05.142248-04:00"
+    "LastSeen": "2025-05-31T11:50:05.226923-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v2/sampling.proto": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:04.322624-04:00"
+    "LastSeen": "2025-05-31T11:49:18.725136-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v3/query_service.proto": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:05.395124-04:00"
+    "LastSeen": "2025-05-31T11:49:19.831371-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/main/swagger/api_v3/query_service.swagger.json": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:42.827816-04:00"
+    "LastSeen": "2025-05-31T11:49:49.583603-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/main/thrift/jaeger.thrift": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:03.922287-04:00"
+    "LastSeen": "2025-05-31T11:49:18.42571-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/master/proto/api_v2/query.proto": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:15.853736-04:00"
+    "LastSeen": "2025-05-31T11:50:14.285208-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/master/proto/zipkin.proto": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:09.697364-04:00"
+    "LastSeen": "2025-05-31T11:50:08.747992-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:14.311248-04:00"
+    "LastSeen": "2025-05-31T11:50:13.10976-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/zipkincore.thrift": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:09.296487-04:00"
+    "LastSeen": "2025-05-31T11:50:08.397953-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/tree/main/proto/api_v2": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:05.638884-04:00"
+    "LastSeen": "2025-05-31T11:49:20.057441-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/dependency_storage.proto": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:43.546171-04:00"
+    "LastSeen": "2025-05-31T11:49:50.240547-04:00"
   },
   "https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/trace_storage.proto": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:43.188961-04:00"
+    "LastSeen": "2025-05-31T11:49:49.920952-04:00"
   },
   "https://github.com/jaegertracing/jaeger-kubernetes": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:13.446751-04:00"
+    "LastSeen": "2025-05-31T11:50:12.182079-04:00"
   },
   "https://github.com/jaegertracing/jaeger-openshift": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:13.950904-04:00"
+    "LastSeen": "2025-05-31T11:50:12.751318-04:00"
   },
   "https://github.com/jaegertracing/jaeger-operator": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:20.3511-04:00"
+    "LastSeen": "2025-05-31T11:49:31.131248-04:00"
   },
   "https://github.com/jaegertracing/jaeger-operator#compatibility-matrix": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:18.209842-04:00"
+    "LastSeen": "2025-05-31T11:50:16.675018-04:00"
   },
   "https://github.com/jaegertracing/jaeger-operator#jager-v2-operator": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:36.568317-04:00"
+    "LastSeen": "2025-05-31T11:49:45.133686-04:00"
   },
   "https://github.com/jaegertracing/jaeger-operator/blob/main/examples/business-application-injected-sidecar.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:28.778783-04:00"
+    "LastSeen": "2025-05-31T11:50:23.572513-04:00"
   },
   "https://github.com/jaegertracing/jaeger-operator/issues/294": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:27.229561-04:00"
+    "LastSeen": "2025-05-31T11:50:22.43806-04:00"
   },
   "https://github.com/jaegertracing/jaeger-operator/issues/750": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:28.429723-04:00"
+    "LastSeen": "2025-05-31T11:50:23.316547-04:00"
   },
   "https://github.com/jaegertracing/jaeger-operator/releases/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:17.275843-04:00"
+    "LastSeen": "2025-05-31T11:50:15.758006-04:00"
   },
   "https://github.com/jaegertracing/jaeger-operator/tree/main/examples": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:20.023644-04:00"
+    "LastSeen": "2025-05-31T11:50:18.369407-04:00"
   },
   "https://github.com/jaegertracing/jaeger-operator/tree/main/examples/statefulset-manual-sidecar.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:29.290786-04:00"
+    "LastSeen": "2025-05-31T11:50:23.871931-04:00"
   },
   "https://github.com/jaegertracing/jaeger-ui/blob/main/packages/jaeger-ui/src/types/config.tsx": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:09.681365-04:00"
+    "LastSeen": "2025-05-31T11:49:23.040133-04:00"
   },
   "https://github.com/jaegertracing/jaeger-ui/blob/master/packages/jaeger-ui/src/utils/tracking/README.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:10.137599-04:00"
+    "LastSeen": "2025-05-31T11:49:23.383859-04:00"
   },
   "https://github.com/jaegertracing/jaeger-ui/issues": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:26.812465-04:00"
+    "LastSeen": "2025-05-31T11:48:46.657472-04:00"
   },
   "https://github.com/jaegertracing/jaeger-ui/issues/1288": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:22.724768-04:00"
+    "LastSeen": "2025-05-31T11:51:00.559078-04:00"
   },
   "https://github.com/jaegertracing/jaeger-ui/issues/1466": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:19.481702-04:00"
+    "LastSeen": "2025-05-31T11:50:56.564772-04:00"
   },
   "https://github.com/jaegertracing/jaeger-ui/issues/197": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:35.741805-04:00"
+    "LastSeen": "2025-05-31T11:49:44.230785-04:00"
   },
   "https://github.com/jaegertracing/jaeger-ui/issues/998": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:18.590693-04:00"
+    "LastSeen": "2025-05-31T11:50:55.651471-04:00"
   },
   "https://github.com/jaegertracing/jaeger-ui/labels/good%20first%20issue": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:56.410793-04:00"
+    "LastSeen": "2025-05-31T11:49:13.953647-04:00"
   },
   "https://github.com/jaegertracing/jaeger-ui/labels/help%20wanted": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:56.945091-04:00"
+    "LastSeen": "2025-05-31T11:49:14.440371-04:00"
   },
   "https://github.com/jaegertracing/jaeger/archive/v1.69.0.tar.gz": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:57.312974-04:00"
+    "LastSeen": "2025-05-31T11:50:37.228517-04:00"
   },
   "https://github.com/jaegertracing/jaeger/archive/v1.69.0.zip": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:57.045474-04:00"
+    "LastSeen": "2025-05-31T11:50:36.992258-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/7872d1b07439c3f2d316065b1fd53e885b26a66f/model/ids.go#L82": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:12.265708-04:00"
+    "LastSeen": "2025-05-31T11:49:25.933268-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:26.385537-04:00"
+    "LastSeen": "2025-05-31T11:51:03.556289-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md#getting-started": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:53.82935-04:00"
+    "LastSeen": "2025-05-31T11:49:11.718206-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:57.018227-04:00"
+    "LastSeen": "2025-05-31T11:49:14.515233-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#assigning-issues": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:57.496924-04:00"
+    "LastSeen": "2025-05-31T11:49:14.97758-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#creating-a-pull-request": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:54.108977-04:00"
+    "LastSeen": "2025-05-31T11:49:12.02868-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/GOVERNANCE.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:35.828301-04:00"
+    "LastSeen": "2025-05-31T11:48:55.486766-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/GOVERNANCE.md#becoming-a-maintainer": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:35.904605-04:00"
+    "LastSeen": "2025-05-31T11:48:55.556343-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/config-badger.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:02.983903-04:00"
+    "LastSeen": "2025-05-31T11:50:04.934272-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/config-cassandra.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:02.352491-04:00"
+    "LastSeen": "2025-05-31T11:50:04.258827-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/config-elasticsearch.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:02.646913-04:00"
+    "LastSeen": "2025-05-31T11:50:04.604994-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/config-kafka-collector.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:01.655113-04:00"
+    "LastSeen": "2025-05-31T11:50:03.652758-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/config-kafka-ingester.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:01.988422-04:00"
+    "LastSeen": "2025-05-31T11:50:03.91518-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/config-opensearch.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:58.674059-04:00"
+    "LastSeen": "2025-05-31T11:50:00.964817-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/config-remote-storage.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:59.908378-04:00"
+    "LastSeen": "2025-05-31T11:50:02.264744-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/config-tail-sampling-always-sample.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:58.989031-04:00"
+    "LastSeen": "2025-05-31T11:50:01.348214-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/config-tail-sampling-service-name-policy.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:59.254038-04:00"
+    "LastSeen": "2025-05-31T11:50:01.673737-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/config.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:59.560753-04:00"
+    "LastSeen": "2025-05-31T11:50:01.935181-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/internal/extension/jaegerquery/config.go#L16": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:57.200757-04:00"
+    "LastSeen": "2025-05-31T11:49:59.948892-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/docker-compose/scylladb/README.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:16.155404-04:00"
+    "LastSeen": "2025-05-31T11:50:14.61138-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/examples/hotrod/README.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:53.515722-04:00"
+    "LastSeen": "2025-05-31T11:49:11.405683-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/go.mod": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:08.80692-04:00"
+    "LastSeen": "2025-05-31T11:50:07.922827-04:00"
   },
   "https://github.com/jaegertracing/jaeger/blob/main/monitoring/jaeger-mixin/dashboard-for-grafana.json": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:16.616166-04:00"
+    "LastSeen": "2025-05-31T11:50:15.028713-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:23.744028-04:00"
+    "LastSeen": "2025-05-31T11:48:44.346555-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/1537": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:19.33749-04:00"
+    "LastSeen": "2025-05-31T11:50:17.569433-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/1639": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:51.408473-04:00"
+    "LastSeen": "2025-05-31T11:49:09.346402-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/166": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:11.958429-04:00"
+    "LastSeen": "2025-05-31T11:49:25.645964-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/1718": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:07.943446-04:00"
+    "LastSeen": "2025-05-31T11:50:07.273746-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/2534": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:07.77856-04:00"
+    "LastSeen": "2025-05-31T11:50:46.27684-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/3381": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:21.527144-04:00"
+    "LastSeen": "2025-05-31T11:50:59.394872-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/355": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:51.943814-04:00"
+    "LastSeen": "2025-05-31T11:49:09.992637-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/4196": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:23.996203-04:00"
+    "LastSeen": "2025-05-31T11:51:01.395643-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/4600": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:20.315968-04:00"
+    "LastSeen": "2025-05-31T11:50:58.43033-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/4708": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:49.179704-04:00"
+    "LastSeen": "2025-05-31T11:49:07.045735-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/4739": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:03.154884-04:00"
+    "LastSeen": "2025-05-31T11:50:42.428413-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/4868": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:11.014374-04:00"
+    "LastSeen": "2025-05-31T11:50:49.618258-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/5058": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:48.465922-04:00"
+    "LastSeen": "2025-05-31T11:49:06.382673-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/5084": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:16.447803-04:00"
+    "LastSeen": "2025-05-31T11:50:53.887226-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/5632": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:12.874933-04:00"
+    "LastSeen": "2025-05-31T11:50:51.430141-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/5633": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:14.977607-04:00"
+    "LastSeen": "2025-05-31T11:50:52.594193-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/5766": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:08.943948-04:00"
+    "LastSeen": "2025-05-31T11:50:47.327786-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/5767": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:09.956814-04:00"
+    "LastSeen": "2025-05-31T11:50:48.748569-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/5910": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:49.709294-04:00"
+    "LastSeen": "2025-05-31T11:49:07.634196-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/6186": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:00.069553-04:00"
+    "LastSeen": "2025-05-31T11:49:15.601671-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/6321": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:55.625844-04:00"
+    "LastSeen": "2025-05-31T11:50:35.724213-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/638": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:22.028094-04:00"
+    "LastSeen": "2025-05-31T11:49:32.876689-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/6458": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:47.280784-04:00"
+    "LastSeen": "2025-05-31T11:49:05.116522-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/6628": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:42.132631-04:00"
+    "LastSeen": "2025-05-31T11:49:48.982248-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/6641": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:06.492219-04:00"
+    "LastSeen": "2025-05-31T11:50:45.145981-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/729": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:50.73533-04:00"
+    "LastSeen": "2025-05-31T11:49:08.661115-04:00"
   },
   "https://github.com/jaegertracing/jaeger/issues/961#issuecomment-453925244": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:34.998874-04:00"
+    "LastSeen": "2025-05-31T11:49:43.581447-04:00"
   },
   "https://github.com/jaegertracing/jaeger/labels/good%20first%20issue": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:55.413302-04:00"
+    "LastSeen": "2025-05-31T11:49:13.104153-04:00"
   },
   "https://github.com/jaegertracing/jaeger/labels/help%20wanted": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:55.874193-04:00"
+    "LastSeen": "2025-05-31T11:49:13.517411-04:00"
   },
   "https://github.com/jaegertracing/jaeger/releases/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:58.91335-04:00"
+    "LastSeen": "2025-05-31T11:50:38.527032-04:00"
   },
   "https://github.com/jaegertracing/jaeger/releases/download/v1.69.0/jaeger-1.69.0-darwin-amd64.tar.gz": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:57.623656-04:00"
+    "LastSeen": "2025-05-31T11:50:37.415618-04:00"
   },
   "https://github.com/jaegertracing/jaeger/releases/download/v1.69.0/jaeger-1.69.0-linux-amd64.tar.gz": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:57.951819-04:00"
+    "LastSeen": "2025-05-31T11:50:37.626816-04:00"
   },
   "https://github.com/jaegertracing/jaeger/releases/download/v1.69.0/jaeger-1.69.0-windows-amd64.tar.gz": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:58.178996-04:00"
+    "LastSeen": "2025-05-31T11:50:37.828786-04:00"
   },
   "https://github.com/jaegertracing/jaeger/releases/download/v1.69.0/jaeger-2.6.0-darwin-amd64.tar.gz": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:56.311955-04:00"
+    "LastSeen": "2025-05-31T11:50:36.347013-04:00"
   },
   "https://github.com/jaegertracing/jaeger/releases/download/v1.69.0/jaeger-2.6.0-linux-amd64.tar.gz": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:56.533224-04:00"
+    "LastSeen": "2025-05-31T11:50:36.559804-04:00"
   },
   "https://github.com/jaegertracing/jaeger/releases/download/v1.69.0/jaeger-2.6.0-windows-amd64.tar.gz": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:56.738984-04:00"
+    "LastSeen": "2025-05-31T11:50:36.754673-04:00"
   },
   "https://github.com/jaegertracing/jaeger/releases/tag/v1.22.0": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:39.511882-04:00"
+    "LastSeen": "2025-05-31T11:49:48.055124-04:00"
   },
   "https://github.com/jaegertracing/jaeger/releases/tag/v1.39.0": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:03.638054-04:00"
+    "LastSeen": "2025-05-31T11:50:42.767659-04:00"
   },
   "https://github.com/jaegertracing/jaeger/releases/tag/v1.69.0": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:56.023416-04:00"
+    "LastSeen": "2025-05-31T11:50:36.087416-04:00"
   },
   "https://github.com/jaegertracing/jaeger/security/advisories": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:22.570571-04:00"
+    "LastSeen": "2025-05-31T11:48:43.328403-04:00"
   },
   "https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:56.857361-04:00"
+    "LastSeen": "2025-05-31T11:49:59.588821-04:00"
   },
   "https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/config-spm.yaml": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:58.046126-04:00"
+    "LastSeen": "2025-05-31T11:50:00.571491-04:00"
   },
   "https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/internal/extension/jaegerquery": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:00.613028-04:00"
+    "LastSeen": "2025-05-31T11:50:02.884024-04:00"
   },
   "https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/internal/extension/jaegerstorage": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:00.244406-04:00"
+    "LastSeen": "2025-05-31T11:50:02.568993-04:00"
   },
   "https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/internal/extension/remotesampling": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:01.336249-04:00"
+    "LastSeen": "2025-05-31T11:50:03.394233-04:00"
   },
   "https://github.com/jaegertracing/jaeger/tree/main/cmd/jaeger/internal/processors/adaptivesampling": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:00.921266-04:00"
+    "LastSeen": "2025-05-31T11:50:03.16043-04:00"
   },
   "https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:57.535262-04:00"
+    "LastSeen": "2025-05-31T11:50:00.223725-04:00"
   },
   "https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:58.127574-04:00"
+    "LastSeen": "2025-05-31T11:50:00.651581-04:00"
   },
   "https://github.com/jaegertracing/jaeger/tree/main/examples/hotrod": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:59.805268-04:00"
+    "LastSeen": "2025-05-31T11:50:39.409933-04:00"
   },
   "https://github.com/jaegertracing/jaeger/tree/main/monitoring/jaeger-mixin": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:16.876109-04:00"
+    "LastSeen": "2025-05-31T11:50:15.328087-04:00"
   },
   "https://github.com/jaegertracing/spark-dependencies": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:10.585283-04:00"
+    "LastSeen": "2025-05-31T11:49:23.807186-04:00"
   },
   "https://github.com/james-ryans": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:16.671636-04:00"
+    "LastSeen": "2025-05-31T11:50:54.136474-04:00"
   },
   "https://github.com/joeyyy09": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:10.274188-04:00"
+    "LastSeen": "2025-05-31T11:50:49.040095-04:00"
   },
   "https://github.com/k8ssandra/cass-operator": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:34.088948-04:00"
+    "LastSeen": "2025-05-31T11:49:42.866643-04:00"
   },
   "https://github.com/kubernetes/charts/tree/master/incubator/jaeger": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:20.645734-04:00"
+    "LastSeen": "2025-05-31T11:49:31.548154-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:46.232379-04:00"
+    "LastSeen": "2025-05-31T11:49:04.219593-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:50.639345-04:00"
+    "LastSeen": "2025-05-31T11:49:56.5614-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/README.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:42.513085-04:00"
+    "LastSeen": "2025-05-31T11:49:49.265741-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:02.216961-04:00"
+    "LastSeen": "2025-05-31T11:49:17.09544-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:02.294191-04:00"
+    "LastSeen": "2025-05-31T11:49:17.171326-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/kafkaexporter/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:49.537601-04:00"
+    "LastSeen": "2025-05-31T11:49:55.476868-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/tailsamplingprocessor/README.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:31.354979-04:00"
+    "LastSeen": "2025-05-31T11:49:41.459593-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:02.601114-04:00"
+    "LastSeen": "2025-05-31T11:49:17.443452-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/kafkaexporter/README.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:52.263523-04:00"
+    "LastSeen": "2025-05-31T11:49:58.103395-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusexporter": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:49.796596-04:00"
+    "LastSeen": "2025-05-31T11:49:55.728834-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckv2extension": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:51.294525-04:00"
+    "LastSeen": "2025-05-31T11:49:57.228047-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/pprofextension": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:51.852584-04:00"
+    "LastSeen": "2025-05-31T11:49:57.772715-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/attributesprocessor": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:48.364823-04:00"
+    "LastSeen": "2025-05-31T11:49:54.339387-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:48.590816-04:00"
+    "LastSeen": "2025-05-31T11:49:54.595097-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:23.45405-04:00"
+    "LastSeen": "2025-05-31T11:49:33.758442-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/jaegerreceiver": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:46.434654-04:00"
+    "LastSeen": "2025-05-31T11:49:52.614703-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kafkareceiver": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:46.735403-04:00"
+    "LastSeen": "2025-05-31T11:49:52.862872-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kafkareceiver/README.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:52.657133-04:00"
+    "LastSeen": "2025-05-31T11:49:58.484905-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/zipkinreceiver": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:47.116005-04:00"
+    "LastSeen": "2025-05-31T11:49:53.200011-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md#client-configuration": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:53.101627-04:00"
+    "LastSeen": "2025-05-31T11:49:58.864052-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/blob/main/connector/forwardconnector/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:50.971435-04:00"
+    "LastSeen": "2025-05-31T11:49:56.941923-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:05.120935-04:00"
+    "LastSeen": "2025-05-31T11:49:19.571224-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/debugexporter": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:50.023872-04:00"
+    "LastSeen": "2025-05-31T11:49:55.962347-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/nopexporter": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:50.302042-04:00"
+    "LastSeen": "2025-05-31T11:49:56.230106-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:48.877648-04:00"
+    "LastSeen": "2025-05-31T11:49:54.904735-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:49.088589-04:00"
+    "LastSeen": "2025-05-31T11:49:55.158982-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/zpagesextension": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:51.612363-04:00"
+    "LastSeen": "2025-05-31T11:49:57.51144-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:47.69827-04:00"
+    "LastSeen": "2025-05-31T11:49:53.738412-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:47.966056-04:00"
+    "LastSeen": "2025-05-31T11:49:54.048022-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/nopreceiver": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:47.428865-04:00"
+    "LastSeen": "2025-05-31T11:49:53.473162-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/otlpreceiver": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:46.194626-04:00"
+    "LastSeen": "2025-05-31T11:49:52.306147-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-cpp": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:44.509207-04:00"
+    "LastSeen": "2025-05-31T11:49:02.851643-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:43.798897-04:00"
+    "LastSeen": "2025-05-31T11:49:02.2711-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Shims.OpenTracing": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:44.104326-04:00"
+    "LastSeen": "2025-05-31T11:49:02.498281-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-go": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:41.060786-04:00"
+    "LastSeen": "2025-05-31T11:49:00.352699-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-go-contrib/pull/936": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:43.063112-04:00"
+    "LastSeen": "2025-05-31T11:49:01.610175-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-go/tree/main/bridge/opentracing": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:43.41132-04:00"
+    "LastSeen": "2025-05-31T11:49:01.915651-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-java": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:38.66836-04:00"
+    "LastSeen": "2025-05-31T11:48:57.970069-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-java/tree/main/opentracing-shim": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:39.19469-04:00"
+    "LastSeen": "2025-05-31T11:48:58.492205-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/jaeger-remote-sampler": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:38.962518-04:00"
+    "LastSeen": "2025-05-31T11:48:58.252214-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-js": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:40.415015-04:00"
+    "LastSeen": "2025-05-31T11:48:59.663739-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-shim-opentracing": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:40.720458-04:00"
+    "LastSeen": "2025-05-31T11:48:59.889551-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:04.81851-04:00"
+    "LastSeen": "2025-05-31T11:49:19.311372-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlpgrpc": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:03.102055-04:00"
+    "LastSeen": "2025-05-31T11:49:17.75066-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlphttp": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:03.179552-04:00"
+    "LastSeen": "2025-05-31T11:49:17.832562-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/trace/v1/trace_service.proto": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:43.903087-04:00"
+    "LastSeen": "2025-05-31T11:49:50.458842-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-python": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:39.653683-04:00"
+    "LastSeen": "2025-05-31T11:48:58.872871-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-python/tree/main/shim/opentelemetry-opentracing-shim": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:39.966323-04:00"
+    "LastSeen": "2025-05-31T11:48:59.271517-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:23.750114-04:00"
+    "LastSeen": "2025-05-31T11:49:34.082896-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#span": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:44.632423-04:00"
+    "LastSeen": "2025-05-31T11:49:51.06665-04:00"
   },
   "https://github.com/opensearch-project/opensearch-k8s-operator": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:15.332157-04:00"
+    "LastSeen": "2025-05-31T11:49:28.713877-04:00"
   },
   "https://github.com/openshift/elasticsearch-operator": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:38.117125-04:00"
+    "LastSeen": "2025-05-31T11:49:47.10734-04:00"
   },
   "https://github.com/opentracing/specification/blob/master/specification.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:08.829387-04:00"
+    "LastSeen": "2025-05-31T11:49:22.488966-04:00"
   },
   "https://github.com/opentracing/specification/blob/master/specification.md#references-between-spans": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:20.722065-04:00"
+    "LastSeen": "2025-05-31T11:49:31.619028-04:00"
   },
   "https://github.com/openzipkin/zipkin-api": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:10.542741-04:00"
+    "LastSeen": "2025-05-31T11:50:09.517933-04:00"
   },
   "https://github.com/openzipkin/zipkin-api/blob/master/thrift/zipkinCore.thrift": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:10.891939-04:00"
+    "LastSeen": "2025-05-31T11:50:09.774685-04:00"
   },
   "https://github.com/openzipkin/zipkin-api/blob/master/zipkin.proto": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:11.154511-04:00"
+    "LastSeen": "2025-05-31T11:50:10.034043-04:00"
   },
   "https://github.com/operator-framework/operator-lifecycle-manager": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:31.537258-04:00"
+    "LastSeen": "2025-05-31T11:50:26.01933-04:00"
   },
   "https://github.com/orgs/jaegertracing/discussions": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:26.259836-04:00"
+    "LastSeen": "2025-05-31T11:48:46.005312-04:00"
   },
   "https://github.com/orgs/jaegertracing/projects/4/views/1": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:45.884372-04:00"
+    "LastSeen": "2025-05-31T11:49:03.807271-04:00"
   },
   "https://github.com/orgs/jaegertracing/repositories": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:27.218529-04:00"
+    "LastSeen": "2025-05-31T11:48:47.078003-04:00"
   },
   "https://github.com/pipiland2612": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:05.803509-04:00"
+    "LastSeen": "2025-05-31T11:50:44.583632-04:00"
   },
   "https://github.com/pmuls99": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:19.709348-04:00"
+    "LastSeen": "2025-05-31T11:50:56.867429-04:00"
   },
   "https://github.com/prathamesh-mutkure": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:18.891198-04:00"
+    "LastSeen": "2025-05-31T11:50:55.902153-04:00"
   },
   "https://github.com/robbert229/jaeger-postgresql": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:25.557886-04:00"
+    "LastSeen": "2025-05-31T11:49:35.496517-04:00"
   },
   "https://github.com/search": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:54.368612-04:00"
+    "LastSeen": "2025-05-31T11:49:12.195398-04:00"
   },
   "https://github.com/uber-go/zap": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:22.570462-04:00"
+    "LastSeen": "2025-05-31T11:49:33.34759-04:00"
   },
   "https://github.com/w3c/distributed-tracing": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:45.200287-04:00"
+    "LastSeen": "2025-05-31T11:49:03.481447-04:00"
   },
   "https://github.com/yurishkuro/microsim": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:00.587333-04:00"
+    "LastSeen": "2025-05-31T11:49:16.003473-04:00"
   },
   "https://github.com/yurishkuro/opentracing-tutorial/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:05.59347-04:00"
+    "LastSeen": "2025-05-31T11:50:05.721925-04:00"
   },
   "https://golang.org/doc/install": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:08.471418-04:00"
+    "LastSeen": "2025-05-31T11:50:07.694644-04:00"
   },
   "https://golangforall.com/en/post/go-docker-delve-remote-debug.html": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:24.972585-04:00"
+    "LastSeen": "2025-05-31T11:49:35.026101-04:00"
   },
   "https://groups.google.com/forum/#!forum/jaeger-tracing": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:23.068057-04:00"
+    "LastSeen": "2025-05-31T11:48:43.856238-04:00"
   },
   "https://hub.docker.com/_/cassandra": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:33.619626-04:00"
+    "LastSeen": "2025-05-31T11:49:42.385234-04:00"
   },
   "https://hub.docker.com/_/elasticsearch": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:37.621642-04:00"
+    "LastSeen": "2025-05-31T11:49:46.412483-04:00"
   },
   "https://hub.docker.com/r/apache/kafka": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:31.538195-04:00"
+    "LastSeen": "2025-05-31T11:49:41.634308-04:00"
   },
   "https://hub.docker.com/r/jaegertracing": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:11.373086-04:00"
+    "LastSeen": "2025-05-31T11:50:10.215127-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:59.10542-04:00"
+    "LastSeen": "2025-05-31T11:50:38.727174-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/all-in-one": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:59.345327-04:00"
+    "LastSeen": "2025-05-31T11:50:39.013948-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/all-in-one/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:11.891187-04:00"
+    "LastSeen": "2025-05-31T11:50:10.56197-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/example-hotrod": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:59.472205-04:00"
+    "LastSeen": "2025-05-31T11:50:39.15061-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:59.256171-04:00"
+    "LastSeen": "2025-05-31T11:50:38.874821-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger-agent": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:28:01.645764-04:00"
+    "LastSeen": "2025-05-31T11:50:41.328597-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger-cassandra-schema": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:28:01.379754-04:00"
+    "LastSeen": "2025-05-31T11:50:41.085402-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger-collector": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:28:00.578199-04:00"
+    "LastSeen": "2025-05-31T11:50:40.278344-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger-collector/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:12.095372-04:00"
+    "LastSeen": "2025-05-31T11:50:10.774796-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger-es-index-cleaner": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:28:01.51746-04:00"
+    "LastSeen": "2025-05-31T11:50:41.200515-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger-ingester": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:28:00.836544-04:00"
+    "LastSeen": "2025-05-31T11:50:40.498386-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger-ingester/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:12.560954-04:00"
+    "LastSeen": "2025-05-31T11:50:11.248393-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger-operator": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:28:01.245601-04:00"
+    "LastSeen": "2025-05-31T11:50:40.894518-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger-query": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:28:00.703567-04:00"
+    "LastSeen": "2025-05-31T11:50:40.38759-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger-query/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:12.319674-04:00"
+    "LastSeen": "2025-05-31T11:50:10.999516-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger-remote-storage": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:28:00.974793-04:00"
+    "LastSeen": "2025-05-31T11:50:40.634277-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/jaeger-remote-storage/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:12.795119-04:00"
+    "LastSeen": "2025-05-31T11:50:11.497532-04:00"
   },
   "https://hub.docker.com/r/jaegertracing/spark-dependencies": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:28:01.116099-04:00"
+    "LastSeen": "2025-05-31T11:50:40.748444-04:00"
   },
   "https://hub.docker.com/r/opensearchproject/opensearch": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:14.755115-04:00"
+    "LastSeen": "2025-05-31T11:49:28.155278-04:00"
   },
   "https://istio.io/faq/distributed-tracing/#no-tracing": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:24.005962-04:00"
+    "LastSeen": "2025-05-31T11:49:34.417342-04:00"
   },
   "https://istio.io/latest/docs/tasks/observability/distributed-tracing/jaeger/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:07.18078-04:00"
+    "LastSeen": "2025-05-31T11:50:06.528241-04:00"
   },
   "https://jbrandhorst.com/post/gogoproto/#reflection": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:06.285823-04:00"
+    "LastSeen": "2025-05-31T11:49:20.677283-04:00"
   },
   "https://kafka.apache.org/documentation/#intro_topics": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:32.724472-04:00"
+    "LastSeen": "2025-05-31T11:49:41.910491-04:00"
   },
   "https://kafka.apache.org/documentation/#quickstart_createtopic": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:32.695609-04:00"
+    "LastSeen": "2025-05-31T11:49:41.88019-04:00"
   },
   "https://kubernetes.github.io/ingress-nginx/deploy/#verify-installation": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:30.981205-04:00"
+    "LastSeen": "2025-05-31T11:50:25.511205-04:00"
   },
   "https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:29.480953-04:00"
+    "LastSeen": "2025-05-31T11:50:24.0587-04:00"
   },
   "https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:29.967775-04:00"
+    "LastSeen": "2025-05-31T11:50:24.533771-04:00"
   },
   "https://kubernetes.io/docs/concepts/configuration/secret/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:31.125519-04:00"
+    "LastSeen": "2025-05-31T11:50:25.660751-04:00"
   },
   "https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:30.154359-04:00"
+    "LastSeen": "2025-05-31T11:50:24.723606-04:00"
   },
   "https://kubernetes.io/docs/concepts/extend-kubernetes/operator/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:17.560848-04:00"
+    "LastSeen": "2025-05-31T11:50:16.068635-04:00"
   },
   "https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:29.626598-04:00"
+    "LastSeen": "2025-05-31T11:50:24.203134-04:00"
   },
   "https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:29.77873-04:00"
+    "LastSeen": "2025-05-31T11:50:24.346135-04:00"
   },
   "https://kubernetes.io/docs/concepts/services-networking/ingress/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:30.886481-04:00"
+    "LastSeen": "2025-05-31T11:50:25.450631-04:00"
   },
   "https://kubernetes.io/docs/concepts/storage/volumes/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:30.300126-04:00"
+    "LastSeen": "2025-05-31T11:50:24.867984-04:00"
   },
   "https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:30.445688-04:00"
+    "LastSeen": "2025-05-31T11:50:25.012368-04:00"
   },
   "https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-image-pull-secret-to-service-account%29": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:30.741125-04:00"
+    "LastSeen": "2025-05-31T11:50:25.305065-04:00"
   },
   "https://kubernetes.io/docs/tasks/configure-pod-container/security-context/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:30.587528-04:00"
+    "LastSeen": "2025-05-31T11:50:25.158118-04:00"
   },
   "https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:18.787774-04:00"
+    "LastSeen": "2025-05-31T11:50:17.03648-04:00"
   },
   "https://kubernetes.io/docs/tasks/tools/install-minikube/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:18.740577-04:00"
+    "LastSeen": "2025-05-31T11:50:16.98921-04:00"
   },
   "https://medium.com/@YuriShkuro/take-opentracing-for-a-hotrod-ride-f6e3141f7941": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:28:00.443629-04:00"
+    "LastSeen": "2025-05-31T11:50:40.141108-04:00"
   },
   "https://medium.com/@larsmilland01/secure-architecture-for-jaeger-with-apache-httpd-reverse-proxy-on-openshift-f31983fad400": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:45.615492-04:00"
+    "LastSeen": "2025-05-31T11:49:51.890029-04:00"
   },
   "https://medium.com/@saransh.shankar/my-journey-as-an-lfx-mentee-with-cncf-jaeger-b001f136ca0b": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:28:15.454854-04:00"
+    "LastSeen": "2025-05-31T11:50:52.937678-04:00"
   },
   "https://medium.com/jaegertracing": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:24.050956-04:00"
+    "LastSeen": "2025-05-31T11:48:44.542359-04:00"
   },
   "https://medium.com/jaegertracing/adaptive-sampling-in-jaeger-50f336f4334": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:34.804898-04:00"
+    "LastSeen": "2025-05-31T11:48:54.303573-04:00"
   },
   "https://medium.com/jaegertracing/announcing-jaeger-1-0-37b5990cc59b": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:42.246841-04:00"
+    "LastSeen": "2025-05-31T11:50:29.267133-04:00"
   },
   "https://medium.com/jaegertracing/better-alignment-with-opentelemetry-by-focusing-on-otlp-f3688939073f": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:32.831953-04:00"
+    "LastSeen": "2025-05-31T11:48:52.464012-04:00"
   },
   "https://medium.com/jaegertracing/deployment-strategies-for-the-jaeger-agent-1d6f91796d09": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:28.600521-04:00"
+    "LastSeen": "2025-05-31T11:49:38.908496-04:00"
   },
   "https://medium.com/jaegertracing/experiment-migrating-opentracing-based-application-in-go-to-use-the-opentelemetry-sdk-29b09fe2fbc4": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:32.199881-04:00"
+    "LastSeen": "2025-05-31T11:48:51.963616-04:00"
   },
   "https://medium.com/jaegertracing/grafana-labs-teams-observed-query-performance-improvements-up-to-10x-with-jaeger-cec84b0e3609": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:26.402923-04:00"
+    "LastSeen": "2025-05-31T11:49:36.198182-04:00"
   },
   "https://medium.com/jaegertracing/how-to-maximize-span-ingestion-while-limiting-writes-per-second-to-scylla-with-jaeger-3bcda5608841": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:30.310768-04:00"
+    "LastSeen": "2025-05-31T11:49:40.558313-04:00"
   },
   "https://medium.com/jaegertracing/introducing-native-support-for-opentelemetry-in-jaeger-eb661be8183c": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:33.448959-04:00"
+    "LastSeen": "2025-05-31T11:48:52.979551-04:00"
   },
   "https://medium.com/jaegertracing/jaeger-and-multitenancy-99dfa1d49dc0": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:28.147851-04:00"
+    "LastSeen": "2025-05-31T11:49:38.318473-04:00"
   },
   "https://medium.com/jaegertracing/jaeger-and-opentelemetry-1846f701d9f2": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:44.283867-04:00"
+    "LastSeen": "2025-05-31T11:49:50.674049-04:00"
   },
   "https://medium.com/jaegertracing/jaeger-tracing-a-friendly-guide-for-beginners-7b53a4a568ca": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:34.204199-04:00"
+    "LastSeen": "2025-05-31T11:48:53.687344-04:00"
   },
   "https://medium.com/jaegertracing/jaeger-v2-released-09a6033d1b10": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:29.41848-04:00"
+    "LastSeen": "2025-05-31T11:48:49.284592-04:00"
   },
   "https://medium.com/jaegertracing/latest": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:21.001488-04:00"
+    "LastSeen": "2025-05-31T11:48:41.728169-04:00"
   },
   "https://medium.com/jaegertracing/learning-from-lfx-mentorship-cncf-jaeger-3fc3463adcea": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:28.820201-04:00"
+    "LastSeen": "2025-05-31T11:48:48.708831-04:00"
   },
   "https://medium.com/jaegertracing/making-design-decisions-for-clickhouse-as-a-core-storage-backend-in-jaeger-62bf90a979d": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:31.514915-04:00"
+    "LastSeen": "2025-05-31T11:48:51.145623-04:00"
   },
   "https://medium.com/jaegertracing/migrating-from-jaeger-client-to-opentelemetry-sdk-bd337d796759": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:35.508919-04:00"
+    "LastSeen": "2025-05-31T11:48:55.010083-04:00"
   },
   "https://medium.com/jaegertracing/protecting-jaeger-ui-with-an-oauth-sidecar-proxy-34205cca4bb1": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:14.25971-04:00"
+    "LastSeen": "2025-05-31T11:49:27.752061-04:00"
   },
   "https://medium.com/jaegertracing/running-jaeger-agent-on-bare-metal-d1fc47d31fab": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:27.634439-04:00"
+    "LastSeen": "2025-05-31T11:49:37.728768-04:00"
   },
   "https://medium.com/jaegertracing/take-jaeger-for-a-hotrod-ride-233cf43e46c2": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:52.939124-04:00"
+    "LastSeen": "2025-05-31T11:49:10.888013-04:00"
   },
   "https://medium.com/jaegertracing/the-life-of-a-span-ee508410200b": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:27.530644-04:00"
+    "LastSeen": "2025-05-31T11:49:37.656915-04:00"
   },
   "https://medium.com/jaegertracing/ticketmaster-traces-100-million-transactions-per-day-with-jaeger-38ec6cf599f0": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:27.012989-04:00"
+    "LastSeen": "2025-05-31T11:49:36.861981-04:00"
   },
   "https://medium.com/jaegertracing/towards-jaeger-v2-moar-opentelemetry-2f8239bee48e": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:30.462401-04:00"
+    "LastSeen": "2025-05-31T11:48:50.223805-04:00"
   },
   "https://medium.com/jaegertracing/trace-comparisons-arrive-in-jaeger-1-7-a97ad5e2d05d": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:25.697909-04:00"
+    "LastSeen": "2025-05-31T11:49:35.572179-04:00"
   },
   "https://medium.com/jaegertracing/using-elasticsearch-rollover-to-manage-indices-8b3d0c77915d": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:19.801534-04:00"
+    "LastSeen": "2025-05-31T11:49:30.762625-04:00"
   },
   "https://medium.com/jaegertracing/weaveworks-combines-jaeger-tracing-with-logs-and-metrics-for-a-troubleshooting-swiss-army-knife-5afc0f42b22e": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:26.314371-04:00"
+    "LastSeen": "2025-05-31T11:49:36.120402-04:00"
   },
   "https://medium.com/jaegertracing/where-did-all-my-spans-go-a-guide-to-diagnosing-dropped-spans-in-jaeger-10d9697f8182": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:31.063482-04:00"
+    "LastSeen": "2025-05-31T11:49:41.186602-04:00"
   },
   "https://medium.com/opentracing/tracing-http-request-latency-in-go-with-opentracing-7cc1282a100a": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:05.686287-04:00"
+    "LastSeen": "2025-05-31T11:50:05.795496-04:00"
   },
   "https://mentorship.lfx.linuxfoundation.org/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:05.563702-04:00"
+    "LastSeen": "2025-05-31T11:50:44.340485-04:00"
   },
   "https://nssm.cc/download": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:36.254593-04:00"
+    "LastSeen": "2025-05-31T11:49:44.808478-04:00"
   },
   "https://nssm.cc/usage": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:36.476755-04:00"
+    "LastSeen": "2025-05-31T11:49:45.03709-04:00"
   },
   "https://opensearch.org/docs/latest/api-reference/index-apis/rollover/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:17.734964-04:00"
+    "LastSeen": "2025-05-31T11:49:29.473393-04:00"
   },
   "https://opensearch.org/downloads.html": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:14.5463-04:00"
+    "LastSeen": "2025-05-31T11:49:28.017754-04:00"
   },
   "https://opentelemetry.io": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:31.392171-04:00"
+    "LastSeen": "2025-05-31T11:49:41.497699-04:00"
   },
   "https://opentelemetry.io/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:37.857372-04:00"
+    "LastSeen": "2025-05-31T11:48:57.375102-04:00"
   },
   "https://opentelemetry.io/docs/collector/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:45.908336-04:00"
+    "LastSeen": "2025-05-31T11:49:52.030319-04:00"
   },
   "https://opentelemetry.io/docs/collector/configuration/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:00.145202-04:00"
+    "LastSeen": "2025-05-31T11:49:15.631836-04:00"
   },
   "https://opentelemetry.io/docs/collector/internal-telemetry/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:53.289429-04:00"
+    "LastSeen": "2025-05-31T11:49:58.922018-04:00"
   },
   "https://opentelemetry.io/docs/collector/scaling/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:08.535273-04:00"
+    "LastSeen": "2025-05-31T11:49:22.178705-04:00"
   },
   "https://opentelemetry.io/docs/collector/troubleshooting/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:02.732237-04:00"
+    "LastSeen": "2025-05-31T11:49:17.472142-04:00"
   },
   "https://opentelemetry.io/docs/concepts/sampling/#head-sampling": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:22.937127-04:00"
+    "LastSeen": "2025-05-31T11:49:33.481262-04:00"
   },
   "https://opentelemetry.io/docs/concepts/sampling/#tail-sampling": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:23.082694-04:00"
+    "LastSeen": "2025-05-31T11:49:33.514043-04:00"
   },
   "https://opentelemetry.io/docs/concepts/signals/traces/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:09.031264-04:00"
+    "LastSeen": "2025-05-31T11:49:22.524314-04:00"
   },
   "https://opentelemetry.io/docs/migration/opentracing/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:38.068648-04:00"
+    "LastSeen": "2025-05-31T11:48:57.444655-04:00"
   },
   "https://opentelemetry.io/docs/reference/specification/protocol/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:37.971505-04:00"
+    "LastSeen": "2025-05-31T11:48:57.415879-04:00"
   },
   "https://opentelemetry.io/docs/specs/otel/protocol/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:45.770452-04:00"
+    "LastSeen": "2025-05-31T11:49:51.947658-04:00"
   },
   "https://opentracing.io/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:07.879451-04:00"
+    "LastSeen": "2025-05-31T11:49:21.683843-04:00"
   },
   "https://opentracing.io/specification/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:44.351399-04:00"
+    "LastSeen": "2025-05-31T11:49:50.766001-04:00"
   },
   "https://operatorhub.io/operator/elastic-cloud-eck": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:20.404343-04:00"
+    "LastSeen": "2025-05-31T11:50:18.742618-04:00"
   },
   "https://opster.com/guides/opensearch/opensearch-capacity-planning/how-to-choose-the-correct-number-of-shards-per-index-in-opensearch": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:17.129616-04:00"
+    "LastSeen": "2025-05-31T11:49:29.085581-04:00"
   },
   "https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:00.88012-04:00"
+    "LastSeen": "2025-05-31T11:49:16.41256-04:00"
   },
   "https://prometheus.io/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:22.104181-04:00"
+    "LastSeen": "2025-05-31T11:49:32.946044-04:00"
   },
   "https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:01.95583-04:00"
+    "StatusCode": 200,
+    "LastSeen": "2025-05-31T11:49:16.820719-04:00"
   },
   "https://prometheus.io/docs/guides/tls-encryption/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:35.909583-04:00"
+    "LastSeen": "2025-05-31T11:49:44.535151-04:00"
   },
   "https://promlabs.com/blog/2020/11/26/an-update-on-promql-compatibility-across-vendors": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:01.742262-04:00"
+    "LastSeen": "2025-05-31T11:49:16.675469-04:00"
   },
   "https://quay.io/organization/jaegertracing": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:11.758424-04:00"
+    "LastSeen": "2025-05-31T11:50:10.416045-04:00"
   },
   "https://quay.io/repository/jaegertracing/all-in-one": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:11.990921-04:00"
+    "LastSeen": "2025-05-31T11:50:10.672905-04:00"
   },
   "https://quay.io/repository/jaegertracing/jaeger-collector": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:12.191323-04:00"
+    "LastSeen": "2025-05-31T11:50:10.872856-04:00"
   },
   "https://quay.io/repository/jaegertracing/jaeger-ingester": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:12.678081-04:00"
+    "LastSeen": "2025-05-31T11:50:11.358273-04:00"
   },
   "https://quay.io/repository/jaegertracing/jaeger-query": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:12.421883-04:00"
+    "LastSeen": "2025-05-31T11:50:11.111092-04:00"
   },
   "https://quay.io/repository/jaegertracing/jaeger-remote-storage": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:12.886421-04:00"
+    "LastSeen": "2025-05-31T11:50:11.599145-04:00"
   },
   "https://shkuro.com": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:07.502819-04:00"
+    "LastSeen": "2025-05-31T11:49:21.304743-04:00"
   },
   "https://shkuro.com/books/2019-mastering-distributed-tracing/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:07.705004-04:00"
+    "LastSeen": "2025-05-31T11:49:21.542942-04:00"
   },
   "https://siliconangle.com/2017/09/13/ride-sharing-firms-lyft-uber-donate-microservices-tech-open-source-community/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:47.569727-04:00"
+    "LastSeen": "2025-05-31T11:50:31.431292-04:00"
   },
   "https://slack.cncf.io": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:25.783542-04:00"
+    "LastSeen": "2025-05-31T11:48:45.700611-04:00"
   },
   "https://slack.cncf.io/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:28:26.149293-04:00"
+    "LastSeen": "2025-05-31T11:51:03.262353-04:00"
   },
   "https://strimzi.io/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:31.873517-04:00"
+    "LastSeen": "2025-05-31T11:49:41.851309-04:00"
   },
   "https://summerofcode.withgoogle.com/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:28:04.328726-04:00"
+    "LastSeen": "2025-05-31T11:50:43.029969-04:00"
   },
   "https://use.fontawesome.com/releases/v5.0.7/js/all.js": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:24.81626-04:00"
+    "LastSeen": "2025-05-31T11:48:44.968149-04:00"
   },
   "https://web.archive.org/web/20241212124714/https://thenewstack.io/cncf-adds-oracle-onboards-envoy-jaeger-projects/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:48.681827-04:00"
+    "LastSeen": "2025-05-31T11:50:32.497267-04:00"
   },
   "https://web.archive.org/web/20250426221351/https://thenewstack.io/jaeger-graduates-cncf-sees-a-future-without-native-jaeger-clients//": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:41.415761-04:00"
+    "LastSeen": "2025-05-31T11:50:28.800063-04:00"
   },
   "https://www.aspecto.io/blog/how-to-deploy-jaeger-on-aws-a-comprehensive-step-by-step-guide/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:29.732443-04:00"
+    "LastSeen": "2025-05-31T11:49:40.086449-04:00"
   },
   "https://www.cncf.io/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:36.097019-04:00"
+    "LastSeen": "2025-05-31T11:48:55.858449-04:00"
   },
   "https://www.cncf.io/announcement/2019/10/31/cloud-native-computing-foundation-announces-jaeger-graduation/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:38.909986-04:00"
+    "LastSeen": "2025-05-31T11:50:27.524977-04:00"
   },
   "https://www.cncf.io/blog/2017/09/13/cncf-hosts-jaeger/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:46.777783-04:00"
+    "LastSeen": "2025-05-31T11:50:30.963022-04:00"
   },
   "https://www.codecov.io/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:36.565196-04:00"
+    "LastSeen": "2025-05-31T11:48:56.320038-04:00"
   },
   "https://www.confluent.io/blog/how-to-choose-the-number-of-topicspartitions-in-a-kafka-cluster/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:33.298481-04:00"
+    "LastSeen": "2025-05-31T11:49:42.20049-04:00"
   },
   "https://www.dosu.dev/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:37.276084-04:00"
+    "LastSeen": "2025-05-31T11:48:56.868107-04:00"
   },
   "https://www.elastic.co/blog/how-many-shards-should-i-have-in-my-elasticsearch-cluster": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:38.244684-04:00"
+    "StatusCode": 206,
+    "LastSeen": "2025-05-31T11:49:47.209879-04:00"
   },
   "https://www.elastic.co/docs/deploy-manage/upgrade/deployment-or-cluster": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:40.36581-04:00"
+    "LastSeen": "2025-05-31T11:49:48.358647-04:00"
   },
   "https://www.elastic.co/downloads/elasticsearch": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:26:37.491357-04:00"
+    "LastSeen": "2025-05-31T11:49:46.284658-04:00"
   },
   "https://www.elastic.co/guide/en/elasticsearch/reference/5.6/heap-size.html": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:27.55241-04:00"
+    "LastSeen": "2025-05-31T11:50:22.701774-04:00"
   },
   "https://www.elastic.co/guide/en/elasticsearch/reference/current/index-lifecycle-management.html": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:40.108463-04:00"
+    "LastSeen": "2025-05-31T11:49:48.321824-04:00"
   },
   "https://www.elastic.co/guide/en/elasticsearch/reference/master/common-options.html#byte-units": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:19.224025-04:00"
+    "LastSeen": "2025-05-31T11:49:30.155041-04:00"
   },
   "https://www.elastic.co/guide/en/elasticsearch/reference/master/common-options.html#time-units": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:18.811569-04:00"
+    "LastSeen": "2025-05-31T11:49:29.814846-04:00"
   },
   "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:39.016963-04:00"
+    "LastSeen": "2025-05-31T11:49:47.558774-04:00"
   },
   "https://www.github.com/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:37.453131-04:00"
+    "LastSeen": "2025-05-31T11:48:57.034355-04:00"
   },
   "https://www.google.com/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:37.55558-04:00"
-  },
-  "https://www.jaegertracing.io/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:28.718973-04:00"
-  },
-  "https://www.jaegertracing.io/docs/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:58.086374-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:58.275344-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/architecture/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:58.420685-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/deployment/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:58.622809-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/external-guides/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:59.322601-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/faq/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:59.147965-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/operations/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:58.949569-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.0/storage/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:58.789506-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:53.591247-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/architecture/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:53.86419-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/deployment/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:54.076727-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/external-guides/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:54.892513-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/faq/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:54.678497-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/operations/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:54.513047-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.1/storage/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:54.337338-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:35.065468-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/architecture/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:35.254501-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/deployment/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:35.436773-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/external-guides/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:36.066294-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/faq/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:35.919191-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/operations/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:35.761796-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.2/storage/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:35.610133-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:33.377179-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/architecture/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:33.538542-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/deployment/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:33.69239-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/external-guides/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:34.586946-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/faq/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:34.357373-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/operations/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:34.174942-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.3/storage/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:33.962161-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:31.806397-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/architecture/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:31.966382-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/deployment/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:32.206867-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/external-guides/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:32.893868-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/faq/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:32.727196-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/operations/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:32.536561-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.4/storage/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:32.370966-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:36.598979-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/architecture/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:36.76948-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/deployment/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:37.025876-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/external-guides/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:37.750615-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/faq/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:37.586301-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/operations/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:37.41686-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.5/storage/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:37.23588-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:40.502226-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/architecture/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:40.723204-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/deployment/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:40.79161-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/external-guides/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:41.524938-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/faq/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:41.278303-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/operations/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:41.112837-04:00"
-  },
-  "https://www.jaegertracing.io/docs/2.6/storage/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:40.952693-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:55.373965-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/architecture/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:55.535892-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/deployment/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:55.70258-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/external-guides/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:56.589313-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/faq/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:56.417457-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/operations/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:56.144865-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release-v2/storage/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:55.996536-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:03.166109-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/architecture/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:03.50168-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/deployment/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:03.722116-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/external-guides/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:04.856109-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/faq/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:04.52532-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/getting-started/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:03.335584-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/monitoring/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:03.939977-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/performance-tuning/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:04.176205-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/tools/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:04.692041-04:00"
-  },
-  "https://www.jaegertracing.io/docs/next-release/troubleshooting/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:04.357527-04:00"
-  },
-  "https://www.jaegertracing.io/download/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:54.710517-04:00"
-  },
-  "https://www.jaegertracing.io/get-in-touch/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:24.992053-04:00"
-  },
-  "https://www.jaegertracing.io/get-involved/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:52.14917-04:00"
-  },
-  "https://www.jaegertracing.io/mentorship-for-mentees/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:25.28604-04:00"
-  },
-  "https://www.jaegertracing.io/mentorship-for-mentors/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:57.750324-04:00"
-  },
-  "https://www.jaegertracing.io/mentorship/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:28:03.914818-04:00"
-  },
-  "https://www.jaegertracing.io/news/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:38.245542-04:00"
-  },
-  "https://www.jaegertracing.io/report-security-issue/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:20.457984-04:00"
-  },
-  "https://www.jaegertracing.io/roadmap/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:45.614215-04:00"
-  },
-  "https://www.jaegertracing.io/sdk-migration/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:37.779868-04:00"
+    "LastSeen": "2025-05-31T11:48:57.19048-04:00"
   },
   "https://www.jetbrains.com/go/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:24.818044-04:00"
+    "LastSeen": "2025-05-31T11:49:34.890603-04:00"
   },
   "https://www.linkedin.com/posts/harshith-mente_lfxmentorship-jaeger-opentelemetry-activity-7235573030997934080-0Id1": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:28:11.722101-04:00"
+    "LastSeen": "2025-05-31T11:50:50.340201-04:00"
   },
   "https://www.linuxfoundation.org/blog/blog/lyft-and-uber-on-stage-together-at-open-source-summit-in-l-a": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:27:46.967493-04:00"
+    "LastSeen": "2025-05-31T11:50:31.087901-04:00"
   },
   "https://www.linuxfoundation.org/trademark-usage": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:24.712371-04:00"
+    "LastSeen": "2025-05-31T11:48:44.857689-04:00"
   },
   "https://www.netlify.com/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:25:37.619602-04:00"
+    "LastSeen": "2025-05-31T11:48:57.242585-04:00"
   },
   "https://www.nginx.com/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:27:15.682242-04:00"
+    "LastSeen": "2025-05-31T11:50:14.125055-04:00"
   },
   "https://www.outreachy.org/": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:28:04.211681-04:00"
+    "LastSeen": "2025-05-31T11:50:42.905443-04:00"
   },
   "https://www.shkuro.com/talks/2018-01-16-introducing-jaeger-1.0/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:44.193197-04:00"
+    "LastSeen": "2025-05-31T11:49:50.579318-04:00"
   },
   "https://www.w3.org/TR/baggage/": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-31T11:26:09.233028-04:00"
+    "LastSeen": "2025-05-31T11:49:22.708294-04:00"
   },
   "https://youtu.be/s7IrYt1igSM": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:25:53.188221-04:00"
+    "LastSeen": "2025-05-31T11:49:11.130704-04:00"
   }
 }

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,10 +1,9 @@
-baseURL: "https://www.jaegertracing.io"
+baseURL: https://www.jaegertracing.io
 title: "Jaeger: open source, distributed tracing platform"
 languageCode: en
 pygmentsCodeFences: true
 pygmentsUseClasses: true
 disableKinds: ["taxonomy"]
-canonifyURLs: true
 theme: ["basetheme", "jaeger-docs"]
 
 mediaTypes:
@@ -38,4 +37,4 @@ params:
     links:
       - title: "Docs"
         url: "/docs"
-  
+

--- a/themes/jaeger-docs/layouts/partials/docs/header.html
+++ b/themes/jaeger-docs/layouts/partials/docs/header.html
@@ -47,16 +47,16 @@
       {{ end }}
       {{ if $isLatest }}
       <span class="tag is-medium is-success">Latest</span>
-      {{ else }}
+      {{ else if .GetPage $latestUrl}}
       <a class="tag is-medium is-warning" href="{{ $latestUrl }}">
         Go to the latest {{ $vMajor }}.x version
       </a>
       {{ end }}
-      {{ if eq $vMajor "1" }}
+      {{ if and (eq $vMajor "1") (.GetPage $latestUrlV2) }}
       <a class="tag is-medium" href="{{ $latestUrlV2 }}">
         Go to the latest 2.x version
       </a>
-      {{ else if eq $vMajor "2" }}
+      {{ else if and (eq $vMajor "2") (.GetPage $latestUrlV1) }}
       <a class="tag is-medium" href="{{ $latestUrlV1 }}">
         Go to the latest 1.x version
       </a>

--- a/themes/jaeger-docs/layouts/partials/docs/panel.html
+++ b/themes/jaeger-docs/layouts/partials/docs/panel.html
@@ -21,7 +21,7 @@
       {{ if and (eq $docVersion $majorMinorVersion) (not .Params.hasParent) }}
         {{ $isCurrentPage := eq $url .RelPermalink }}
         <div class="nav-link">
-          <a href="{{ .Permalink }}"{{ if $isCurrentPage }} class="is-active"{{ end }}>
+          <a href="{{ .RelPermalink }}"{{ if $isCurrentPage }} class="is-active"{{ end }}>
             {{ if .Params.navtitle }}{{ .Params.navtitle }}{{ else }}{{ .Title }}{{ end }}
           </a>
 

--- a/themes/jaeger-docs/layouts/partials/footer.html
+++ b/themes/jaeger-docs/layouts/partials/footer.html
@@ -46,7 +46,7 @@
         <ul>
             <li><a href="/get-in-touch/#via-chat">Via chat</a></li>
             <li><a href="/get-in-touch/#project-video-meetings">Project video meetings</a></li>
-            <li><a href="/get-in-touch/#report-issues-on-github">Report issues on GitHub</a></li>
+            <li><a href="/get-in-touch/#open-issue-or-discussion-on-github">Report issues on GitHub</a></li>
             <li><a href="/report-security-issue">Report a security issue</a></li>
         </ul>
       </div>

--- a/themes/jaeger-docs/layouts/partials/javascript.html
+++ b/themes/jaeger-docs/layouts/partials/javascript.html
@@ -7,7 +7,6 @@
 <script src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}"></script>
 {{ end }}
 
-{{/*
 {{ if $isDocsPage }}
     {{ $jsFiles := (slice "lunr-2.3.6.min.js") }}
     {{ range $jsFiles }}
@@ -15,4 +14,3 @@
     <script src="{{ $js.Permalink }}" integrity="{{ $js.Data.Integrity }}"></script>
     {{ end }}
 {{ end }}
-*/ -}}

--- a/themes/jaeger-docs/layouts/partials/javascript.html
+++ b/themes/jaeger-docs/layouts/partials/javascript.html
@@ -4,9 +4,10 @@
 {{ $jsFiles := (slice "jquery-ui-1.9.1.custom.min.js" "anchor.min.js" "tocbot.min.js" "app.js") }}
 {{ range $jsFiles }}
 {{ $js := resources.Get (printf "js/%s" .) | minify | fingerprint }}
-<script src="{{ $js.Permalink }}" integrity="{{ $js.Data.Integrity }}"></script>
+<script src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}"></script>
 {{ end }}
 
+{{/*
 {{ if $isDocsPage }}
     {{ $jsFiles := (slice "lunr-2.3.6.min.js") }}
     {{ range $jsFiles }}
@@ -14,3 +15,4 @@
     <script src="{{ $js.Permalink }}" integrity="{{ $js.Data.Integrity }}"></script>
     {{ end }}
 {{ end }}
+*/ -}}

--- a/themes/jaeger-docs/layouts/partials/meta.html
+++ b/themes/jaeger-docs/layouts/partials/meta.html
@@ -4,7 +4,7 @@
 {{ $isDoc := eq .Section "docs" }}
 {{ $type := cond $isHome "website" "article" }}
 {{ $twitterHandle := site.Params.twitterHandle }}
-{{ $imageUrl := printf "%s/%s" site.BaseURL site.Params.openGraphImage }}
+{{ $imageUrl := printf "%s%s" site.BaseURL site.Params.openGraphImage }}
 <meta charset="utf-8" />
 <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
 {{ with $description }}
@@ -14,7 +14,7 @@
 
 <!-- OpenGraph metadata -->
 <meta property="og:title" content="{{ $title }}" />
-<meta property="og:url" content="{{ .Permalink }}" />
+<meta property="og:url" content="{{ .Permalink }}" data-proofer-ignore>
 {{ if $isDoc }}
 <meta property="og:type" content="documentation" />
 {{ $path := "" }}
@@ -31,7 +31,7 @@
 {{ end }}
 <link rel="canonical" href="{{ $url }}" />
 {{ else }}
-<link rel="canonical" href="{{ .Permalink }}" />
+<link rel="canonical" href="{{ .Permalink }}" data-proofer-ignore>
 {{ end }}
 <meta property="og:locale" content="en_US" />
 {{ if not $isHome }}
@@ -41,7 +41,7 @@
 <meta property="og:description" content="{{ . }}" />
 {{ end }}
 <meta name="og:type" content="{{ $type }}" />
-<meta name="og:image" content="{{ $imageUrl }}" />
+<meta name="og:image" content="{{ $imageUrl }}" data-proofer-ignore>
 <meta name="og:image:alt" content="Jaeger tracing project logo" />
 <meta name="og:image:type" content="image/png" />
 <meta name="og:image:width" content="1801" />


### PR DESCRIPTION
- Contributes to #889
  - Resolves invalid links of the form `https://www.jaegertracing.io/docs/2.6/(cli|operator)/`
- Fixes `themes/jaeger-docs/layouts/partials/docs/header.html` so that it doesn't create invalid cross-version links
- Drops the now deprecated [canonifyURLs](https://gohugo.io/content-management/urls/#canonical-urls) Hugo config option, since it unnecessarily creates external links to intra-site targets, that should be encoded as simple paths
- Fixes other misc links and hash targets
- Adjusts some layouts so that local paths are used for intra-site links. When a full URL is required, we've added `data-proofer-ignore` so that the link checker doesn't need to be bothered with it.