### PR TITLE
Hugo.yaml cleanup: drop unused navbar param

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,10 +1,12 @@
+# cSpell:ignore basetheme jaegertracing pygments githubrepo twitterhandle mediumhandle opengraphimage
+
 baseURL: https://www.jaegertracing.io
 title: "Jaeger: open source, distributed tracing platform"
 languageCode: en
 pygmentsCodeFences: true
 pygmentsUseClasses: true
-disableKinds: ["taxonomy"]
-theme: ["basetheme", "jaeger-docs"]
+disableKinds: [taxonomy]
+theme: [basetheme, jaeger-docs]
 
 mediaTypes:
   text/netlify:
@@ -16,10 +18,10 @@ outputFormats:
     baseName: _redirects
 
 outputs:
-  home: ["HTML", "JSON", "REDIRECTS"]
+  home: [HTML, JSON, REDIRECTS]
 
 params:
-  tagline: "Monitor and troubleshoot workflows in complex distributed systems"
+  tagline: Monitor and troubleshoot workflows in complex distributed systems
   githubrepo: jaegertracing/jaeger
   twitterhandle: JaegerTracing
   mediumhandle: jaegertracing
@@ -32,9 +34,3 @@ params:
   latestV2: "2.6"
   binariesLatestV2: "2.6.0"
   versionsV2: ["2.6","2.5","2.4","2.3","2.2","2.1","2.0"]
-
-  navbar:
-    links:
-      - title: "Docs"
-        url: "/docs"
-


### PR DESCRIPTION
- Cleans up `hugo.yaml`.
- Mainly drops unused params config `navbar`

No change to the generated site files (neither for a dev nor a production build):

```console
$ make netlify-production-build
hugo --minify
...
Total in 13219 ms
$ (cd public && git diff)             
$ 
```