### PR TITLE
Navbar partial whitespace cleanup

### DIFF
--- a/themes/jaeger-docs/layouts/partials/navbar.html
+++ b/themes/jaeger-docs/layouts/partials/navbar.html
@@ -1,35 +1,33 @@
-{{ $menuPages     := site.Menus.docs }}
-{{ $githubRepo    := site.Params.githubrepo }}
-{{ $twitterHandle := site.Params.twitterhandle }}
-{{ $versionsV1      := site.Params.versions }}
-{{ $versionsV2      := site.Params.versionsV2 }}
-{{ $versions      := append $versionsV1 $versionsV2 }}
-{{ $latestV1      := site.Params.latest }}
-{{ $latestV2      := site.Params.latestV2 }}
-{{ $docs          := where site.Pages "Section" "docs" }}
-{{ $isDocsPage    := eq .Section "docs" }}
-{{ $isPreview     := eq (getenv "HUGO_PREVIEW") "true" }}
-{{ $path := "" }}
-{{ with .File }}
-  {{ $path = .Path }}
-{{ else }}
-  {{ $path = .Path }}
-{{ end }}
-{{ $majorMinorVersion := index (split $path "/") 1 }}
-{{ $vMajor        := index (split $majorMinorVersion ".") 0 }}
-{{ if eq $majorMinorVersion "next-release" }}
-  {{ $vMajor = "1" }}
-{{ else if eq $majorMinorVersion "next-release-v2" }}
-  {{ $vMajor = "2" }}
-{{ end }}
-{{ $isLatest := or (eq $majorMinorVersion $latestV1) (eq $majorMinorVersion $latestV2) }}
+{{ $menuPages     := site.Menus.docs -}}
+{{ $githubRepo    := site.Params.githubrepo -}}
+{{ $twitterHandle := site.Params.twitterhandle -}}
+{{ $versionsV1      := site.Params.versions -}}
+{{ $versionsV2      := site.Params.versionsV2 -}}
+{{ $versions      := append $versionsV1 $versionsV2 -}}
+{{ $latestV1      := site.Params.latest -}}
+{{ $latestV2      := site.Params.latestV2 -}}
+{{ $docs          := where site.Pages "Section" "docs" -}}
+{{ $isDocsPage    := eq .Section "docs" -}}
+{{ $isPreview     := eq (getenv "HUGO_PREVIEW") "true" -}}
+{{ $path := "" -}}
+{{ with .File -}}
+  {{ $path = .Path -}}
+{{ else -}}
+  {{ $path = .Path -}}
+{{ end -}}
+{{ $majorMinorVersion := index (split $path "/") 1 -}}
+{{ $vMajor        := index (split $majorMinorVersion ".") 0 -}}
+{{ if eq $majorMinorVersion "next-release" -}}
+  {{ $vMajor = "1" -}}
+{{ else if eq $majorMinorVersion "next-release-v2" -}}
+  {{ $vMajor = "2" -}}
+{{ end -}}
+{{ $isLatest := or (eq $majorMinorVersion $latestV1) (eq $majorMinorVersion $latestV2) -}}
 <nav class="navbar is-fixed-top">
   <div class="container is-fluid">
     <div class="navbar-brand">
 
-      <a class="navbar-item" href="/">
-        <img src="/img/jaeger-logo.png" alt="Jaeger project logo">
-      </a>
+      <a class="navbar-item" href="/"><img src="/img/jaeger-logo.png" alt="Jaeger project logo"></a>
 
       <div class="navbar-burger burger" data-target="topNav">
         <span></span>
@@ -40,7 +38,7 @@
 
     <div id="topNav" class="navbar-menu">
       <div class="navbar-end">
-        {{ if and $isDocsPage $isLatest }}
+        {{ if and $isDocsPage $isLatest -}}
         <div class="navbar-item">
           <div class="dropdown" id="search-dropdown">
             <div class="dropdown-trigger">
@@ -60,67 +58,56 @@
             </div>
           </div>
         </div>
-        {{ end }}
+        {{ end -}}
 
         <div class="navbar-item has-dropdown is-hoverable" id="sandwich-popup-menu">
-          <a class="navbar-link">
-            Docs
-          </a>
+          <a class="navbar-link">Docs</a>
           <div class="navbar-dropdown">
-            {{ range $docs }}
-              {{ $docPath := "" }}
-              {{ with .File }}
-                {{ $docPath = .Path }}
-              {{ else }}
-                {{ $docPath = .Path }}
-              {{ end }}
-              {{ $docVersion := index (split $docPath "/") 1 }}
+            {{ range $docs -}}
+              {{ $docPath := "" -}}
+              {{ with .File -}}
+                {{ $docPath = .Path -}}
+              {{ else -}}
+                {{ $docPath = .Path -}}
+              {{ end -}}
+              {{ $docVersion := index (split $docPath "/") 1 -}}
               <!-- When generating Docs menu for home page, use the latest version, -->
               <!-- when generating menu for pages inside docs/, use same version as the doc -->
-              {{ $matchVersion := cond ($isDocsPage) $majorMinorVersion $latestV2 }}
-              {{ if and (eq $docVersion $matchVersion) (not .Params.hasparent) }}
+              {{ $matchVersion := cond ($isDocsPage) $majorMinorVersion $latestV2 -}}
+              {{ if and (eq $docVersion $matchVersion) (not .Params.hasparent) -}}
                 <a class="navbar-item" href="{{ .RelPermalink }}">
