### PR TITLE
Fix link to site root SDK migration in Troublshooting, and more

### DIFF
--- a/content/docs/v1/1.64/troubleshooting.md
+++ b/content/docs/v1/1.64/troubleshooting.md
@@ -35,7 +35,7 @@ For example, when using the Jaeger SDK for Java, the strategy is usually printed
 
 ### Remote Sampling
 
-The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](../../../sdk-migration/#migration-to-opentelemetry) for details).
+The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](/sdk-migration/#migration-to-opentelemetry) for details).
 
 If you suspect the remote sampling is not working correctly, try these steps:
 

--- a/content/docs/v1/1.65/troubleshooting.md
+++ b/content/docs/v1/1.65/troubleshooting.md
@@ -35,7 +35,7 @@ For example, when using the Jaeger SDK for Java, the strategy is usually printed
 
 ### Remote Sampling
 
-The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](../../../sdk-migration/#migration-to-opentelemetry) for details).
+The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](/sdk-migration/#migration-to-opentelemetry) for details).
 
 If you suspect the remote sampling is not working correctly, try these steps:
 

--- a/content/docs/v1/1.66/troubleshooting.md
+++ b/content/docs/v1/1.66/troubleshooting.md
@@ -35,7 +35,7 @@ For example, when using the Jaeger SDK for Java, the strategy is usually printed
 
 ### Remote Sampling
 
-The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](../../../sdk-migration/#migration-to-opentelemetry) for details).
+The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](/sdk-migration/#migration-to-opentelemetry) for details).
 
 If you suspect the remote sampling is not working correctly, try these steps:
 

--- a/content/docs/v1/1.67/troubleshooting.md
+++ b/content/docs/v1/1.67/troubleshooting.md
@@ -35,7 +35,7 @@ For example, when using the Jaeger SDK for Java, the strategy is usually printed
 
 ### Remote Sampling
 
-The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](../../../sdk-migration/#migration-to-opentelemetry) for details).
+The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](/sdk-migration/#migration-to-opentelemetry) for details).
 
 If you suspect the remote sampling is not working correctly, try these steps:
 

--- a/content/docs/v1/1.68/troubleshooting.md
+++ b/content/docs/v1/1.68/troubleshooting.md
@@ -35,7 +35,7 @@ For example, when using the Jaeger SDK for Java, the strategy is usually printed
 
 ### Remote Sampling
 
-The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](../../../sdk-migration/#migration-to-opentelemetry) for details).
+The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](/sdk-migration/#migration-to-opentelemetry) for details).
 
 If you suspect the remote sampling is not working correctly, try these steps:
 

--- a/content/docs/v1/1.69/troubleshooting.md
+++ b/content/docs/v1/1.69/troubleshooting.md
@@ -35,7 +35,7 @@ For example, when using the Jaeger SDK for Java, the strategy is usually printed
 
 ### Remote Sampling
 
-The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](../../../sdk-migration/#migration-to-opentelemetry) for details).
+The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](/sdk-migration/#migration-to-opentelemetry) for details).
 
 If you suspect the remote sampling is not working correctly, try these steps:
 

--- a/content/docs/v1/_dev/troubleshooting.md
+++ b/content/docs/v1/_dev/troubleshooting.md
@@ -35,7 +35,7 @@ For example, when using the Jaeger SDK for Java, the strategy is usually printed
 
 ### Remote Sampling
 
-The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](../../../sdk-migration/#migration-to-opentelemetry) for details).
+The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](/sdk-migration/#migration-to-opentelemetry) for details).
 
 If you suspect the remote sampling is not working correctly, try these steps:
 

--- a/content/docs/v2/2.0/_index.md
+++ b/content/docs/v2/2.0/_index.md
@@ -7,8 +7,6 @@ children:
   url: getting-started
 - title: Features
   url: features
-- title: Migration
-  url: migration
 ---
 
 Welcome to Jaeger's documentation! Below, you'll find information for beginners and experienced Jaeger users. If you cannot find what you are looking for, or have an issue not covered here, we'd love to [hear from you](/get-in-touch/).

--- a/content/docs/v2/2.0/troubleshooting.md
+++ b/content/docs/v2/2.0/troubleshooting.md
@@ -32,7 +32,7 @@ The logging reporter follows the sampling decision made by the sampler, meaning 
 
 ### Remote Sampling
 
-The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](../../../sdk-migration/#migration-to-opentelemetry) for details).
+The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](/sdk-migration/#migration-to-opentelemetry) for details).
 
 If you suspect the remote sampling is not working correctly, try these steps:
 

--- a/content/docs/v2/2.1/troubleshooting.md
+++ b/content/docs/v2/2.1/troubleshooting.md
@@ -22,7 +22,7 @@ OpenTelemetry SDKs can be configured with an exporter that prints recorded spans
 
 ### Remote Sampling
 
-The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](../../../sdk-migration/#migration-to-opentelemetry) for details).
+The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](/sdk-migration/#migration-to-opentelemetry) for details).
 
 If you suspect the remote sampling is not working correctly, try these steps:
 

--- a/content/docs/v2/2.2/troubleshooting.md
+++ b/content/docs/v2/2.2/troubleshooting.md
@@ -22,7 +22,7 @@ OpenTelemetry SDKs can be configured with an exporter that prints recorded spans
 
 ### Remote Sampling
 
-The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](../../../sdk-migration/#migration-to-opentelemetry) for details).
+The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](/sdk-migration/#migration-to-opentelemetry) for details).
 
 If you suspect the remote sampling is not working correctly, try these steps:
 

--- a/content/docs/v2/2.3/troubleshooting.md
+++ b/content/docs/v2/2.3/troubleshooting.md
@@ -22,7 +22,7 @@ OpenTelemetry SDKs can be configured with an exporter that prints recorded spans
 
 ### Remote Sampling
 
-The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](../../../sdk-migration/#migration-to-opentelemetry) for details).
+The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](/sdk-migration/#migration-to-opentelemetry) for details).
 
 If you suspect the remote sampling is not working correctly, try these steps:
 

--- a/content/docs/v2/2.4/troubleshooting.md
+++ b/content/docs/v2/2.4/troubleshooting.md
@@ -22,7 +22,7 @@ OpenTelemetry SDKs can be configured with an exporter that prints recorded spans
 
 ### Remote Sampling
 
-The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](../../../sdk-migration/#migration-to-opentelemetry) for details).
+The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](/sdk-migration/#migration-to-opentelemetry) for details).
 
 If you suspect the remote sampling is not working correctly, try these steps:
 

--- a/content/docs/v2/2.5/troubleshooting.md
+++ b/content/docs/v2/2.5/troubleshooting.md
@@ -22,7 +22,7 @@ OpenTelemetry SDKs can be configured with an exporter that prints recorded spans
 
 ### Remote Sampling
 
-The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](../../../sdk-migration/#migration-to-opentelemetry) for details).
+The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](/sdk-migration/#migration-to-opentelemetry) for details).
 
 If you suspect the remote sampling is not working correctly, try these steps:
 

--- a/content/docs/v2/2.6/troubleshooting.md
+++ b/content/docs/v2/2.6/troubleshooting.md
@@ -22,7 +22,7 @@ OpenTelemetry SDKs can be configured with an exporter that prints recorded spans
 
 ### Remote Sampling
 
-The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](../../../sdk-migration/#migration-to-opentelemetry) for details).
+The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](/sdk-migration/#migration-to-opentelemetry) for details).
 
 If you suspect the remote sampling is not working correctly, try these steps:
 

--- a/content/docs/v2/_dev/troubleshooting.md
+++ b/content/docs/v2/_dev/troubleshooting.md
@@ -22,7 +22,7 @@ OpenTelemetry SDKs can be configured with an exporter that prints recorded spans
 
 ### Remote Sampling
 
-The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](../../../sdk-migration/#migration-to-opentelemetry) for details).
+The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](/sdk-migration/#migration-to-opentelemetry) for details).
 
 If you suspect the remote sampling is not working correctly, try these steps:
 

--- a/scripts/docsy/README.md
+++ b/scripts/docsy/README.md
@@ -29,18 +29,22 @@ Root `_index.md` uses relative links starting with `./`:
   [Memory](./memory/) → [Memory](./storage/memory/)
   ```
 - When target became _index.md: Link preserved
+  (tested in `scripts/reorg-docs/tests/FileMover/link_updates.test.ts`)
   ```markdown
   [Architecture](./architecture/) → [Architecture](./architecture/)
   ```
 
-#### 2. Links in Unmoved Files
+#### 2. Links in top-level non-index files not affected by reorg
 
-Files that weren't moved use single-level parent references:
+Top-level non-index files that weren't moved.
+
 - When target moved to subdirectory:
+  (tested in `scripts/reorg-docs/tests/FileMover/integration.test.ts`)
   ```markdown
-  [Memory](../memory/) → [Memory](../storage/memory/)
+  [APIs](../apis/) → [APIs](../architecture/apis/)
   ```
 - When target became _index.md: Link preserved
+  (tested in `scripts/reorg-docs/tests/FileMover/integration.test.ts`)
   ```markdown
   [Architecture](../architecture/) → [Architecture](../architecture/)
   ```
@@ -49,10 +53,11 @@ Files that weren't moved use single-level parent references:
 
 Files that were moved have different handling based on target location:
 
-a. **Same Directory Target**
+a. From an (new) _index.md, to a page that was moved into the same folder:
+
    - Uses `./` for files in the same directory:
    ```markdown
-   [Memory](../memory/) → [Memory](./memory/)
+   [Sampling](../sampling/) → [Memory](./sampling/)
    ```
 
 b. **Different Directory Target**
@@ -61,6 +66,10 @@ b. **Different Directory Target**
    [Architecture](../architecture/) → [Architecture](../../architecture/)
    [Deploy](../deployment/) → [Deploy](../../deployment/)
    ```
+c. Linked to top-level non-index file that was not moved.
+   Test: 'for non-index page to unmoved page'
+
+   > Note: Integration tests for these link transformations can be found in `scripts/reorg-docs/tests/FileMover/integration.test.ts` under the "link transformations from README examples" describe block.
 
 #### 4. Special Cases
 

--- a/scripts/reorg-docs/.gitignore
+++ b/scripts/reorg-docs/.gitignore
@@ -1,0 +1,30 @@
+# Dependencies
+node_modules/
+
+# TypeScript build output
+dist/
+*.tsbuildinfo
+
+# Test coverage
+coverage/
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/scripts/reorg-docs/README.md
+++ b/scripts/reorg-docs/README.md
@@ -1,0 +1,32 @@
+# Documentation Reorganizer
+
+A tool to reorganize Jaeger documentation files by moving parent pages to
+`_index.md` files and their children into appropriate subdirectories, so as to
+be compatible with Docsy (and Hugo).
+
+## Installation
+
+From the `scripts/reorg-docs` directory:
+
+```bash
+npm install
+```
+
+## Development
+
+### Running Tests
+
+```bash
+npm test
+# or
+npm run test:watch
+```
+
+## Usage
+
+Example:
+
+```bash
+(cd scripts/reorg-docs/ && npm run build) && \
+node ./scripts/reorg-docs/dist/cli.js content/docs/v2/2.0
+```

--- a/scripts/reorg-docs/package.json
+++ b/scripts/reorg-docs/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "reorg-docs",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "Documentation reorganization tool for Jaeger",
+  "main": "dist/cli.js",
+  "bin": {
+    "reorg-docs": "./dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "start": "node dist/cli.js"
+  },
+  "dependencies": {
+    "js-yaml": "^4.1.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.0",
+    "@types/js-yaml": "^4.0.5",
+    "@types/mdast": "^3.0.0",
+    "@types/node": "^18.15.11",
+    "jest": "^29.5.0",
+    "memfs": "^3.5.1",
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.0.3"
+  },
+  "jest": {
+    "preset": "ts-jest/presets/default-esm",
+    "testEnvironment": "node",
+    "extensionsToTreatAsEsm": [".ts"],
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.js$": "$1"
+    },
+    "transform": {
+      "^.+\\.tsx?$": [
+        "ts-jest",
+        {
+          "useESM": true
+        }
+      ]
+    }
+  }
+}

