### PR TITLE
Add partials for redirect support of aliases etc

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -4,6 +4,7 @@ baseURL: https://www.jaegertracing.io
 title: Jaeger
 disableKinds: [taxonomy]
 theme: [basetheme, jaeger-docs]
+disableAliases: true # We do redirects via Netlify's _redirects file
 pygmentsCodeFences: true
 pygmentsUseClasses: true
 

--- a/layouts/_partials/func/trim-lines.html
+++ b/layouts/_partials/func/trim-lines.html
@@ -1,0 +1,5 @@
+{{ range split . "\n" -}}
+{{ with trim . " \t" -}}
+{{ . }}
+{{ end -}}
+{{ end -}}

--- a/layouts/_partials/redirects/aliases.txt
+++ b/layouts/_partials/redirects/aliases.txt
@@ -1,0 +1,28 @@
+{{/* Generate rules for `aliases` page param. */ -}}
+{{/* cSpell:ignore cond */ -}}
+
+{{ $p := . -}}
+{{ range $alias := $p.Aliases -}}
+  {{ if not (strings.HasPrefix $alias "/") -}}
+    {{ $alias = partial "relative-redirects-alias"
+        (dict
+          "alias" $alias
+          "p" (cond (strings.HasPrefix $alias "./") $p $p.Parent)
+        ) -}}
+  {{ end -}}
+  {{ $alias | printf "%-35s" }} {{ $p.RelPermalink }}
+{{ end -}}
+
+{{- define "partials/relative-redirects-alias" -}}
+  {{ $result := "" }}
+  {{ if strings.HasPrefix .alias "../" }}
+    {{ $result = (partial "relative-redirects-alias"
+          (dict
+            "alias" (strings.TrimPrefix "../" .alias)
+            "p" .p.Parent ))
+    }}
+  {{ else }}
+    {{ $result = path.Join .p.RelPermalink .alias }}
+  {{ end }}
+  {{ return $result }}
+{{ end -}}

--- a/layouts/_partials/redirects/pages.txt
+++ b/layouts/_partials/redirects/pages.txt
@@ -1,0 +1,19 @@
+{{/* Generate redirects for all given pages */ -}}
+{{/* cSpell:ignore cond */ -}}
+
+{{ range $p := .Site.Pages -}}
+
+  {{ range $p.Params.redirects -}}
+    {{ $from := cond (strings.HasPrefix .from "/")
+        .from
+        (print $p.RelPermalink .from) -}}
+    {{ $to := cond (strings.HasPrefix .to "/")
+        .to
+        (print $p.RelPermalink .to) -}}
+    {{ $from | printf "%-35s" }} {{ $to }}
+  {{ end -}}
+
+  {{ partial "redirects/aliases.txt" $p -}}
+  {{ partial "redirects/redirect.txt" $p -}}
+
+{{ end -}}

--- a/layouts/_partials/redirects/redirect.txt
+++ b/layouts/_partials/redirects/redirect.txt
@@ -1,0 +1,6 @@
+{{/* Generate a Netlify redirect rule for pages with a `redirect` param */ -}}
+
+{{ $p := . -}}
+{{ with $p.Params.redirect -}}
+  {{ $p.RelPermalink | printf "%-35s" }} {{ . }}
+{{ end -}}

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -4,3 +4,4 @@
 {{ $lines := split $redirects "\n" -}}
 {{ $sorted := sort $lines | uniq -}}
 {{ delimit $sorted "\n" }}
+{{ partial "redirects/pages.txt" . | partial "func/trim-lines.html" -}}


### PR DESCRIPTION
- Contributes to #913
- Adds layouts in support of the generation of page aliases as Netlify redirects. There are no such aliases fields in the current pages, but there will be once pages are moved. That is, there is no difference in the site page generation.