-                  {{ .Title }}
+                  {{- .Title }}
                 </a>
-
-                {{ with .Params.children }}
-                  {{ range . }}
-                    {{ $url := cond $isDocsPage (printf "/docs/%s/%s" $majorMinorVersion .url) (printf "/docs/%s/%s" $latestV2 .url) }}
+                {{ with .Params.children -}}
+                  {{ range . -}}
+                    {{ $url := cond $isDocsPage (printf "/docs/%s/%s" $majorMinorVersion .url) (printf "/docs/%s/%s" $latestV2 .url) -}}
                     <a class="navbar-item is-small is-hidden-desktop" href="{{ $url }}">
-                      &cir; {{ if .navtitle }}{{ .navtitle }}{{ else }}{{ .title }}{{ end }}
+                      &cir; {{ .navtitle | default .title }}
                     </a>
-                  {{ end }}
-                {{ end }}
-              {{ end }}
-            {{ end }}
+                  {{ end -}}
+                {{ end -}}
+              {{ end -}}
+            {{ end -}}
           </div>
         </div>
-
-        {{ if $isDocsPage }}
+        {{ if $isDocsPage -}}
         <div class="navbar-item has-dropdown is-hoverable">
-          <a class="navbar-link">
-            Versions
-          </a>
+          <a class="navbar-link">Versions</a>
           <div class="navbar-dropdown">
-            {{ range $versions }}
-            {{ $version := . }}
-            {{ $isLatest := or (eq $version $latestV1) (eq $version $latestV2) }}
+            {{ range $versions -}}
+            {{ $version := . -}}
+            {{ $isLatest := or (eq $version $latestV1) (eq $version $latestV2) -}}
             <a class="navbar-item" href="/docs/{{ $version }}">
-              {{ $version }}{{ if $isLatest }}&nbsp;&nbsp;(<strong>latest</strong>){{ end }}
+              {{- $version }}{{ if $isLatest }}&nbsp;&nbsp;(<strong>latest</strong>){{ end }}
             </a>
-            {{ end }}
-            {{ if $isPreview }}
-              <a class="navbar-item" href="/docs/next-release-v2">
-                next 2.x&nbsp;release&nbsp;(preview)
-              </a>
-              <a class="navbar-item" href="/docs/next-release">
-                next 1.x&nbsp;release&nbsp;(preview)
-              </a>
-            {{ end }}
+            {{ end -}}
+            {{ if $isPreview -}}
+              <a class="navbar-item" href="/docs/next-release-v2">next 2.x&nbsp;release&nbsp;(preview)</a>
+              <a class="navbar-item" href="/docs/next-release">next 1.x&nbsp;release&nbsp;(preview)</a>
+            {{ end -}}
           </div>
         </div>
-        {{ end }}
-
+        {{ end -}}
         <a class="navbar-item" href="/download">
           Download
         </a>
@@ -133,68 +120,56 @@
           <a class="navbar-link">
             Project
           </a>
-
           <div class="navbar-dropdown is-right">
             <a class="navbar-item" href="/get-involved">
                 Get involved
             </a>
-
             <a class="navbar-item" href="/get-in-touch">
               Get in touch
             </a>
-
             <a class="navbar-item" href="/mentorship">
               Mentorships
             </a>
-
             <a class="navbar-item" href="/mentorship-for-mentees">
               Mentorships - For Mentees
             </a>
-
             <a class="navbar-item" href="/mentorship-for-mentors">
               Mentorships - For Mentors
             </a>
-
             <a class="navbar-item" href="/news">
               News
             </a>
-
             <a class="navbar-item" href="/roadmap">
               Roadmap
             </a>
-
             <a class="navbar-item" href="https://github.com/cncf/artwork/tree/master/projects/jaeger">
               Branding
             </a>
-
             <a class="navbar-item" href="/report-security-issue">
               Report security issue
             </a>
-
             <a class="navbar-item" href="https://github.com/jaegertracing/jaeger">
               Main GitHub repo
             </a>
-
             <a class="navbar-item" href="https://github.com/jaegertracing/documentation">
               Docs GitHub repo
             </a>
           </div>
         </div>
-
-        {{ with $githubRepo }}
+        {{ with $githubRepo -}}
         <a class="navbar-item" href="https://github.com/{{ . }}" target="_blank">
           <span class="icon">
             <i class="fab fa-github" style="color: #333;"></i>
           </span>
         </a>
-        {{ end }}
-        {{ with $twitterHandle }}
+        {{ end -}}
+        {{ with $twitterHandle -}}
         <a class="navbar-item" href="https://twitter.com/{{ . }}" target="_blank">
           <span class="icon" style="color: #55acee;">
             <i class="fab fa-twitter"></i>
           </span>
         </a>
-        {{ end }}
+        {{ end -}}
       </div>
     </div>
   </div>


### PR DESCRIPTION
- Contributes to #746
- There are **no change to the generated production (i.e., minified) site files**
- Trims superfluous whitespace from `themes/jaeger-docs/layouts/partials/navbar.html`. This partial iterates over all docs, and for each iteration adds whitespace to the navbar. This creates files with _a lot_ of unnecessary blank lines, which makes it all the more challenging to diff the site-file changes necessary in preparation for the Docsy migration.
- In most cases, a Hugo template code statement ending in `}}` is replaced by `-}}`; a directive that will trim the excess whitespace following the directive when the page is generated.