### PR TITLE
Update to Hugo v0.147.6, adjust theme css integrity

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -18,7 +18,7 @@ jobs:
     - name: ✨ Setup Hugo
       env:
         # should match one from netlify.toml
-        HUGO_VERSION: 0.143.1
+        HUGO_VERSION: 0.147.6
       run: |
         mkdir ~/hugo
         cd ~/hugo

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ command = "make netlify-production-build"
 
 [build.environment]
 # should match one from .github/workflows/ci-test.yml
-HUGO_VERSION = "0.143.1"
+HUGO_VERSION = "0.147.6"
 
 [context.deploy-preview]
 command = "make netlify-deploy-preview"

--- a/themes/jaeger-docs/layouts/partials/css.html
+++ b/themes/jaeger-docs/layouts/partials/css.html
@@ -1,4 +1,4 @@
-{{ $inServerMode := hugo.IsServer }}
+{{ $inProduction := hugo.IsProduction -}}
 {{ $sass         := "sass/style.sass" }}
 {{ $target       := "css/style.css" }}
 {{ $includePaths := (slice "node_modules") }}
@@ -9,9 +9,9 @@
 <link rel="stylesheet" href="/css/tocbot.css">
 {{ end }}
 <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-{{ $cssOpts := cond ($inServerMode) $cssDevOpts $cssProdOpts }}
+{{ $cssOpts := cond $inProduction $cssProdOpts $cssDevOpts -}}
 {{ $css := resources.Get "sass/style.sass" | toCSS $cssOpts }}
-{{ if $inServerMode }}
+{{ if not $inProduction -}}
 <link rel="stylesheet" media="screen" href="{{ $css.RelPermalink }}">
 {{ else }}
 {{ $prodCss := $css | fingerprint }}


### PR DESCRIPTION
- Prep for #746
- Updates Hugo to v0.147.6 (in both files)
- Adjusts `themes/jaeger-docs/layouts/partials/css.html` so that we fingerprint the main `styles.css` file only in production