--- a/scripts/reorg-docs/src/FileMover.ts
+++ b/scripts/reorg-docs/src/FileMover.ts
@@ -1,0 +1,175 @@
+import path from 'path';
+import yaml from 'js-yaml';
+import type { FileSystem } from './types.js';
+import { LinkFixer } from './LinkFixer.js';
+import { FileWalker } from './FileWalker.js';
+
+interface FrontMatter {
+  title?: string;
+  children?: Array<{
+    title: string;
+    url: string;
+  }>;
+}
+
+export class FileMover {
+  private readonly docsDir: string;
+  private readonly fs: FileSystem;
+  private readonly linkFixer: LinkFixer;
+  private readonly walker: FileWalker;
+  private movedFiles: Map<string, string>;
+
+  /**
+   * @param docsDir - Root directory containing documentation files
+   * @param fs - File system module (fs/promises or memfs for testing)
+   */
+  constructor(docsDir: string, fs: FileSystem) {
+    this.docsDir = docsDir;
+    this.fs = fs;
+    this.linkFixer = new LinkFixer(docsDir, fs);
+    this.walker = new FileWalker(fs);
+    this.movedFiles = new Map();
+  }
+
+  /**
+   * Process all files in the docs directory
+   */
+  async processDirectory(): Promise<void> {
+    // First pass: Move all files (non-recursive since we only move from top level)
+    for await (const filePath of this.walker.walkFiles(this.docsDir, false)) {
+      await this.testAndMove(filePath);
+    }
+
+    // Second pass: Update links in all files (recursive to find moved files)
+    for await (const filePath of this.walker.walkFiles(this.docsDir, true)) {
+      await this.linkFixer.updateLinksInFile(filePath, this.movedFiles);
+    }
+  }
+
+  /**
+   * Tests if a file should be moved and moves it and its children if necessary
+   * @param filePath - Path to the file to test and potentially move
+   * @returns True if the file or any of its children were moved
+   */
+  async testAndMove(filePath: string): Promise<boolean> {
+    const initialMoveCount = this.movedFiles.size;
+    const shouldMoveResult = await this.shouldMove(filePath);
+    if (shouldMoveResult) {
+      // Get children before moving the parent file
+      const children = await this.getChildren(filePath);
+      await this.moveParentFile(filePath);
+      await this.moveChildrenFromList(filePath, children);
+    }
+    return this.movedFiles.size > initialMoveCount;
+  }
+
+  /**
+   * Determines if a file should be moved based on its front matter
+   */
+  async shouldMove(filePath: string): Promise<boolean> {
+    try {
+      // Never move _index.md files
+      if (path.basename(filePath) === '_index.md') {
+        return false;
+      }
+
+      const content = await this.fs.readFile(filePath, 'utf8');
+      const matches = content.match(/^---\n([\s\S]*?)\n---/);
+      if (!matches) return false; // No front matter
+
+      const frontMatter = yaml.load(matches[1]) as FrontMatter;
+      return Boolean(frontMatter?.children?.length);
+    } catch (error) {
+      if (error instanceof Error && 'code' in error && error.code !== 'ENOENT') {
+        throw error;
+      }
+      return false;
+    }
+  }
+
+  /**
+   * Gets the children from a file's front matter
+   */
+  private async getChildren(filePath: string): Promise<string[]> {
+    try {
+      const content = await this.fs.readFile(filePath, 'utf8');
+      const matches = content.match(/^---\n([\s\S]*?)\n---/);
+      if (!matches) return []; // No front matter
+
+      const frontMatter = yaml.load(matches[1]) as FrontMatter;
+      return frontMatter?.children?.map(child => child.url) ?? [];
+    } catch (error) {
+      if (error instanceof Error && 'code' in error && error.code !== 'ENOENT') {
+        throw error;
+      }
+      return [];
+    }
+  }
+
+  /**
+   * Move a parent file to _index.md in its own directory and update any links to moved files
+   * @param parentFile - Path to the parent file
+   */
+  private async moveParentFile(parentFile: string): Promise<void> {
+    try {
+      // Create parent directory
+      const parentDir = path.join(path.dirname(parentFile), path.basename(parentFile, '.md'));
+      await this.fs.mkdir(parentDir, { recursive: true });
+
+      // Move parent to _index.md if not already there
+      const indexFile = path.join(parentDir, '_index.md');
+      try {
+        await this.fs.access(indexFile);
+      } catch {
+        await this.fs.rename(parentFile, indexFile);
+        this.movedFiles.set(parentFile, indexFile);
+      }
+    } catch (error) {
+      if (error instanceof Error && 'code' in error && error.code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Move child files referenced in parent's front matter and update their links
+   * @param parentFile - Path to the parent file
+   * @param children - List of child URLs to move
+   */
+  private async moveChildrenFromList(parentFile: string, children: string[]): Promise<void> {
+    try {
+      const parentDir = path.join(path.dirname(parentFile), path.basename(parentFile, '.md'));
+
+      for (const childUrl of children) {
+        const childFile = path.join(path.dirname(parentFile), `${childUrl}.md`);
+        try {
+          await this.fs.access(childFile);
+
+          const newLocation = path.join(parentDir, path.basename(childFile));
+          try {
+            await this.fs.access(newLocation);
+          } catch {
+            await this.fs.rename(childFile, newLocation);
+            this.movedFiles.set(childFile, newLocation);
+          }
+        } catch (error) {
+          if (error instanceof Error && 'code' in error && error.code !== 'ENOENT') {
+            throw error;
+          }
+        }
+      }
+    } catch (error) {
+      if (error instanceof Error && 'code' in error && error.code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Get the map of moved files
+   * @returns Map of original paths to new locations
+   */
+  getMovedFiles(): ReadonlyMap<string, string> {
+    return this.movedFiles;
+  }
+}

--- a/scripts/reorg-docs/src/FileWalker.ts
+++ b/scripts/reorg-docs/src/FileWalker.ts
@@ -1,0 +1,40 @@
+import path from 'path';
+import type { FileSystem } from './types.js';
+
+export class FileWalker {
+  private readonly fs: FileSystem;
+
+  constructor(fs: FileSystem) {
+    this.fs = fs;
+  }
+
+  /**
+   * Walks through files in a directory and yields each file path
+   * @param dirPath - Directory to walk through
+   * @param recursive - Whether to walk through subdirectories (defaults to false)
+   * @yields Path to each file in the directory (only .md files)
+   */
+  async *walkFiles(dirPath: string, recursive = false): AsyncGenerator<string> {
+    const entries = await this.fs.readdir(dirPath);
+
+    for (const entry of entries) {
+      const fullPath = path.join(dirPath, entry);
+
+      try {
+        const stats = await this.fs.stat(fullPath);
+        if (stats.isDirectory()) {
+          // Only recurse if recursive flag is true
+          if (recursive) {
+            yield* this.walkFiles(fullPath, recursive);
+          }
+        } else if (entry.endsWith('.md')) {
+          yield fullPath;
+        }
+      } catch (error) {
+        if (error instanceof Error && 'code' in error && error.code !== 'ENOENT') {
+          throw error;
+        }
+      }
+    }
+  }
+}

--- a/scripts/reorg-docs/src/LinkFixer.ts
+++ b/scripts/reorg-docs/src/LinkFixer.ts
@@ -1,0 +1,274 @@
+import path from 'path';
+import type { FileSystem } from './types.js';
+
+let count = 0;
+function regexX(strings: TemplateStringsArray, ...values: string[]) {
+  let pattern = strings.raw.join('')
+    .replace(/\s+#.*$/gm, '') // remove comments
+    .replace(/\s+/g, '');  // remove whitespace
+  // if (count++ < 3) console.log(` >> ${pattern}\n`);
+  return pattern;
+}
+
+/**
+ * Represents a link substitution to be applied
+ */
+interface LinkSubstitution {
+  from: string;      // Original markdown link
+  to: string;        // New markdown link
+  explanation?: string; // Optional explanation for debugging
+}
+
+/**
+ * LinkFixer handles updating markdown links in files during documentation reorganization.
+ *
+ * Strategy:
+ * The link updating logic is divided into distinct cases based on the type of file being processed:
+ *
+ * 1. Top-level _index.md file:
+ *    - Special handling as it contains links to both moved and unmoved files
+ *    - Must preserve link format (with/without trailing slash)
+ *
+ * 2. Top-level non-index files that remain post-reorg:
+ *    - Files that weren't moved but may contain links to moved files
+ *    - Links need to be updated to point to new locations
+ *
+ * 3. Moved files:
+ *    3.1 Files that became index files (_index.md):
+ *        - Parent files moved to subdirectories and renamed
+ *        - Links need to be updated relative to new location
+ *
+ *    3.2 Files moved without becoming index files:
+ *        - Child files moved to parent's directory
+ *        - Links need to be updated relative to new location
+ */
+export class LinkFixer {
+  private readonly docsDir: string;
+  private readonly fs: FileSystem;
+
+  constructor(docsDir: string, fs: FileSystem) {
+    this.docsDir = docsDir;
+    this.fs = fs;
+  }
+
+  /**
+   * Normalizes a path for comparison purposes only
+   * This is used to match paths, not for the final output
+   */
+  private normalizeForComparison(filePath: string): string {
+    return filePath.replace(/\/$/, '').replace(/\.md$/, '');
+  }
+
+  /**
+   * Updates markdown links in a file based on moved file locations
+   * Delegates to specific handlers to determine substitutions, then applies them.
+   */
+  async updateLinksInFile(filePath: string, movedFiles: Map<string, string>): Promise<void> {
+    const content = await this.fs.readFile(filePath, 'utf8');
+    const fileName = path.basename(filePath);
+    const isIndex = fileName === '_index.md';
+    const isTopLevel = path.dirname(filePath) === this.docsDir;
+
+    // if (filePath.includes('architecture/_index.md')) {
+    //  console.log(`\n > 33331 ${filePath} content: `);
+    //}
+
+    // Get substitutions from the appropriate handler
+    let substitutions: LinkSubstitution[];
+    if (isTopLevel && isIndex) {
+      substitutions = await this.handleTopLevelIndex(content, filePath, movedFiles);
+    } else if (isTopLevel) {
+      substitutions = await this.handleTopLevelFile(content, filePath, movedFiles);
+    } else if (isIndex) {
+      substitutions = await this.handleMovedIndexFile(content, filePath, movedFiles);
+    } else {
+      substitutions = await this.handleMovedFile(content, filePath, movedFiles);
+    }
+
+    // Sort substitutions by length (longest first) to handle nested links correctly
+    substitutions.sort((a, b) => b.from.length - a.from.length);
+
+    // Apply all substitutions to the content
+    let updatedContent = content;
+    for (const { from, to } of substitutions) {
+      updatedContent = updatedContent.replaceAll(from, to);
+    }
+
+    // Write the updated content back to the file
+    await this.fs.writeFile(filePath, updatedContent);
+  }
+
+  /**
+   * Handles link updates in the top-level _index.md file.
+   * Returns list of substitutions to be applied.
+   */
+  private async handleTopLevelIndex(content: string, filePath: string, movedFiles: Map<string, string>): Promise<LinkSubstitution[]> {
+    return this.findLinkSubstitutions(content, filePath, movedFiles, {
+      preserveTrailingSlash: true,
+      preferDirectoryStyle: true,
+      preserveOriginalFormat: true
+    });
+  }
+
+  /**
+   * Handles link updates in top-level files that weren't moved.
+   * Returns list of substitutions to be applied.
+   */
+  private async handleTopLevelFile(content: string, filePath: string, movedFiles: Map<string, string>): Promise<LinkSubstitution[]> {
+    return this.findLinkSubstitutions(content, filePath, movedFiles, {
+      preserveTrailingSlash: true,
+      preferDirectoryStyle: true,
+      preserveOriginalFormat: true
+    });
+  }
+
+  /**
+   * Handles link updates in files that were moved and became _index.md files.
+   * Returns list of substitutions to be applied.
+   */
+  private async handleMovedIndexFile(content: string, filePath: string, movedFiles: Map<string, string>): Promise<LinkSubstitution[]> {
+    return this.findLinkSubstitutions(content, filePath, movedFiles, {
+      preserveTrailingSlash: true,
+      preferDirectoryStyle: true,
+      preserveOriginalFormat: true
+    });
+  }
+
+  /**
+   * Handles link updates in files that were moved but didn't become index files.
+   * Returns list of substitutions to be applied.
+   */
+  private async handleMovedFile(content: string, filePath: string, movedFiles: Map<string, string>): Promise<LinkSubstitution[]> {
+    return this.findLinkSubstitutions(content, filePath, movedFiles, {
+      preserveTrailingSlash: true,
+      preferDirectoryStyle: true,
+      preserveOriginalFormat: true
+    });
+  }
+
+  /**
+   * Core link substitution finding logic used by handlers.
+   * Returns list of substitutions to be applied.
+   */
+  private findLinkSubstitutions(
+    content: string,
+    filePath: string,
+    movedFiles: Map<string, string>,
+    options: {
+      preserveTrailingSlash: boolean;
+      preferDirectoryStyle: boolean;
+      preserveOriginalFormat: boolean;
+    }
+  ): LinkSubstitution[] {
+    const currentDir = path.dirname(filePath);
+    const isCurrentFileIndex = path.basename(filePath) === '_index.md';
+    const wasCurrentFileMoved = movedFiles.has(filePath);
+    const substitutions: LinkSubstitution[] = [];
+
+    // Regular expression to match markdown links
+    const linkPattern = new RegExp(regexX`
+      # Link text
+      \[
+        ([^\]]+)
+      \]
+
+      # Link reference
+      \(
+        # Path capture group
+        (
+          (?:\.\/|\.\.\/)*  # Optional prefixes of ./ or ../
+          [^)#\s]+    # Path content
+        )
+        # Optional hash capture group
+        (?:#
+          ([^)\s]+)
+        )?
+      \)
+    `, 'g');
+
+    let match;
+    while ((match = linkPattern.exec(content)) !== null) {
+      const [fullMatch, linkText, linkPath, hash] = match;
+      const hashFragment = hash ? `#${hash}` : '';
+
+      // console.log(`\nLink: ${fullMatch}`);
+
+      // Skip external links
+      if (linkPath.startsWith('http')) continue;
+
+      // Skip root-relative links
+      if (linkPath.startsWith('/')) continue;
+
+      // Preserve the exact format of the original link
+      const hasTrailingSlash = linkPath.endsWith('/');
+      const originalPrefix = linkPath.match(/^(?:\.\/|\.\.\/)+/)?.[0] || '';
+      const pathWithoutPrefix = linkPath.slice(originalPrefix.length);
+
+      // Check if the original path had .md extension
+      const hadMdExtension = pathWithoutPrefix.endsWith('.md');
+
+      // Only normalize for comparison
+      const normalizedForComparison = this.normalizeForComparison(pathWithoutPrefix);
+
+      // Check if this path needs to be updated
+      let matched = false;
+      for (const [oldPath, targetPath] of movedFiles.entries()) {
+        const oldNormalized = this.normalizeForComparison(oldPath);
+        const pathBasename = path.basename(normalizedForComparison);
+        const oldBasename = path.basename(oldNormalized);
+
+        if (oldBasename === pathBasename) {
+          const targetDir = path.dirname(targetPath);
+          const relPath = path.relative(currentDir, targetDir);
+          const targetBasename = path.basename(targetPath);
+          const isIndexFile = targetBasename === '_index.md';
+
+          // Preserve the original prefix exactly as it was
+          // If there was no prefix and we need to go up directories, use ../
+          const needsParentDir = relPath.startsWith('..');
+          const prefix = !isCurrentFileIndex ? '../' :
+            originalPrefix && !needsParentDir ? './' : '';
+
+          // Build the new path preserving original format
+          let newPath;
+          if (isIndexFile && options.preferDirectoryStyle) {
+            // For index files, use directory style without _index
+            newPath = prefix + relPath + (hasTrailingSlash || options.preserveTrailingSlash ? '/' : '');
+          } else {
+            // For regular files, preserve original format
+            const basename = path.basename(targetPath, '.md');
+            const extension = hadMdExtension ? '.md' : '';
+            const trailingSlash = hasTrailingSlash ? '/' : '';
+            newPath = prefix + path.join(relPath, basename) + extension + trailingSlash;
+          }
+
+          const newMarkdownLink = `[${linkText}](${newPath}${hashFragment})`;
+          substitutions.push({
+            from: fullMatch,
+            to: newMarkdownLink,
+            explanation: `File ${oldPath} moved to ${targetPath}, updating link to use new parent directory ${targetBasename}`
+          });
+          matched = true;
+          break;
+        }
+      }
+      if (matched) continue;
+
+      // A non-external, relative link to a resource that wasn't moved.
+      // If the current file was moved (and hence was moved into a subdirectory),
+      // and linkPath starts with `../`, we need to adjust it.
+      const wasCurrentFileMoved = Array.from(movedFiles.values()).includes(filePath);
+      if (!(originalPrefix.startsWith('../') && !isCurrentFileIndex && wasCurrentFileMoved)) continue;
+
+      const newPath : string = originalPrefix + linkPath;
+      const newMarkdownLink = `[${linkText}](${newPath}${hashFragment})`;
+      substitutions.push({
+        from: fullMatch,
+        to: newMarkdownLink,
+        explanation: `File ${linkPath} moved to ${newPath}. Current file was moved into a subdirectory, and linkPath starts with '../'.`
+      });
+    }
+
+    return substitutions;
+  }
+}

--- a/scripts/reorg-docs/src/cli.ts
+++ b/scripts/reorg-docs/src/cli.ts
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+import { promises as fs } from 'fs';
+import { FileMover } from './FileMover.js';
+
+async function main() {
+  try {
+    // Get docs directory from command line or use default
+    const docsDir = process.argv[2] || 'content/docs/v2/2.6';
+
+    // Ensure docs directory exists
+    try {
+      await fs.access(docsDir);
+    } catch {
+      console.error(`Directory not found: ${docsDir}`);
+      process.exit(1);
+    }
+
+    console.log(`Processing documentation in: ${docsDir}`);
+
+    // Create file mover instance and process the directory
+    const mover = new FileMover(docsDir, fs);
+    await mover.processDirectory();
+
+    // Print summary of moved files
+    const movedFiles = mover.getMovedFiles();
+    if (movedFiles.size > 0) {
+      console.log('\nMoved files:');
+      for (const [from, to] of movedFiles.entries()) {
+        console.log(`  ${from} → ${to}`);
+      }
+    } else {
+      console.log('\nNo files needed to be moved.');
+    }
+    console.log(`\nTotal files moved: ${movedFiles.size}`);
+
+  } catch (error) {
+    console.error('Error:', error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/reorg-docs/src/types.ts
+++ b/scripts/reorg-docs/src/types.ts
@@ -1,0 +1,16 @@
+import type { FileHandle } from 'fs/promises';
+import type { ObjectEncodingOptions } from 'fs';
+
+export interface FileSystem {
+  access: (path: string) => Promise<void>;
+  mkdir: (path: string, options?: { recursive?: boolean }) => Promise<string | undefined>;
+  readFile: (path: string, encoding: BufferEncoding) => Promise<string>;
+  writeFile: (path: string, data: string | Buffer) => Promise<void>;
+  rename: (oldPath: string, newPath: string) => Promise<void>;
+  open: (path: string, flags: string) => Promise<FileHandle>;
+  stat: (path: string) => Promise<{ isDirectory: () => boolean }>;
+  readdir: {
+    (path: string): Promise<string[]>;
+    (path: string, options: ObjectEncodingOptions & { withFileTypes: true }): Promise<Array<{ name: string; isDirectory: () => boolean }>>;
+  };
+}

--- a/scripts/reorg-docs/test-integration.sh
+++ b/scripts/reorg-docs/test-integration.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# Create tmp/test-data directory if it doesn't exist
+mkdir -p tmp/test-data
+
+# Run the integration test
+npm test -- tests/FileMover/integration.test.ts
+
+# Clean up test data only, preserve tmp folder
+rm -rf tmp/test-data

--- a/scripts/reorg-docs/tests/FileMover/basic_operations.test.ts
+++ b/scripts/reorg-docs/tests/FileMover/basic_operations.test.ts
@@ -1,0 +1,67 @@
+import { Volume } from 'memfs';
+import { FileMover } from '../../src/FileMover.js';
+import type { FileSystem } from '../../src/types.js';
+
+describe('FileMover: basic operations', () => {
+  let vol: any;
+  let fs: FileSystem;
+  let mover: FileMover;
+
+  beforeEach(() => {
+    vol = Volume.fromJSON({
+      '/docs/architecture.md': '# Architecture',
+      '/docs/deployment.md': '# Deployment',
+      '/docs/faq.md': '# FAQ'
+    });
+    fs = vol.promises as unknown as FileSystem;
+    mover = new FileMover('/docs', fs);
+  });
+
+  it('creates parent directory and moves file to _index.md', async () => {
+    await mover.moveParentFile('/docs/deployment.md');
+
+    // Check directory was created
+    const dirStats = await fs.stat('/docs/deployment');
+    expect(dirStats.isDirectory()).toBe(true);
+
+    // Check file was moved and renamed
+    expect(await fs.readFile('/docs/deployment/_index.md', 'utf8')).toBe('# Deployment');
+
+    // Check original file was removed
+    await expect(fs.readFile('/docs/deployment.md', 'utf8')).rejects.toThrow();
+  });
+
+  it('skips already moved files', async () => {
+    // Pre-create target structure
+    await fs.mkdir('/docs/deployment');
+    await fs.writeFile('/docs/deployment/_index.md', 'Already moved');
+
+    // Try to move file
+    await mover.moveParentFile('/docs/deployment.md');
+
+    // Check content wasn't changed
+    const content = await fs.readFile('/docs/deployment/_index.md', 'utf8');
+    expect(content).toBe('Already moved');
+  });
+
+  it('tracks moved files', async () => {
+    await mover.moveParentFile('/docs/deployment.md');
+
+    const movedFiles = mover.getMovedFiles();
+    expect(movedFiles.get('/docs/deployment.md')).toBe('/docs/deployment/_index.md');
+  });
+
+  it('handles parent file with no children without changing other files', async () => {
+    await mover.moveParentFile('/docs/faq.md');
+
+    // Verify faq.md is moved to its own directory
+    expect(await fs.readFile('/docs/faq/_index.md', 'utf8')).toBe('# FAQ');
+
+    // Verify other files remain untouched
+    expect(await fs.readFile('/docs/architecture.md', 'utf8')).toBe('# Architecture');
+    expect(await fs.readFile('/docs/deployment.md', 'utf8')).toBe('# Deployment');
+
+    // Verify original faq.md no longer exists
+    await expect(fs.readFile('/docs/faq.md', 'utf8')).rejects.toThrow();
+  });
+});

--- a/scripts/reorg-docs/tests/FileMover/children.test.ts
+++ b/scripts/reorg-docs/tests/FileMover/children.test.ts
@@ -1,0 +1,52 @@
+import { Volume } from 'memfs';
+import { FileMover } from '../../src/FileMover.js';
+import type { FileSystem } from '../../src/types.js';
+
+describe('FileMover: child file handling', () => {
+  let vol: any;
+  let fs: FileSystem;
+  let mover: FileMover;
+
+  beforeEach(() => {
+    // Set up test files including parent with children
+    vol = Volume.fromJSON({
+      '/docs/architecture.md': `---
+title: Architecture
+children:
+  - title: Sampling
+    url: sampling
+  - title: Terminology
+    url: terminology
+---
+# Architecture Overview`,
+      '/docs/sampling.md': '# Sampling',
+      '/docs/terminology.md': '# Terminology'
+    });
+    fs = vol.promises as unknown as FileSystem;
+    mover = new FileMover('/docs', fs);
+  });
+
+  it('moves child files to parent directory', async () => {
+    const moved = await mover.testAndMove('/docs/architecture.md');
+    expect(moved).toBe(true);
+
+    // Verify children were moved
+    expect(await fs.readFile('/docs/architecture/sampling.md', 'utf8')).toBe('# Sampling');
+    expect(await fs.readFile('/docs/architecture/terminology.md', 'utf8')).toBe('# Terminology');
+
+    // Verify original files were removed
+    await expect(fs.readFile('/docs/sampling.md', 'utf8')).rejects.toThrow();
+    await expect(fs.readFile('/docs/terminology.md', 'utf8')).rejects.toThrow();
+  });
+
+  it('tracks moved child files', async () => {
+    const moved = await mover.testAndMove('/docs/architecture.md');
+    expect(moved).toBe(true);
+
+    // Verify moved files are tracked
+    const movedFiles = mover.getMovedFiles();
+    expect(movedFiles.get('/docs/architecture.md')).toBe('/docs/architecture/_index.md');
+    expect(movedFiles.get('/docs/sampling.md')).toBe('/docs/architecture/sampling.md');
+    expect(movedFiles.get('/docs/terminology.md')).toBe('/docs/architecture/terminology.md');
+  });
+});

--- a/scripts/reorg-docs/tests/FileMover/integration.test.ts
+++ b/scripts/reorg-docs/tests/FileMover/integration.test.ts
@@ -1,0 +1,221 @@
+import { Volume } from 'memfs';
+import { FileMover } from '../../src/FileMover.js';
+import type { FileSystem } from '../../src/types.js';
+import * as fs from 'fs/promises';
+import path from 'path';
+
+const DOCS_VERSION = '2.6';
+const DOCS_MAJOR_VERSION = DOCS_VERSION[0];
+const DOCS_VERSION_PATH = `v${DOCS_MAJOR_VERSION}/${DOCS_VERSION}`;
+
+describe('FileMover: integration tests with real docs', () => {
+  const REPO_ROOT = path.resolve(process.cwd(), '../..');
+  const TMP_ROOT = path.join(REPO_ROOT, 'tmp');
+  const TEST_DATA_ROOT = path.join(TMP_ROOT, 'test-data');
+  const TEST_DOCS_PATH = path.join(TEST_DATA_ROOT, DOCS_VERSION);
+  const LOG_FILE = path.join(TMP_ROOT, 'integration.test-log.txt');
+  let realFs: FileSystem;
+  let mover: FileMover;
+  let movedFiles: ReadonlyMap<string, string>;
+
+  // Helper to read and check file contents
+  async function _readFile(relativePath: string): Promise<string> {
+    return realFs.readFile(path.join(TEST_DOCS_PATH, relativePath), 'utf8');
+  }
+
+  beforeAll(async () => {
+    // Clean up test directory before starting
+    await fs.rm(TEST_DATA_ROOT, { recursive: true, force: true });
+
+    await fs.mkdir(TMP_ROOT, { recursive: true }); // Create tmp root if it doesn't exist
+    await fs.mkdir(TEST_DATA_ROOT, { recursive: true }); // Create test root if it doesn't exist
+
+    // Copy real docs from content/docs/vX/X.Y to tmp/test-data/X.Y
+    const sourceDir = path.resolve(REPO_ROOT, `content/docs/${DOCS_VERSION_PATH}`);
+    await copyDirectory(sourceDir, TEST_DOCS_PATH);
+
+    realFs = fs as unknown as FileSystem;
+
+    // Initialize and run FileMover
+    mover = new FileMover(TEST_DOCS_PATH, realFs);
+    await mover.processDirectory();
+    movedFiles = mover.getMovedFiles();
+  });
+
+  afterAll(async () => {
+    // Leave the test directory results for debugging
+    // await fs.rm(TEST_DATA_ROOT, { recursive: true, force: true });
+  });
+
+  it('moves some files (sanity check)', () => {
+    expect(movedFiles.size).toBeGreaterThan(0);
+  });
+
+
+  it('leaves _index.md where it is (sanity check)', async () => {
+    const rootIndex = await _readFile('_index.md');
+    expect(rootIndex).toContain('title: Docs');
+  });
+
+
+  it('creates the right file system layout for all the moved files', () => {
+    // Convert the moved files to relative paths for comparison
+    const actualMoves: string[] = [];
+    movedFiles.forEach((newPath, oldPath) => {
+      const relativeOldPath = path.relative(TEST_DATA_ROOT, oldPath);
+      const relativeNewPath = path.relative(TEST_DATA_ROOT, newPath);
+      actualMoves.push(`      ${relativeOldPath} -> ${relativeNewPath}`);
+    });
+
+    const expectedMoves = `      2.6/architecture.md -> 2.6/architecture/_index.md
+      2.6/apis.md -> 2.6/architecture/apis.md
+      2.6/sampling.md -> 2.6/architecture/sampling.md
+      2.6/spm.md -> 2.6/architecture/spm.md
+      2.6/terminology.md -> 2.6/architecture/terminology.md
+      2.6/deployment.md -> 2.6/deployment/_index.md
+      2.6/configuration.md -> 2.6/deployment/configuration.md
+      2.6/frontend-ui.md -> 2.6/deployment/frontend-ui.md
+      2.6/kubernetes.md -> 2.6/deployment/kubernetes.md
+      2.6/windows.md -> 2.6/deployment/windows.md
+      2.6/security.md -> 2.6/deployment/security.md
+      2.6/external-guides.md -> 2.6/external-guides/_index.md
+      2.6/migration.md -> 2.6/external-guides/migration.md
+      2.6/operations.md -> 2.6/operations/_index.md
+      2.6/monitoring.md -> 2.6/operations/monitoring.md
+      2.6/troubleshooting.md -> 2.6/operations/troubleshooting.md
+      2.6/performance-tuning.md -> 2.6/operations/performance-tuning.md
+      2.6/tools.md -> 2.6/operations/tools.md
+      2.6/storage.md -> 2.6/storage/_index.md
+      2.6/memory.md -> 2.6/storage/memory.md
+      2.6/badger.md -> 2.6/storage/badger.md
+      2.6/cassandra.md -> 2.6/storage/cassandra.md
+      2.6/elasticsearch.md -> 2.6/storage/elasticsearch.md
+      2.6/kafka.md -> 2.6/storage/kafka.md
+      2.6/opensearch.md -> 2.6/storage/opensearch.md`;
+
+    expect(actualMoves.join('\n')).toBe(expectedMoves);
+  });
+
+  describe('really moved the files - content sanity check', () => {
+    it('moves parent files to _index.md', async () => {
+      const architectureIndex = await _readFile('architecture/_index.md');
+      expect(architectureIndex).toContain('title: Architecture');
+    });
+
+    it('moves child files to parent directories', async () => {
+      const samplingFile = await _readFile('architecture/sampling.md');
+      expect(samplingFile).toContain('title: Sampling');
+    });
+
+    it('updates relative links in moved files', async () => {
+      const samplingFile = await _readFile('architecture/sampling.md');
+      expect(samplingFile).toContain('[remote-sampling-api]: ../apis/');  // Links to other sections should be relative to root
+    });
+  });
+
+
+
+  describe('preserves external links in root _index.md', () => {
+    let rootIndex: string;
+
+    beforeEach(async () => {
+      rootIndex = await _readFile('_index.md');
+    });
+
+    it('preserves absolute links', () => {
+      expect(rootIndex).toContain('[hear from you](/get-in-touch/)');
+    });
+
+    it('preserves section-relative links to pages that didn\'t move', () => {
+      expect(rootIndex).toContain('[Getting Started](./getting-started/)');
+    });
+
+    it('preserves external URLs', () => {
+      expect(rootIndex).toContain('[Uber Technologies](http://uber.github.io)');
+      expect(rootIndex).toContain('[Cloud Native Computing Foundation](https://cncf.io/)');
+    });
+  });
+
+  describe('updates links in files not moved by reorg', () => {
+    let gettingStartedContent: string;
+
+    beforeEach(async () => {
+      gettingStartedContent = await _readFile('getting-started.md');
+    });
+
+    it('preserves links to sections that became _index.md', () => {
+      // getting-started.md should preserve its link to architecture/ which became _index.md
+      expect(gettingStartedContent).toContain('[see Architecture](../architecture/)');
+    });
+
+    it('updates links to files moved to subdirectories', () => {
+      // getting-started.md should update its link to memory.md which moved to storage/
+      expect(gettingStartedContent).toContain('[APIs page](../architecture/apis/)');
+    });
+
+    it('preserves hash fragments in links to moved files', async () => {
+      const faqContent = await _readFile('faq.md');
+      const markdownLink = '[Elasticsearch Rollover](../storage/elasticsearch/#index-rollover)';
+      expect(faqContent).toContain(markdownLink);
+    });
+  });
+
+  describe('updates links in root _index.md', () => {
+    let rootIndex: string;
+
+    beforeEach(async () => {
+      rootIndex = await _readFile('_index.md');
+    });
+
+    it('updates links to files moved to subdirectories', () => {
+      expect(rootIndex).toContain('[Memory storage](./storage/memory/)');
+    });
+
+    it('preserves links to sections that became _index.md', () => {
+      expect(rootIndex).toContain('[Features](./features/)');
+    });
+  });
+
+  describe('updates links in moved files', () => {
+    it('for index page to pages in same folder', async () => {
+      const architectureIndex = await _readFile('architecture/_index.md');
+      expect(architectureIndex).toContain('[adaptive sampling](./sampling/#adaptive-sampling)');
+    });
+
+    it('for index page to pages in other folder', async () => {
+      const architectureIndex = await _readFile('architecture/_index.md');
+      // Links to storage backends should use ../../
+      expect(architectureIndex).toContain('[Badger](../storage/badger/');
+    });
+
+    it('for index page to page in folder with hash on link', async () => {
+      const architectureIndex = await _readFile('architecture/_index.md');
+      // Links with hash fragments should be preserved
+      expect(architectureIndex).toContain('[adaptive sampling](./sampling/#adaptive-sampling)');
+    });
+
+    it('for non-index page to unmoved page', async () => {
+      const monitoringIndex = await _readFile('operations/monitoring.md');
+      // Links with hash fragments should be preserved
+      expect(monitoringIndex).toContain('[Getting Started](../../getting-started/)');
+    });
+  });
+
+});
+
+async function copyDirectory(src: string, dest: string): Promise<void> {
+  await fs.mkdir(dest, { recursive: true });
+
+  const entries = await fs.readdir(src, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+
+    if (entry.isDirectory()) {
+      await copyDirectory(srcPath, destPath);
+    } else {
+      await fs.copyFile(srcPath, destPath);
+    }
+  }
+}

--- a/scripts/reorg-docs/tests/FileMover/link_updates.test.ts
+++ b/scripts/reorg-docs/tests/FileMover/link_updates.test.ts
@@ -1,0 +1,92 @@
+import { Volume } from 'memfs';
+import { FileMover } from '../../src/FileMover.js';
+import type { FileSystem } from '../../src/types.js';
+
+// ------------------------------------------------------------
+
+const ROOT_INDEX_CONTENT = `---
+title: Documentation
+---
+# Documentation
+
+See [Features](./features/) for a list of features.
+See [Architecture](./architecture/) for design details.`;
+
+// ------------------------------------------------------------
+
+const ARCHITECTURE_CONTENT = `---
+title: Architecture
+children:
+  - title: Components
+    url: components
+---
+# Architecture Overview`;
+
+// ------------------------------------------------------------
+
+const DEPLOYMENT_CONTENT = `---
+title: Deployment
+children:
+  - title: Production Setup
+    url: production-setup
+---
+# Deployment Guide
+See [production setup](production-setup.md) for details.`;
+
+// ------------------------------------------------------------
+
+const PRODUCTION_SETUP_CONTENT = `# Production Setup
+Back to [deployment guide](deployment.md).`;
+
+// ------------------------------------------------------------
+
+const newLocal = {
+  '/docs/_index.md': ROOT_INDEX_CONTENT,
+  '/docs/architecture.md': ARCHITECTURE_CONTENT,
+  '/docs/features.md': '# Features',
+  '/docs/deployment.md': DEPLOYMENT_CONTENT,
+  '/docs/production-setup.md': PRODUCTION_SETUP_CONTENT
+};
+
+describe('FileMover: link updates', () => {
+  let vol: any;
+  let fs: FileSystem;
+  let mover: FileMover;
+
+  beforeEach(() => {
+    vol = Volume.fromJSON(newLocal);
+    fs = vol.promises as unknown as FileSystem;
+    mover = new FileMover('/docs', fs);
+  });
+
+  it('preserves links to sections that became _index.md', async () => {
+    // Move architecture.md to architecture/_index.md
+    const moved = await mover.testAndMove('/docs/architecture.md');
+    expect(moved).toBe(true);
+
+    // Verify architecture.md became _index.md
+    const indexContent = await fs.readFile('/docs/architecture/_index.md', 'utf8');
+    expect(indexContent).toContain('# Architecture Overview');
+
+    // Verify link in root _index.md is preserved
+    const rootContent = await fs.readFile('/docs/_index.md', 'utf8');
+    expect(rootContent).toContain('[Architecture](./architecture/)');
+
+    // Verify link to unmoved file is also preserved
+    expect(rootContent).toContain('[Features](./features/)');
+  });
+
+  it('updates links in moved files', async () => {
+    const moved = await mover.testAndMove('/docs/deployment.md');
+    expect(moved).toBe(true);
+
+    // Check links in parent file were updated
+    const parentContent = await fs.readFile('/docs/deployment/_index.md', 'utf8');
+    expect(parentContent).toContain('See [production setup](production-setup.md) for details.');
+
+    // Check links in child file were updated
+    const childContent = await fs.readFile('/docs/deployment/production-setup.md', 'utf8');
+    expect(childContent).toContain('Back to [deployment guide](deployment.md).');
+  });
+
+});

--- a/scripts/reorg-docs/tests/FileMover/sanity.test.ts
+++ b/scripts/reorg-docs/tests/FileMover/sanity.test.ts
@@ -1,0 +1,73 @@
+import { Volume } from 'memfs';
+import { FileMover } from '../../src/FileMover.js';
+import type { FileSystem } from '../../src/types.js';
+
+describe('FileMover: sanity checks', () => {
+  let vol: any;
+  let fs: FileSystem;
+  let mover: FileMover;
+
+  beforeEach(async () => {
+    // Set up minimal file system with just faq.md
+    vol = Volume.fromJSON({
+      '/docs/faq.md': '# FAQ',
+      '/docs/_index.md': `---
+title: Documentation Root
+children:
+  - title: FAQ
+    url: faq
+---
+# Documentation Home`
+    });
+    fs = vol.promises as unknown as FileSystem;
+    await fs.mkdir('/docs', { recursive: true });
+
+    mover = new FileMover('/docs', fs);
+  });
+
+  it('returns false and does nothing for a standalone file', async () => {
+    // Verify initial state
+    expect(await fs.readFile('/docs/faq.md', 'utf8')).toBe('# FAQ');
+
+    // Test and move the file
+    const moved = await mover.testAndMove('/docs/faq.md');
+    expect(moved).toBe(false);
+
+    // Verify nothing changed
+    expect(await fs.readFile('/docs/faq.md', 'utf8')).toBe('# FAQ');
+    expect(mover.getMovedFiles().size).toBe(0);
+  });
+
+  it('processDirectory does nothing in a file system with just faq.md', async () => {
+    const contents = await fs.readdir('/docs');
+
+    expect(await fs.readFile('/docs/faq.md', 'utf8')).toBe('# FAQ');
+    await mover.processDirectory();
+    // Verify nothing changed
+    expect(await fs.readFile('/docs/faq.md', 'utf8')).toBe('# FAQ');
+    expect(mover.getMovedFiles().size).toBe(0);
+  });
+
+  it('does not move _index.md even if it has children', async () => {
+    // Get initial content and state
+    const indexContent = await fs.readFile('/docs/_index.md', 'utf8');
+    const faqContent = await fs.readFile('/docs/faq.md', 'utf8');
+
+    // Try to move the file
+    const moved = await mover.testAndMove('/docs/_index.md');
+    expect(moved).toBe(false);
+
+    // Verify _index.md is still in its original location with original content
+    expect(await fs.readFile('/docs/_index.md', 'utf8')).toBe(indexContent);
+
+    // Verify faq.md is still in its original location and hasn't been moved
+    expect(await fs.readFile('/docs/faq.md', 'utf8')).toBe(faqContent);
+    await expect(fs.stat('/docs/_index/faq.md')).rejects.toThrow();
+
+    // Verify no _index directory was created
+    await expect(fs.stat('/docs/_index')).rejects.toThrow();
+
+    // Verify no files were tracked as moved
+    expect(mover.getMovedFiles().size).toBe(0);
+  });
+});

--- a/scripts/reorg-docs/tests/FileMover/should_move.test.ts
+++ b/scripts/reorg-docs/tests/FileMover/should_move.test.ts
@@ -1,0 +1,83 @@
+import { Volume } from 'memfs';
+import { FileMover } from '../../src/FileMover.js';
+import type { FileSystem } from '../../src/types.js';
+
+describe('FileMover: move decision logic', () => {
+  let vol: any;
+  let fs: FileSystem;
+  let mover: FileMover;
+
+  beforeEach(() => {
+    vol = Volume.fromJSON({
+      '/docs/empty.md': '',
+      '/docs/no-front-matter.md': '# Just a title',
+      '/docs/empty-front-matter.md': `---
+---
+# Content with empty front matter`,
+      '/docs/no-children.md': `---
+title: No Children Here
+---
+# Content without children`,
+      '/docs/empty-children.md': `---
+title: Empty Children
+children: []
+---
+# Content with empty children array`,
+      '/docs/with-children.md': `---
+title: Has Children
+children:
+  - title: Child One
+    url: child-one
+  - title: Child Two
+    url: child-two
+---
+# Content with children`,
+      '/docs/_index.md': `---
+title: Documentation Root
+children:
+  - title: Getting Started
+    url: getting-started
+  - title: Architecture
+    url: architecture
+---
+# Documentation Home`
+    });
+    fs = vol.promises as unknown as FileSystem;
+    mover = new FileMover('/docs', fs);
+  });
+
+  it('returns false for empty files', async () => {
+    const shouldMove = await mover.shouldMove('/docs/empty.md');
+    expect(shouldMove).toBe(false);
+  });
+
+  it('returns false for files without front matter', async () => {
+    const shouldMove = await mover.shouldMove('/docs/no-front-matter.md');
+    expect(shouldMove).toBe(false);
+  });
+
+  it('returns false for files with empty front matter', async () => {
+    const shouldMove = await mover.shouldMove('/docs/empty-front-matter.md');
+    expect(shouldMove).toBe(false);
+  });
+
+  it('returns false for files without children field', async () => {
+    const shouldMove = await mover.shouldMove('/docs/no-children.md');
+    expect(shouldMove).toBe(false);
+  });
+
+  it('returns false for files with empty children array', async () => {
+    const shouldMove = await mover.shouldMove('/docs/empty-children.md');
+    expect(shouldMove).toBe(false);
+  });
+
+  it('returns true for files with children', async () => {
+    const shouldMove = await mover.shouldMove('/docs/with-children.md');
+    expect(shouldMove).toBe(true);
+  });
+
+  it('returns false for _index.md even with children', async () => {
+    const shouldMove = await mover.shouldMove('/docs/_index.md');
+    expect(shouldMove).toBe(false);
+  });
+});

--- a/scripts/reorg-docs/tests/FileMover/unmoved_files.test.ts
+++ b/scripts/reorg-docs/tests/FileMover/unmoved_files.test.ts
@@ -1,0 +1,135 @@
+import { Volume } from 'memfs';
+import { FileMover } from '../../src/FileMover.js';
+import type { FileSystem } from '../../src/types.js';
+
+describe('FileMover: handling of unmoved files', () => {
+  let vol: any;
+  let fs: FileSystem;
+  let fileMover: FileMover;
+
+  beforeEach(() => {
+    // Set up test files including ones that should not move
+    vol = Volume.fromJSON({
+      '/docs/architecture.md': `---
+title: Architecture
+children:
+  - title: Sampling
+    url: sampling
+  - title: Terminology
+    url: terminology
+---
+# Architecture Overview`,
+      '/docs/faq.md': '# FAQ',
+      '/docs/sampling.md': '# Sampling',
+      '/docs/terminology.md': '# Terminology',
+      '/docs/client-libraries.md': '# Client Libraries',
+      '/docs/_index.md': `---
+title: Documentation Root
+children:
+  - title: Getting Started
+    url: getting-started
+  - title: Architecture
+    url: architecture
+---
+# Documentation Home`
+    });
+    fs = vol.promises as unknown as FileSystem;
+    fileMover = new FileMover('/docs', fs);
+  });
+
+  it('handles parent file with no children without changing other files', async () => {
+    // Move a file that has no children
+    const moved = await fileMover.testAndMove('/docs/faq.md');
+    expect(moved).toBe(false);
+
+    // Verify faq.md is still in its original location
+    expect(await fs.readFile('/docs/faq.md', 'utf8')).toBe('# FAQ');
+
+    // Verify other files remain untouched
+    expect(await fs.readFile('/docs/architecture.md', 'utf8')).toContain('# Architecture Overview');
+    expect(await fs.readFile('/docs/sampling.md', 'utf8')).toBe('# Sampling');
+    expect(await fs.readFile('/docs/terminology.md', 'utf8')).toBe('# Terminology');
+    expect(await fs.readFile('/docs/client-libraries.md', 'utf8')).toBe('# Client Libraries');
+  });
+
+  it('leaves standalone files untouched when no moves are requested', async () => {
+    // Set up a file system with only files that should not move
+    vol = Volume.fromJSON({
+      '/docs/faq.md': '# Frequently Asked Questions'
+    });
+    fs = vol.promises as unknown as FileSystem;
+    fileMover = new FileMover('/docs', fs);
+
+    // Try to move a non-existent file
+    const moved = await fileMover.testAndMove('/docs/architecture.md');
+    expect(moved).toBe(false);
+
+    // Verify faq.md is still in its original location and unchanged
+    expect(await fs.readFile('/docs/faq.md', 'utf8')).toBe('# Frequently Asked Questions');
+
+    // Verify no files were tracked as moved
+    expect(fileMover.getMovedFiles().size).toBe(0);
+  });
+
+  it('preserves files not mentioned in any moves', async () => {
+    // Set up a file system with a mix of files to move and preserve
+    vol = Volume.fromJSON({
+      '/docs/architecture.md': `---
+title: Architecture
+children:
+  - title: Sampling
+    url: sampling
+---
+# Architecture Overview`,
+      '/docs/sampling.md': '# Sampling',
+      '/docs/faq.md': '# FAQ',
+      '/docs/monitoring.md': '# Monitoring',
+      '/docs/client-libraries.md': '# Client Libraries'
+    });
+    fs = vol.promises as unknown as FileSystem;
+    fileMover = new FileMover('/docs', fs);
+
+    // Move architecture.md and its children
+    const moved = await fileMover.testAndMove('/docs/architecture.md');
+    expect(moved).toBe(true);
+
+    // Verify files that should move are moved
+    expect(await fs.readFile('/docs/architecture/_index.md', 'utf8')).toContain('# Architecture Overview');
+    expect(await fs.readFile('/docs/architecture/sampling.md', 'utf8')).toBe('# Sampling');
+
+    // Verify unmoved files remain in their original locations and unchanged
+    expect(await fs.readFile('/docs/faq.md', 'utf8')).toBe('# FAQ');
+    expect(await fs.readFile('/docs/monitoring.md', 'utf8')).toBe('# Monitoring');
+    expect(await fs.readFile('/docs/client-libraries.md', 'utf8')).toBe('# Client Libraries');
+
+    // Verify only the expected files were tracked as moved
+    const movedFiles = fileMover.getMovedFiles();
+    expect(movedFiles.size).toBe(2); // architecture.md and sampling.md
+    expect(movedFiles.has('/docs/faq.md')).toBe(false);
+    expect(movedFiles.has('/docs/monitoring.md')).toBe(false);
+    expect(movedFiles.has('/docs/client-libraries.md')).toBe(false);
+  });
+
+  it('does not move _index.md even if it has children', async () => {
+    // Get initial content and state
+    const indexContent = await fs.readFile('/docs/_index.md', 'utf8');
+    const faqContent = await fs.readFile('/docs/faq.md', 'utf8');
+
+    // Try to move the file
+    const moved = await fileMover.testAndMove('/docs/_index.md');
+    expect(moved).toBe(false);
+
+    // Verify _index.md is still in its original location with original content
+    expect(await fs.readFile('/docs/_index.md', 'utf8')).toBe(indexContent);
+
+    // Verify faq.md is still in its original location and hasn't been moved
+    expect(await fs.readFile('/docs/faq.md', 'utf8')).toBe(faqContent);
+    await expect(fs.stat('/docs/_index/faq.md')).rejects.toThrow();
+
+    // Verify no _index directory was created
+    await expect(fs.stat('/docs/_index')).rejects.toThrow();
+
+    // Verify no files were tracked as moved
+    expect(fileMover.getMovedFiles().size).toBe(0);
+  });
+});

--- a/scripts/reorg-docs/tests/LinkFixer/top_level_index.test.ts
+++ b/scripts/reorg-docs/tests/LinkFixer/top_level_index.test.ts
@@ -1,0 +1,94 @@
+import { Volume } from 'memfs';
+import { LinkFixer } from '../../src/LinkFixer.js';
+import type { FileSystem } from '../../src/types.js';
+
+/**
+ * Tests for how LinkFixer handles links in the top-level _index.md file of a folder
+ * being reorganized. This file is special because it contains links to:
+ * - Files that will be moved into subdirectories
+ * - Files that will remain at the same level
+ * - Links to other sections using website root paths
+ */
+describe('LinkFixer: top-level _index.md handling', () => {
+  let vol: any;
+  let fs: FileSystem;
+  let linkFixer: LinkFixer;
+
+  const getMovedFiles = () => new Map([
+    ['/docs/sampling.md', '/docs/architecture/sampling.md'],
+    ['/docs/terminology.md', '/docs/architecture/terminology.md']
+  ]);
+
+  beforeEach(() => {
+    // Set up common test files
+    vol = Volume.fromJSON({
+      '/docs/architecture.md': '# Architecture',
+      '/docs/sampling.md': '# Sampling',
+      '/docs/terminology.md': '# Terminology'
+    });
+    fs = vol.promises as unknown as FileSystem;
+    linkFixer = new LinkFixer('/docs', fs);
+  });
+
+  it('preserves links to unmoved files and website root paths', async () => {
+    const originalContent = `---
+title: Documentation
+---
+Some text:
+- [Client Libraries](client-libraries) - unmoved file
+- [About Jaeger](/about/) - website root path
+`;
+    await fs.writeFile('/docs/_index.md', originalContent);
+    await linkFixer.updateLinksInFile('/docs/_index.md', getMovedFiles());
+    const content = await fs.readFile('/docs/_index.md', 'utf8');
+    expect(content).toBe(originalContent);
+  });
+
+  it('updates link when file moves to its own directory as _index.md', async () => {
+    const originalContent = `---
+title: Documentation
+---
+
+Oh my:
+
+- [Architecture](architecture/) - will move to subfolder
+`;
+    await fs.writeFile('/docs/_index.md', originalContent);
+
+    await linkFixer.updateLinksInFile('/docs/_index.md', getMovedFiles());
+
+    const content = await fs.readFile('/docs/_index.md', 'utf8');
+    expect(content).toBe(originalContent);
+  });
+
+  it('updates links preserving their original ending slash or', async () => {
+    const originalContent = `---
+title: Documentation
+---
+
+## Hello
+
+- [Sampling](./sampling) - no trailing slash
+- [Terminology](terminology/) - with trailing slash
+- [Sampling again](./sampling#hello) - with hash
+- [Terminology](terminology/#hi) - with hash
+`;
+    await fs.writeFile('/docs/_index.md', originalContent);
+
+    await linkFixer.updateLinksInFile('/docs/_index.md', getMovedFiles());
+
+    const expectedContent = `---
+title: Documentation
+---
+
+## Hello
+
+- [Sampling](./architecture/sampling) - no trailing slash
+- [Terminology](architecture/terminology/) - with trailing slash
+- [Sampling again](./architecture/sampling#hello) - with hash
+- [Terminology](architecture/terminology/#hi) - with hash
+`;
+    const content = await fs.readFile('/docs/_index.md', 'utf8');
+    expect(content).toBe(expectedContent);
+  });
+});

--- a/scripts/reorg-docs/tsconfig.json
+++ b/scripts/reorg-docs/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "sourceMap": true,
+    "declaration": true,
+    "rootDir": "src",
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}


### PR DESCRIPTION
- Contributes to: #746
- Adds `reorg-docs` tool, in support of addressing #913
  - Once the Docsy migration is done we'll remove the tool
- Fixes: #915
- Makes relative links to the `/sdk-migration/` page absolute. This makes it easier for the `reorg-docs` tool to manage.