### PR TITLE
Fix link into Apache archive

### DIFF
--- a/.htmltest.external.yml
+++ b/.htmltest.external.yml
@@ -17,4 +17,3 @@ IgnoreURLs:
   # Temporary: invalid URLs for which replacements need to be found
   # Temporary: as we work on https://github.com/jaegertracing/documentation/issues/889
   - ^https://github.com/jaegertracing/jaeger/(blob|tree)/(v2|main/(internal|model|pkg))
-  - ^https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory

--- a/content/docs/1.16/operator.md
+++ b/content/docs/1.16/operator.md
@@ -510,7 +510,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However, the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.17/operator.md
+++ b/content/docs/1.17/operator.md
@@ -632,7 +632,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.18/operator.md
+++ b/content/docs/1.18/operator.md
@@ -648,7 +648,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.19/operator.md
+++ b/content/docs/1.19/operator.md
@@ -686,7 +686,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.20/operator.md
+++ b/content/docs/1.20/operator.md
@@ -686,7 +686,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.21/operator.md
+++ b/content/docs/1.21/operator.md
@@ -686,7 +686,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.22/operator.md
+++ b/content/docs/1.22/operator.md
@@ -686,7 +686,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.23/operator.md
+++ b/content/docs/1.23/operator.md
@@ -686,7 +686,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.24/operator.md
+++ b/content/docs/1.24/operator.md
@@ -686,7 +686,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.25/operator.md
+++ b/content/docs/1.25/operator.md
@@ -728,7 +728,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.26/operator.md
+++ b/content/docs/1.26/operator.md
@@ -728,7 +728,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.27/operator.md
+++ b/content/docs/1.27/operator.md
@@ -728,7 +728,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.28/operator.md
+++ b/content/docs/1.28/operator.md
@@ -728,7 +728,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.29/operator.md
+++ b/content/docs/1.29/operator.md
@@ -708,7 +708,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.30/operator.md
+++ b/content/docs/1.30/operator.md
@@ -708,7 +708,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.31/operator.md
+++ b/content/docs/1.31/operator.md
@@ -716,7 +716,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.32/operator.md
+++ b/content/docs/1.32/operator.md
@@ -716,7 +716,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.33/operator.md
+++ b/content/docs/1.33/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.34/operator.md
+++ b/content/docs/1.34/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.35/operator.md
+++ b/content/docs/1.35/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.36/operator.md
+++ b/content/docs/1.36/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.37/operator.md
+++ b/content/docs/1.37/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.38/operator.md
+++ b/content/docs/1.38/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.39/operator.md
+++ b/content/docs/1.39/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.40/operator.md
+++ b/content/docs/1.40/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.41/operator.md
+++ b/content/docs/1.41/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.42/operator.md
+++ b/content/docs/1.42/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.43/operator.md
+++ b/content/docs/1.43/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.44/operator.md
+++ b/content/docs/1.44/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.45/operator.md
+++ b/content/docs/1.45/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.46/operator.md
+++ b/content/docs/1.46/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.47/operator.md
+++ b/content/docs/1.47/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.48/operator.md
+++ b/content/docs/1.48/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.49/operator.md
+++ b/content/docs/1.49/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.50/operator.md
+++ b/content/docs/1.50/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.51/operator.md
+++ b/content/docs/1.51/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.52/operator.md
+++ b/content/docs/1.52/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.53/operator.md
+++ b/content/docs/1.53/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.54/operator.md
+++ b/content/docs/1.54/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.55/operator.md
+++ b/content/docs/1.55/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.56/operator.md
+++ b/content/docs/1.56/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.57/operator.md
+++ b/content/docs/1.57/operator.md
@@ -761,7 +761,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.58/operator.md
+++ b/content/docs/1.58/operator.md
@@ -725,7 +725,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.59/operator.md
+++ b/content/docs/1.59/operator.md
@@ -725,7 +725,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.60/operator.md
+++ b/content/docs/1.60/operator.md
@@ -725,7 +725,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.61/operator.md
+++ b/content/docs/1.61/operator.md
@@ -725,7 +725,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.62/operator.md
+++ b/content/docs/1.62/operator.md
@@ -725,7 +725,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.63/operator.md
+++ b/content/docs/1.63/operator.md
@@ -725,7 +725,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.64/operator.md
+++ b/content/docs/1.64/operator.md
@@ -741,7 +741,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.65/operator.md
+++ b/content/docs/1.65/operator.md
@@ -741,7 +741,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.66/operator.md
+++ b/content/docs/1.66/operator.md
@@ -741,7 +741,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.67/operator.md
+++ b/content/docs/1.67/operator.md
@@ -741,7 +741,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.68/operator.md
+++ b/content/docs/1.68/operator.md
@@ -741,7 +741,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/1.69/operator.md
+++ b/content/docs/1.69/operator.md
@@ -741,7 +741,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/content/docs/next-release/operator.md
+++ b/content/docs/next-release/operator.md
@@ -741,7 +741,7 @@ storage:
 The connection configuration to storage is derived from storage options.
 
 {{< warning >}}
-Make sure to assign enough memory resources. Spark [documentation](https://spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
+Make sure to assign enough memory resources. Spark [documentation](https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory) recommends at least `8Gi` of memory.
 However the job is able to starts with at least `2Gi` of memory. The right memory settings
 will depend on the amount of data being processed.
 Note that the job loads all data for the current day into memory.

--- a/data/refcache.json
+++ b/data/refcache.json
@@ -23,6 +23,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-05-31T11:48:55.951926-04:00"
   },
+  "https://archive.apache.org/dist/spark/docs/2.4.4/hardware-provisioning.html#memory": {
+    "StatusCode": 206,
+    "LastSeen": "2025-05-31T12:36:31.041616-04:00"
+  },
   "https://artifacthub.io/packages/helm/bitnami/cassandra": {
     "StatusCode": 200,
     "LastSeen": "2025-05-31T11:49:42.482668-04:00"


### PR DESCRIPTION
- Contributes to #889
- Adjusts link to `spark.apache.org/docs/2.4.4/hardware-provisioning.html#memory`; the page has been moved to an archive server