### PR TITLE
Fix project title etc in Hugo config

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,0 +1,3 @@
+---
+title: 'Jaeger: open source, distributed tracing platform'
+---

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,21 +1,34 @@
 # cSpell:ignore basetheme jaegertracing pygments githubrepo twitterhandle mediumhandle opengraphimage
 
 baseURL: https://www.jaegertracing.io
-title: "Jaeger: open source, distributed tracing platform"
-languageCode: en
-pygmentsCodeFences: true
-pygmentsUseClasses: true
+title: Jaeger
 disableKinds: [taxonomy]
 theme: [basetheme, jaeger-docs]
+pygmentsCodeFences: true
+pygmentsUseClasses: true
+
+#
+# Language settings
+#
+
+defaultContentLanguage: en
+defaultContentLanguageInSubdir: false
+
+languages:
+  en:
+    languageName: English
+    # languageCode: en-US
+    params:
+      description: Open source, distributed tracing platform
 
 mediaTypes:
   text/netlify:
-    delimiter: ""
 
 outputFormats:
   REDIRECTS:
     mediaType: text/netlify
     baseName: _redirects
+    notAlternative: true
 
 outputs:
   home: [HTML, JSON, REDIRECTS]

--- a/themes/jaeger-docs/layouts/_default/baseof.html
+++ b/themes/jaeger-docs/layouts/_default/baseof.html
@@ -3,7 +3,7 @@
 <!DOCTYPE html>
 <html class="has-navbar-fixed-top" lang="{{ site.LanguageCode }}" prefix="og: http://ogp.me/ns#">
   <head>
-    <title>{{ block "title" . }}{{ site.Title }}{{ end }}</title>
+    <title>{{ block "title" . }}{{ .Title }}{{ end }}</title>
     {{ partial "meta.html" . }}
     <link rel="shortcut icon" href="/favicon.ico">
     {{ partial "css.html" . }}

--- a/themes/jaeger-docs/layouts/index.html
+++ b/themes/jaeger-docs/layouts/index.html
@@ -13,7 +13,7 @@
     {{ $channel = $rss.channel }}
     {{ warnf "Loaded Medium feed for: %v" $channel.title }}
   {{ end }}
-  
+
 {{ $defaultImgLink := "/img/jaeger-icon-color.png" }}
 {{ warnf "Loaded RSS feed for: %v" $rss.channel.title }}
 {{ $posts := first 20 $rss.channel.item }}
@@ -37,7 +37,7 @@
   {{ warnf "Post: %v" $v.title }}
 {{ end }}
 
-{{ partial "home/hero.html" (dict "posts" $posts "title" site.Title "tagline" site.Params.tagline "latestVersion" site.Params.latestV2) }}
+{{ partial "home/hero.html" (dict "posts" $posts "title" .Title "tagline" site.Params.tagline "latestVersion" site.Params.latestV2) }}
 {{ partial "home/why.html" . }}
 {{ partial "home/features.html" . }}
 {{ partial "home/articles.html" (dict "posts" $posts "imgLinks" $imgLinks) }}

--- a/themes/jaeger-docs/layouts/partials/meta.html
+++ b/themes/jaeger-docs/layouts/partials/meta.html
@@ -1,5 +1,4 @@
 {{ $isHome := eq .Kind "home" }}
-{{ $title := cond $isHome site.Title .Title }}
 {{ $description := cond $isHome site.Params.tagline .Params.description }}
 {{ $isDoc := eq .Section "docs" }}
 {{ $type := cond $isHome "website" "article" }}
@@ -13,7 +12,7 @@
 {{ hugo.Generator }}
 
 <!-- OpenGraph metadata -->
-<meta property="og:title" content="{{ $title }}" />
+<meta property="og:title" content="{{ .Title }}" />
 <meta property="og:url" content="{{ .Permalink }}" data-proofer-ignore>
 {{ if $isDoc }}
 <meta property="og:type" content="documentation" />


### PR DESCRIPTION
- Fixes site title so that it matches how it is used by Docsy
- Contributes to #746
- Makes other adjustments to `hugo.yaml` in prep for migration to Docsy
- Adjusts a few layouts so that **generated site files are** essentially **the same**, except for `og:site` (now only Jaeger), as demonstrated by this site diff:
  ```console
  $ (cd public && git diff -bw --ignore-blank-lines) | grep ^diff | wc -l
      1548
  $ (cd public && git diff -bw --ignore-blank-lines -I "og:site" -I "const version = (\"\"| null )" -- ':(exclude)*.xml' ') | wc -l
       0
  ```