### PR TITLE
[Docsy] reorg-docs tool: add support for generation of aliases

### DIFF
--- a/scripts/docsy/README.md
+++ b/scripts/docsy/README.md
@@ -163,3 +163,57 @@ The script will:
    - Handle cases where child files might already be in their target location
    - Preserve all content and front matter during moves
    - Report actions taken and any issues encountered
+
+   ---
+
+## Correspondence between v1 and v2 pages
+
+Docs (1.69)
+Features
+Getting Started
+Architecture
+○ APIs
+○ Sampling
+Deployment
+○ Kubernetes
+○ Frontend/UI
+○ CLI Flags
+○ Security
+○ On Windows
+○ SPM
+Monitoring
+Perf Tuning
+Troubleshooting
+FAQs
+Tools
+External Guides
+
+Docs (2.6)
+○ Getting Started
+○ Features
+Architecture
+○ APIs
+○ Sampling
+○ SPM
+○ Terminology
+Deployment
+○ Configuration
+○ User Interface
+○ On Kubernetes
+○ On Windows
+○ Security
+Storage Backends
+○ Memory
+○ Badger
+○ Cassandra
+○ ElasticSearch
+○ Kafka
+○ OpenSearch
+Operations
+○ Monitoring
+○ Troubleshooting
+○ Performance Tuning
+○ Tools
+FAQs
+External Guides
+○ Migration Guides

--- a/scripts/reorg-docs/package.json
+++ b/scripts/reorg-docs/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "clean": "rm -rf dist",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
     "start": "node dist/cli.js"
@@ -17,19 +18,20 @@
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.0",
-    "@types/js-yaml": "^4.0.5",
-    "@types/mdast": "^3.0.0",
-    "@types/node": "^22.0.0",
-    "jest": "^29.5.0",
-    "memfs": "^3.5.1",
-    "ts-jest": "^29.1.0",
-    "typescript": "^5.0.3"
+    "@types/jest": "^29.5.14",
+    "@types/js-yaml": "^4.0.9",
+    "@types/mdast": "^4.0.4",
+    "@types/node": "^22.15.29",
+    "jest": "^29.7.0",
+    "memfs": "^4.17.2",
+    "ts-jest": "^29.3.4",
+    "typescript": "^5.8.3"
   },
   "jest": {
     "preset": "ts-jest/presets/default-esm",
     "testEnvironment": "node",
     "extensionsToTreatAsEsm": [".ts"],
+    "testMatch": ["<rootDir>/tests/**/*.test.ts"],
     "moduleNameMapper": {
       "^(\\.{1,2}/.*)\\.js$": "$1"
     },
@@ -41,5 +43,6 @@
         }
       ]
     }
-  }
+  },
+  "spelling": "cSpell:ignore mdast -"
 }

--- a/scripts/reorg-docs/tests/FileMover/idempotence.test.ts
+++ b/scripts/reorg-docs/tests/FileMover/idempotence.test.ts
@@ -1,0 +1,67 @@
+import { Volume } from 'memfs';
+import { FileMover } from '../../src/FileMover.js';
+import type { FileSystem } from '../../src/types.js';
+
+describe('FileMover: idempotence', () => {
+  let vol: any;
+  let fs: FileSystem;
+  let mover: FileMover;
+
+  beforeEach(() => {
+    vol = Volume.fromJSON({
+      '/docs/operations.md': `---
+title: Operations Guide
+children:
+  - title: Monitoring
+    url: monitoring
+---
+# Operations Guide`,
+      '/docs/monitoring.md': `---
+title: Monitoring Jaeger
+navtitle: Monitoring
+hasparent: true
+---
+# Monitoring Guide`
+    });
+    fs = vol.promises as unknown as FileSystem;
+    mover = new FileMover('/docs', fs);
+  });
+
+  it('produces identical results when run multiple times', async () => {
+    // First run
+    await mover.processDirectory();
+    const firstRunContent = await fs.readFile('/docs/operations/monitoring.md', 'utf8');
+
+    // Second run with a fresh mover
+    mover = new FileMover('/docs', fs);
+    await mover.processDirectory();
+    const secondRunContent = await fs.readFile('/docs/operations/monitoring.md', 'utf8');
+
+    // Contents should be identical
+    expect(secondRunContent).toBe(firstRunContent);
+  });
+
+  it('does not duplicate aliases', async () => {
+    // Run twice
+    await mover.processDirectory();
+    mover = new FileMover('/docs', fs);
+    await mover.processDirectory();
+
+    // Check the content
+    const content = await fs.readFile('/docs/operations/monitoring.md', 'utf8');
+    const aliasMatches = content.match(/aliases:/g);
+    expect(aliasMatches?.length).toBe(1);  // Should only have one aliases: field
+    expect(content).toContain('aliases: [../monitoring]');  // Should have the correct format
+  });
+
+  it('finds no files to move after initial processing', async () => {
+    // First run should move files
+    await mover.processDirectory();
+    const initialMovedCount = mover.getMovedFiles().size;
+    expect(initialMovedCount).toBeGreaterThan(0);
+
+    // Second moveFiles should find nothing to move
+    await mover.moveFiles();
+    expect(mover.getMovedFiles().size).toBe(initialMovedCount);
+  });
+});

--- a/scripts/reorg-docs/tests/FileMover/link_updates.test.ts
+++ b/scripts/reorg-docs/tests/FileMover/link_updates.test.ts
@@ -45,7 +45,8 @@ const newLocal = {
   '/docs/architecture.md': ARCHITECTURE_CONTENT,
   '/docs/features.md': '# Features',
   '/docs/deployment.md': DEPLOYMENT_CONTENT,
-  '/docs/production-setup.md': PRODUCTION_SETUP_CONTENT
+  '/docs/production-setup.md': PRODUCTION_SETUP_CONTENT,
+  '/docs/components.md': '# Components'
 };
 
 describe('FileMover: link updates', () => {

--- a/scripts/reorg-docs/tests/FileMover/sanity.test.ts
+++ b/scripts/reorg-docs/tests/FileMover/sanity.test.ts
@@ -2,7 +2,7 @@ import { Volume } from 'memfs';
 import { FileMover } from '../../src/FileMover.js';
 import type { FileSystem } from '../../src/types.js';
 
-describe('FileMover: sanity checks', () => {
+describe('Sanity checks', () => {
   let vol: any;
   let fs: FileSystem;
   let mover: FileMover;

--- a/scripts/reorg-docs/tsconfig.json
+++ b/scripts/reorg-docs/tsconfig.json
@@ -10,9 +10,10 @@
     "outDir": "dist",
     "sourceMap": true,
     "declaration": true,
-    "rootDir": "src",
-    "isolatedModules": true
+    "rootDir": ".",
+    "isolatedModules": true,
+    "types": ["node", "jest"]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
- Contributes to #913
- Adds support (to the reorg-docs tool) for the generation of aliases
- Updates tool package deps
  - Closes #918 by superseding it