### PR TITLE
Page reorg of v1 latest and next-release

### DIFF
--- a/.htmltest.old-versions.yml
+++ b/.htmltest.old-versions.yml
@@ -4,4 +4,5 @@ IgnoreAltMissing: true
 IgnoreURLs:
   - /livereload.js
   - ^/docs/latest/ # ignore redirect of latest
-  - ^/docs/1.69/client-(features|libraries)/
+  # Valid URL, whether canonical (before reorg) or not (and handled via a redirect)
+  - ^/docs/1.[6-9]\d/

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -6,6 +6,9 @@ IgnoreDirs:
 IgnoreURLs:
   - /livereload.js # cSpell:disable-line
   - ^https://www.jaegertracing.io/js/lunr
+  # Valid URL, whether canonical (before reorg) or not (and handled via a redirect)
+  - ^/docs/1.[6-9]\d/sampling/
+  - ^/docs/latest/architecture/
   # Valid URLs, but servers yield 403 or similar errors
   - ^https://(twitter|x).com/[Jj]aeger[Tt]racing
   - ^https://calendar.google.com/

--- a/content/docs/v1/1.69/architecture/_index.md
+++ b/content/docs/v1/1.69/architecture/_index.md
@@ -42,7 +42,7 @@ run in a single process, or as a scalable distributed system. There are two main
 
 In this deployment the collectors receive the data from traced applications and write it directly to storage. The storage must be able to handle both average and peak traffic. Collectors use an in-memory queue to smooth short-term traffic peaks, but a sustained traffic spike may result in dropped data if the storage is not able to keep up.
 
-Collectors are able to centrally serve sampling configuration to the SDKs, known as [remote sampling mode](../sampling/#remote-sampling). They can also enable automatic sampling configuration calculation, known as [adaptive sampling](../sampling/#adaptive-sampling).
+Collectors are able to centrally serve sampling configuration to the SDKs, known as [remote sampling mode](./sampling/#remote-sampling). They can also enable automatic sampling configuration calculation, known as [adaptive sampling](./sampling/#adaptive-sampling).
 
 [![Architecture](/img/architecture-v1-2023.png)](/img/architecture-v1-2023.png)
 
@@ -98,7 +98,7 @@ There are many ways to instrument an application:
 
 Instrumentation typically should not depend on specific tracing SDKs, but only on abstract tracing APIs like the OpenTelemetry API. The tracing SDKs implement the tracing APIs and take care of data export.
 
-The instrumentation is designed to be always on in production. To minimize  overhead, the SDKs employ various sampling strategies. When a trace is sampled, the profiling span data is captured and transmitted to the Jaeger backend. When a trace is not sampled, no profiling data is collected at all, and the calls to the tracing API are short-circuited to incur a minimal amount of overhead. For more information, please refer to the [Sampling](../sampling/) page.
+The instrumentation is designed to be always on in production. To minimize  overhead, the SDKs employ various sampling strategies. When a trace is sampled, the profiling span data is captured and transmitted to the Jaeger backend. When a trace is not sampled, no profiling data is collected at all, and the calls to the tracing API are short-circuited to incur a minimal amount of overhead. For more information, please refer to the [Sampling](./sampling/) page.
 
 ### Collector
 
@@ -106,7 +106,7 @@ The instrumentation is designed to be always on in production. To minimize  over
 
 ### Query
 
-**jaeger-query** is a service that exposes the [APIs](../apis/) for retrieving traces from storage and hosts a Web UI for searching and analyzing traces.
+**jaeger-query** is a service that exposes the [APIs](./apis/) for retrieving traces from storage and hosts a Web UI for searching and analyzing traces.
 
 ### Ingester
 

--- a/content/docs/v1/1.69/architecture/apis.md
+++ b/content/docs/v1/1.69/architecture/apis.md
@@ -1,5 +1,6 @@
 ---
 title: APIs
+aliases: [../apis]
 hasparent: true
 ---
 
@@ -21,7 +22,7 @@ Since Jaeger v1.32, **jaeger-collector** and **jaeger-query** Service ports that
 
 Since v1.35, the Jaeger backend can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. It is no longer necessary to configure the OpenTelemetry SDKs with Jaeger exporters, nor deploy the OpenTelemetry Collector between the OpenTelemetry SDKs and the Jaeger backend.
 
-The OTLP data is accepted in these formats: (1) binary gRPC, (2) Protobuf over HTTP, (3) JSON over HTTP. For more details on the OTLP receiver see the [official documentation][otlp-rcvr]. Note that not all configuration options are supported in **jaeger-collector** (see `--collector.otlp.*` [CLI Flags](../cli/#jaeger-collector)), and only tracing data is accepted, since Jaeger does not store other telemetry types.
+The OTLP data is accepted in these formats: (1) binary gRPC, (2) Protobuf over HTTP, (3) JSON over HTTP. For more details on the OTLP receiver see the [official documentation][otlp-rcvr]. Note that not all configuration options are supported in **jaeger-collector** (see `--collector.otlp.*` [CLI Flags](../../deployment/cli/#jaeger-collector)), and only tracing data is accepted, since Jaeger does not store other telemetry types.
 
 | Port  | Protocol | Endpoint     | Format
 | ----- | -------  | ------------ | ----
@@ -73,7 +74,7 @@ Jaeger UI communicates with **jaeger-query** Service via JSON API. For example, 
 
 ## Remote Storage API (stable)
 
-When using the `grpc` storage type (a.k.a. [remote storage](../deployment/#remote-storage)), Jaeger components can use custom storage backends as long as those backends implement the gRPC [Remote Storage API][storage.proto].
+When using the `grpc` storage type (a.k.a. [remote storage](../../deployment/#remote-storage)), Jaeger components can use custom storage backends as long as those backends implement the gRPC [Remote Storage API][storage.proto].
 
 ## Remote Sampling Configuration (stable)
 
@@ -115,7 +116,7 @@ For programmatic access to the service graph, the recommended API is gRPC/Protob
 
 ## Service Performance Monitoring (internal)
 
-Please refer to the [SPM Documentation](../spm/#api)
+Please refer to the [SPM Documentation](../../deployment/spm/#api)
 
 [jaeger-idl]: https://github.com/jaegertracing/jaeger-idl/
 [jaeger.thrift]: https://github.com/jaegertracing/jaeger-idl/blob/main/thrift/jaeger.thrift

--- a/content/docs/v1/1.69/architecture/sampling.md
+++ b/content/docs/v1/1.69/architecture/sampling.md
@@ -1,5 +1,6 @@
 ---
 title: Sampling
+aliases: [../sampling]
 hasparent: true
 ---
 

--- a/content/docs/v1/1.69/deployment/_index.md
+++ b/content/docs/v1/1.69/deployment/_index.md
@@ -46,7 +46,7 @@ Jaeger binaries can be configured in a number of ways (in the order of decreasin
   * environment variables,
   * configuration files in JSON, TOML, YAML, HCL, or Java properties formats.
 
-To see the complete list of options, run the binary with the `help` command or refer to the [CLI Flags](../cli/) page for more information. Options that are specific to a certain storage backend are _only listed if the storage type is selected_. For example, to see all available options in the Collector with Cassandra storage:
+To see the complete list of options, run the binary with the `help` command or refer to the [CLI Flags](./cli/) page for more information. Options that are specific to a certain storage backend are _only listed if the storage type is selected_. For example, to see all available options in the Collector with Cassandra storage:
 
 ```sh
 $ docker run --rm \
@@ -98,7 +98,7 @@ You can navigate to `http://localhost:16686` to access the Jaeger UI.
 **jaeger-collector**s are stateless and thus many instances of **jaeger-collector** can be run in parallel.
 **jaeger-collector**s require almost no configuration, except for storage location, such as
 `--cassandra.keyspace` and `--cassandra.servers` options, or the location of Elasticsearch cluster,
-via `--es.server-urls`, depending on which storage is specified. See the [CLI Flags](../cli/) for all
+via `--es.server-urls`, depending on which storage is specified. See the [CLI Flags](./cli/) for all
 command line options.
 
 At default settings **jaeger-collector** exposes the following ports:
@@ -107,7 +107,7 @@ At default settings **jaeger-collector** exposes the following ports:
 | ----- | -------  | -------- | ----
 | 4317  | gRPC     | n/a      | Accepts traces in [OpenTelemetry OTLP format][otlp] (Protobuf).
 | 4318  | HTTP     | `/v1/traces` | Accepts traces in [OpenTelemetry OTLP format][otlp] (Protobuf and JSON).
-| 14268 | HTTP     | `/api/sampling` | Serves sampling policies (see [Remote Sampling](../sampling/#remote-sampling)).
+| 14268 | HTTP     | `/api/sampling` | Serves sampling policies (see [Remote Sampling](../architecture/sampling/#remote-sampling)).
 |       |          | `/api/traces` | Accepts spans in [jaeger.thrift][jaeger-thrift] format with `binary` thrift protocol (`POST`).
 | 14269 | HTTP     | `/`      | Admin port: health check (`GET`).
 |       |          | `/metrics` | Prometheus-style metrics (`GET`).
@@ -170,7 +170,7 @@ The base path can be configured via the `--query.base-path` command line paramet
 
 ### UI Customization and Embedding
 
-Please refer to the [dedicated Frontend/UI page](../frontend-ui/).
+Please refer to the [dedicated Frontend/UI page](./frontend-ui/).
 
 ## Remote Storage (component)
 
@@ -601,7 +601,7 @@ Known remote storage backends:
 ## Metrics Storage Backends
 
 Jaeger Query is capable of querying aggregated R.E.D metrics from a storage backend,
-visualizing them on the [Monitor tab](../spm/). It should be emphasized that the
+visualizing them on the [Monitor tab](./spm/). It should be emphasized that the
 configured metrics storage type is for reading _only_ and therefore, only applies
 to the Jaeger Query component (and All In One, which contains Jaeger Query).
 

--- a/content/docs/v1/1.69/deployment/cli.md
+++ b/content/docs/v1/1.69/deployment/cli.md
@@ -1,5 +1,6 @@
 ---
 title: CLI flags
+aliases: [../cli]
 widescreen: true
 hasparent: true
 ---

--- a/content/docs/v1/1.69/deployment/frontend-ui.md
+++ b/content/docs/v1/1.69/deployment/frontend-ui.md
@@ -1,6 +1,7 @@
 ---
 title: Frontend/UI Configuration
 navtitle: Frontend/UI
+aliases: [../frontend-ui]
 hasparent: true
 weight: 7
 ---

--- a/content/docs/v1/1.69/deployment/operator.md
+++ b/content/docs/v1/1.69/deployment/operator.md
@@ -1,5 +1,6 @@
 ---
 title: Operator for Kubernetes
+aliases: [../operator]
 hasparent: true
 ---
 
@@ -486,7 +487,7 @@ spec:
 <3> The options for the `create-schema` job.
 
 {{< info >}}
-The default create-schema job uses `MODE=prod`, which implies a replication factor of `2`, using `NetworkTopologyStrategy` as the class, effectively meaning that at least 3 nodes are required in the Cassandra cluster. If a `SimpleStrategy` is desired, set the mode to `test`, which then sets the replication factor of `1`. Refer to the [create-schema script](https://github.com/jaegertracing/jaeger/blob/main/internal/storage/v1/cassandra/schema/create.sh) for more details.
+The default create-schema job uses `MODE=prod`, which implies a replication factor of `2`, using `NetworkTopologyStrategy` as the class, effectively meaning that at least 3 nodes are required in the Cassandra cluster. If a `SimpleStrategy` is desired, set the mode to `test`, which then sets the replication factor of `1`. Refer to the [create-schema script](https://github.com/jaegertracing/jaeger/blob/v1.69.0/internal/storage/v1/cassandra/schema/create.sh) for more details.
 {{< /info >}}
 
 ### Elasticsearch storage
@@ -1100,7 +1101,7 @@ spec:
 
 This example defines a default sampling strategy that is probabilistic, with a 50% chance of the trace instances being sampled.
 
-Refer to the Jaeger documentation on [Sampling Configuration](</docs/{{% param latest %}}/sampling/>) to see how service and endpoint sampling can be configured. The JSON representation described in that documentation can be used in the operator by converting to YAML.
+Refer to the Jaeger documentation on [Collector Sampling Configuration](/docs/latest/sampling/#collector-sampling-configuration) to see how service and endpoint sampling can be configured. The JSON representation described in that documentation can be used in the operator by converting to YAML.
 
 ## Finer grained configuration
 

--- a/content/docs/v1/1.69/deployment/security.md
+++ b/content/docs/v1/1.69/deployment/security.md
@@ -1,5 +1,6 @@
 ---
 title: Securing Jaeger Installation
+aliases: [../security]
 hasparent: true
 ---
 

--- a/content/docs/v1/1.69/deployment/spm.md
+++ b/content/docs/v1/1.69/deployment/spm.md
@@ -1,5 +1,6 @@
 ---
 title: Service Performance Monitoring (SPM)
+aliases: [../spm]
 hasparent: true
 ---
 
@@ -51,7 +52,7 @@ The feature can be accessed from the "Monitor" tab along the top menu.
 This demo includes [Microsim](https://github.com/yurishkuro/microsim); a microservices
 simulator to generate trace data.
 
-If generating traces manually is preferred, the [Sample App: HotROD](../getting-started/#sample-app-hotrod)
+If generating traces manually is preferred, the [Sample App: HotROD](../../getting-started/#sample-app-hotrod)
 can be started via docker. Be sure to include `--net monitor_backend` in the `docker run` command.
 
 ## Architecture
@@ -350,14 +351,14 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
-[metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
-[openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.69.0/docker-compose/monitor
+[metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/v1.69.0/model/proto/metrics/metricsquery.proto
+[openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/v1.69.0/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [spanmetrics-conn]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.69.0/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/v1/1.69/deployment/windows.md
+++ b/content/docs/v1/1.69/deployment/windows.md
@@ -1,5 +1,6 @@
 ---
 title: Windows Service Deployment
+aliases: [../windows]
 hasparent: true
 ---
 

--- a/content/docs/v1/1.69/features.md
+++ b/content/docs/v1/1.69/features.md
@@ -73,6 +73,6 @@ to highlight services and/or operations with statistically significant request/e
 latencies, then leveraging Jaeger's Trace Search capabilities to pinpoint specific
 traces belonging to these services/operations.
 
-See [Service Performance Monitoring (SPM)](../spm/) for more details.
+See [Service Performance Monitoring (SPM)](../deployment/spm/) for more details.
 
 [otlp]: https://opentelemetry.io/docs/reference/specification/protocol/

--- a/content/docs/v1/1.69/getting-started.md
+++ b/content/docs/v1/1.69/getting-started.md
@@ -54,7 +54,7 @@ Port  | Protocol | Component | Function
 
 ### With Service Performance Monitoring (SPM)
 
-Please refer to [Service Performance Monitoring (SPM)](../spm/#getting-started).
+Please refer to [Service Performance Monitoring (SPM)](../deployment/spm/#getting-started).
 
 ## On Kubernetes
 

--- a/content/docs/v1/1.69/troubleshooting.md
+++ b/content/docs/v1/1.69/troubleshooting.md
@@ -35,11 +35,11 @@ For example, when using the Jaeger SDK for Java, the strategy is usually printed
 
 ### Remote Sampling
 
-The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](/sdk-migration/#migration-to-opentelemetry) for details).
+The Jaeger backend supports [Remote Sampling](../architecture/sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](/sdk-migration/#migration-to-opentelemetry) for details).
 
 If you suspect the remote sampling is not working correctly, try these steps:
 
-1. Make sure that the SDK is actually configured to use remote sampling, points to the correct sampling service address (see [APIs](../apis/#remote-sampling-configuration-stable)), and that address is reachable from your application's [networking namespace](#networking-namespace).
+1. Make sure that the SDK is actually configured to use remote sampling, points to the correct sampling service address (see [APIs](../architecture/apis/#remote-sampling-configuration-stable)), and that address is reachable from your application's [networking namespace](#networking-namespace).
 1. Verify that the server is returning the appropriate sampling strategy for your service:
 ```
     $ curl "jaeger-collector:14268/api/sampling?service=foobar"

--- a/content/docs/v1/_dev/architecture/_index.md
+++ b/content/docs/v1/_dev/architecture/_index.md
@@ -42,7 +42,7 @@ run in a single process, or as a scalable distributed system. There are two main
 
 In this deployment the collectors receive the data from traced applications and write it directly to storage. The storage must be able to handle both average and peak traffic. Collectors use an in-memory queue to smooth short-term traffic peaks, but a sustained traffic spike may result in dropped data if the storage is not able to keep up.
 
-Collectors are able to centrally serve sampling configuration to the SDKs, known as [remote sampling mode](../sampling/#remote-sampling). They can also enable automatic sampling configuration calculation, known as [adaptive sampling](../sampling/#adaptive-sampling).
+Collectors are able to centrally serve sampling configuration to the SDKs, known as [remote sampling mode](./sampling/#remote-sampling). They can also enable automatic sampling configuration calculation, known as [adaptive sampling](./sampling/#adaptive-sampling).
 
 [![Architecture](/img/architecture-v1-2023.png)](/img/architecture-v1-2023.png)
 
@@ -98,7 +98,7 @@ There are many ways to instrument an application:
 
 Instrumentation typically should not depend on specific tracing SDKs, but only on abstract tracing APIs like the OpenTelemetry API. The tracing SDKs implement the tracing APIs and take care of data export.
 
-The instrumentation is designed to be always on in production. To minimize  overhead, the SDKs employ various sampling strategies. When a trace is sampled, the profiling span data is captured and transmitted to the Jaeger backend. When a trace is not sampled, no profiling data is collected at all, and the calls to the tracing API are short-circuited to incur a minimal amount of overhead. For more information, please refer to the [Sampling](../sampling/) page.
+The instrumentation is designed to be always on in production. To minimize  overhead, the SDKs employ various sampling strategies. When a trace is sampled, the profiling span data is captured and transmitted to the Jaeger backend. When a trace is not sampled, no profiling data is collected at all, and the calls to the tracing API are short-circuited to incur a minimal amount of overhead. For more information, please refer to the [Sampling](./sampling/) page.
 
 ### Collector
 
@@ -106,7 +106,7 @@ The instrumentation is designed to be always on in production. To minimize  over
 
 ### Query
 
-**jaeger-query** is a service that exposes the [APIs](../apis/) for retrieving traces from storage and hosts a Web UI for searching and analyzing traces.
+**jaeger-query** is a service that exposes the [APIs](./apis/) for retrieving traces from storage and hosts a Web UI for searching and analyzing traces.
 
 ### Ingester
 

--- a/content/docs/v1/_dev/architecture/apis.md
+++ b/content/docs/v1/_dev/architecture/apis.md
@@ -1,5 +1,6 @@
 ---
 title: APIs
+aliases: [../apis]
 hasparent: true
 ---
 
@@ -21,7 +22,7 @@ Since Jaeger v1.32, **jaeger-collector** and **jaeger-query** Service ports that
 
 Since v1.35, the Jaeger backend can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. It is no longer necessary to configure the OpenTelemetry SDKs with Jaeger exporters, nor deploy the OpenTelemetry Collector between the OpenTelemetry SDKs and the Jaeger backend.
 
-The OTLP data is accepted in these formats: (1) binary gRPC, (2) Protobuf over HTTP, (3) JSON over HTTP. For more details on the OTLP receiver see the [official documentation][otlp-rcvr]. Note that not all configuration options are supported in **jaeger-collector** (see `--collector.otlp.*` [CLI Flags](../cli/#jaeger-collector)), and only tracing data is accepted, since Jaeger does not store other telemetry types.
+The OTLP data is accepted in these formats: (1) binary gRPC, (2) Protobuf over HTTP, (3) JSON over HTTP. For more details on the OTLP receiver see the [official documentation][otlp-rcvr]. Note that not all configuration options are supported in **jaeger-collector** (see `--collector.otlp.*` [CLI Flags](../../deployment/cli/#jaeger-collector)), and only tracing data is accepted, since Jaeger does not store other telemetry types.
 
 | Port  | Protocol | Endpoint     | Format
 | ----- | -------  | ------------ | ----
@@ -73,7 +74,7 @@ Jaeger UI communicates with **jaeger-query** Service via JSON API. For example, 
 
 ## Remote Storage API (stable)
 
-When using the `grpc` storage type (a.k.a. [remote storage](../deployment/#remote-storage)), Jaeger components can use custom storage backends as long as those backends implement the gRPC [Remote Storage API][storage.proto].
+When using the `grpc` storage type (a.k.a. [remote storage](../../deployment/#remote-storage)), Jaeger components can use custom storage backends as long as those backends implement the gRPC [Remote Storage API][storage.proto].
 
 ## Remote Sampling Configuration (stable)
 
@@ -115,7 +116,7 @@ For programmatic access to the service graph, the recommended API is gRPC/Protob
 
 ## Service Performance Monitoring (internal)
 
-Please refer to the [SPM Documentation](../spm/#api)
+Please refer to the [SPM Documentation](../../deployment/spm/#api)
 
 [jaeger-idl]: https://github.com/jaegertracing/jaeger-idl/
 [jaeger.thrift]: https://github.com/jaegertracing/jaeger-idl/blob/main/thrift/jaeger.thrift

--- a/content/docs/v1/_dev/architecture/sampling.md
+++ b/content/docs/v1/_dev/architecture/sampling.md
@@ -1,5 +1,6 @@
 ---
 title: Sampling
+aliases: [../sampling]
 hasparent: true
 ---
 

--- a/content/docs/v1/_dev/deployment/_index.md
+++ b/content/docs/v1/_dev/deployment/_index.md
@@ -46,7 +46,7 @@ Jaeger binaries can be configured in a number of ways (in the order of decreasin
   * environment variables,
   * configuration files in JSON, TOML, YAML, HCL, or Java properties formats.
 
-To see the complete list of options, run the binary with the `help` command or refer to the [CLI Flags](../cli/) page for more information. Options that are specific to a certain storage backend are _only listed if the storage type is selected_. For example, to see all available options in the Collector with Cassandra storage:
+To see the complete list of options, run the binary with the `help` command or refer to the [CLI Flags](./cli/) page for more information. Options that are specific to a certain storage backend are _only listed if the storage type is selected_. For example, to see all available options in the Collector with Cassandra storage:
 
 ```sh
 $ docker run --rm \
@@ -98,7 +98,7 @@ You can navigate to `http://localhost:16686` to access the Jaeger UI.
 **jaeger-collector**s are stateless and thus many instances of **jaeger-collector** can be run in parallel.
 **jaeger-collector**s require almost no configuration, except for storage location, such as
 `--cassandra.keyspace` and `--cassandra.servers` options, or the location of Elasticsearch cluster,
-via `--es.server-urls`, depending on which storage is specified. See the [CLI Flags](../cli/) for all
+via `--es.server-urls`, depending on which storage is specified. See the [CLI Flags](./cli/) for all
 command line options.
 
 At default settings **jaeger-collector** exposes the following ports:
@@ -107,7 +107,7 @@ At default settings **jaeger-collector** exposes the following ports:
 | ----- | -------  | -------- | ----
 | 4317  | gRPC     | n/a      | Accepts traces in [OpenTelemetry OTLP format][otlp] (Protobuf).
 | 4318  | HTTP     | `/v1/traces` | Accepts traces in [OpenTelemetry OTLP format][otlp] (Protobuf and JSON).
-| 14268 | HTTP     | `/api/sampling` | Serves sampling policies (see [Remote Sampling](../sampling/#remote-sampling)).
+| 14268 | HTTP     | `/api/sampling` | Serves sampling policies (see [Remote Sampling](../architecture/sampling/#remote-sampling)).
 |       |          | `/api/traces` | Accepts spans in [jaeger.thrift][jaeger-thrift] format with `binary` thrift protocol (`POST`).
 | 14269 | HTTP     | `/`      | Admin port: health check (`GET`).
 |       |          | `/metrics` | Prometheus-style metrics (`GET`).
@@ -170,7 +170,7 @@ The base path can be configured via the `--query.base-path` command line paramet
 
 ### UI Customization and Embedding
 
-Please refer to the [dedicated Frontend/UI page](../frontend-ui/).
+Please refer to the [dedicated Frontend/UI page](./frontend-ui/).
 
 ## Remote Storage (component)
 
@@ -601,7 +601,7 @@ Known remote storage backends:
 ## Metrics Storage Backends
 
 Jaeger Query is capable of querying aggregated R.E.D metrics from a storage backend,
-visualizing them on the [Monitor tab](../spm/). It should be emphasized that the
+visualizing them on the [Monitor tab](./spm/). It should be emphasized that the
 configured metrics storage type is for reading _only_ and therefore, only applies
 to the Jaeger Query component (and All In One, which contains Jaeger Query).
 

--- a/content/docs/v1/_dev/deployment/cli.md
+++ b/content/docs/v1/_dev/deployment/cli.md
@@ -1,5 +1,6 @@
 ---
 title: CLI flags
+aliases: [../cli]
 widescreen: true
 hasparent: true
 ---

--- a/content/docs/v1/_dev/deployment/frontend-ui.md
+++ b/content/docs/v1/_dev/deployment/frontend-ui.md
@@ -1,6 +1,7 @@
 ---
 title: Frontend/UI Configuration
 navtitle: Frontend/UI
+aliases: [../frontend-ui]
 hasparent: true
 weight: 7
 ---

--- a/content/docs/v1/_dev/deployment/operator.md
+++ b/content/docs/v1/_dev/deployment/operator.md
@@ -1,5 +1,6 @@
 ---
 title: Operator for Kubernetes
+aliases: [../operator]
 hasparent: true
 ---
 
@@ -486,7 +487,7 @@ spec:
 <3> The options for the `create-schema` job.
 
 {{< info >}}
-The default create-schema job uses `MODE=prod`, which implies a replication factor of `2`, using `NetworkTopologyStrategy` as the class, effectively meaning that at least 3 nodes are required in the Cassandra cluster. If a `SimpleStrategy` is desired, set the mode to `test`, which then sets the replication factor of `1`. Refer to the [create-schema script](https://github.com/jaegertracing/jaeger/blob/v1.69.0/internal/storage/v1/cassandra/schema/create.sh) for more details.
+The default create-schema job uses `MODE=prod`, which implies a replication factor of `2`, using `NetworkTopologyStrategy` as the class, effectively meaning that at least 3 nodes are required in the Cassandra cluster. If a `SimpleStrategy` is desired, set the mode to `test`, which then sets the replication factor of `1`. Refer to the [create-schema script](https://github.com/jaegertracing/jaeger/blob/main/internal/storage/v1/cassandra/schema/create.sh) for more details.
 {{< /info >}}
 
 ### Elasticsearch storage
@@ -1100,7 +1101,7 @@ spec:
 
 This example defines a default sampling strategy that is probabilistic, with a 50% chance of the trace instances being sampled.
 
-Refer to the Jaeger documentation on [Collector Sampling Configuration](/docs/latest/sampling/#collector-sampling-configuration) to see how service and endpoint sampling can be configured. The JSON representation described in that documentation can be used in the operator by converting to YAML.
+Refer to the Jaeger documentation on [Sampling Configuration](</docs/{{% param latest %}}/sampling/>) to see how service and endpoint sampling can be configured. The JSON representation described in that documentation can be used in the operator by converting to YAML.
 
 ## Finer grained configuration
 

--- a/content/docs/v1/_dev/deployment/security.md
+++ b/content/docs/v1/_dev/deployment/security.md
@@ -1,5 +1,6 @@
 ---
 title: Securing Jaeger Installation
+aliases: [../security]
 hasparent: true
 ---
 

--- a/content/docs/v1/_dev/deployment/spm.md
+++ b/content/docs/v1/_dev/deployment/spm.md
@@ -1,5 +1,6 @@
 ---
 title: Service Performance Monitoring (SPM)
+aliases: [../spm]
 hasparent: true
 ---
 
@@ -51,7 +52,7 @@ The feature can be accessed from the "Monitor" tab along the top menu.
 This demo includes [Microsim](https://github.com/yurishkuro/microsim); a microservices
 simulator to generate trace data.
 
-If generating traces manually is preferred, the [Sample App: HotROD](../getting-started/#sample-app-hotrod)
+If generating traces manually is preferred, the [Sample App: HotROD](../../getting-started/#sample-app-hotrod)
 can be started via docker. Be sure to include `--net monitor_backend` in the `docker run` command.
 
 ## Architecture
@@ -350,14 +351,14 @@ data quality issue, and the instrumentation should set the span kind.
 The reason for defaulting to `server` span kinds is to avoid double-counting
 both ingress and egress spans in the `server` and `client` span kinds, respectively.
 
-[spm-demo]: https://github.com/jaegertracing/jaeger/tree/v1.69.0/docker-compose/monitor
-[metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/v1.69.0/model/proto/metrics/metricsquery.proto
-[openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/v1.69.0/model/proto/metrics/openmetrics.proto#L53
+[spm-demo]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor
+[metricsquery.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/metricsquery.proto
+[openmetrics.proto]: https://github.com/jaegertracing/jaeger/blob/main/model/proto/metrics/openmetrics.proto#L53
 [opentelemetry-collector]: https://opentelemetry.io/docs/collector/
 [spanmetrics]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor#section-readme
 [spanmetrics-conn]: https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector#section-readme
 [prom-metric-labels]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/v1.69.0/docker-compose/monitor#http-api
+[http-api-readme]: https://github.com/jaegertracing/jaeger/tree/main/docker-compose/monitor#http-api
 [spanmetrics-config-dimensions]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L23
 [spanmetrics-config-duration]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/testdata/config.yaml#L14
 

--- a/content/docs/v1/_dev/deployment/windows.md
+++ b/content/docs/v1/_dev/deployment/windows.md
@@ -1,5 +1,6 @@
 ---
 title: Windows Service Deployment
+aliases: [../windows]
 hasparent: true
 ---
 

--- a/content/docs/v1/_dev/features.md
+++ b/content/docs/v1/_dev/features.md
@@ -73,6 +73,6 @@ to highlight services and/or operations with statistically significant request/e
 latencies, then leveraging Jaeger's Trace Search capabilities to pinpoint specific
 traces belonging to these services/operations.
 
-See [Service Performance Monitoring (SPM)](../spm/) for more details.
+See [Service Performance Monitoring (SPM)](../deployment/spm/) for more details.
 
 [otlp]: https://opentelemetry.io/docs/reference/specification/protocol/

--- a/content/docs/v1/_dev/getting-started.md
+++ b/content/docs/v1/_dev/getting-started.md
@@ -54,7 +54,7 @@ Port  | Protocol | Component | Function
 
 ### With Service Performance Monitoring (SPM)
 
-Please refer to [Service Performance Monitoring (SPM)](../spm/#getting-started).
+Please refer to [Service Performance Monitoring (SPM)](../deployment/spm/#getting-started).
 
 ## On Kubernetes
 

--- a/content/docs/v1/_dev/troubleshooting.md
+++ b/content/docs/v1/_dev/troubleshooting.md
@@ -35,11 +35,11 @@ For example, when using the Jaeger SDK for Java, the strategy is usually printed
 
 ### Remote Sampling
 
-The Jaeger backend supports [Remote Sampling](../sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](/sdk-migration/#migration-to-opentelemetry) for details).
+The Jaeger backend supports [Remote Sampling](../architecture/sampling/#remote-sampling), i.e., configuring sampling strategies centrally and making them available to the SDKs. Some, but not all, OpenTelemetry SDKs support remote sampling, often via extensions (refer to [Migration to OpenTelemetry](/sdk-migration/#migration-to-opentelemetry) for details).
 
 If you suspect the remote sampling is not working correctly, try these steps:
 
-1. Make sure that the SDK is actually configured to use remote sampling, points to the correct sampling service address (see [APIs](../apis/#remote-sampling-configuration-stable)), and that address is reachable from your application's [networking namespace](#networking-namespace).
+1. Make sure that the SDK is actually configured to use remote sampling, points to the correct sampling service address (see [APIs](../architecture/apis/#remote-sampling-configuration-stable)), and that address is reachable from your application's [networking namespace](#networking-namespace).
 1. Verify that the server is returning the appropriate sampling strategy for your service:
 ```
     $ curl "jaeger-collector:14268/api/sampling?service=foobar"

--- a/content/get-involved.md
+++ b/content/get-involved.md
@@ -11,7 +11,7 @@ In order to understand the project better and come up with reasonable solutions,
 
 * Go through some Jaeger tutorials, such as [this blog post](https://medium.com/jaegertracing/take-jaeger-for-a-hotrod-ride-233cf43e46c2) or [this video](https://youtu.be/s7IrYt1igSM?si=B3NI6ruohKfSPUCl&t=445).
 * Run the [HotROD demo yourself](https://github.com/jaegertracing/jaeger/blob/main/examples/hotrod/README.md). The blogs and videos may be outdated, it's good to get hands on.
-* Review the [Jaeger architecture](</docs/{{% param latestV2 %}}/architecture/>) and understand the components.
+* Review the [Jaeger architecture](/docs/latest/architecture/) and understand the components.
 * Fork and clone the respective repositories to be able to [build and run the project locally](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md#getting-started).
 * Learn about contributing with the best practices, including how to [sign your code and contribute](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#creating-a-pull-request).
 * Try to solve some of the [simple open issues](./#help-with-coding) that you can find across Jaeger repositories.

--- a/themes/jaeger-docs/layouts/partials/docs/header.html
+++ b/themes/jaeger-docs/layouts/partials/docs/header.html
@@ -32,6 +32,10 @@
   {{ $vMajor    = "2" }}
 {{ end }}
 
+{{ $latestUrl = partial "docs/lookup-page" (slice . $latestUrl) -}}
+{{ $latestUrlV1 = partial "docs/lookup-page" (slice . $latestUrlV1) -}}
+{{ $latestUrlV2 = partial "docs/lookup-page" (slice . $latestUrlV2) -}}
+
 <header>
   <p class="title is-1">{{ .Title }}</p>
   {{ with .Params.description }}
@@ -48,16 +52,16 @@
       {{ end }}
       {{ if $isLatest }}
       <span class="tag is-medium is-success">Latest</span>
-      {{ else if .GetPage $latestUrl}}
+      {{ else if $latestUrl }}
       <a class="tag is-medium is-warning" href="{{ $latestUrl }}">
         Go to the latest {{ $vMajor }}.x version
       </a>
       {{ end }}
-      {{ if and (eq $vMajor "1") (.GetPage $latestUrlV2) }}
+      {{ if and (eq $vMajor "1") $latestUrlV2 }}
       <a class="tag is-medium" href="{{ $latestUrlV2 }}">
         Go to the latest 2.x version
       </a>
-      {{ else if and (eq $vMajor "2") (.GetPage $latestUrlV1) }}
+      {{ else if and (eq $vMajor "2") $latestUrlV1 }}
       <a class="tag is-medium" href="{{ $latestUrlV1 }}">
         Go to the latest 1.x version
       </a>

--- a/themes/jaeger-docs/layouts/partials/docs/lookup-page.html
+++ b/themes/jaeger-docs/layouts/partials/docs/lookup-page.html
@@ -1,0 +1,40 @@
+{{/* Page lookup helper for inter-version links. */ -}}
+
+{{ $page := index . 0 -}}
+{{ $url := index . 1 -}}
+{{ $result := $url -}}
+{{ $segments := split (trim $url "/") "/" -}}
+
+{{ if lt (len $segments) 3 -}}
+  {{ if not ($page.GetPage $url) -}}
+    {{ $result = "" -}}
+  {{ end -}}
+{{ else -}}
+  {{ $version := index $segments 1 -}}
+  {{ $targetPage := index $segments (cond (eq (len $segments) 4) 3 2) -}}
+
+  {{ if not ($page.GetPage $url) -}}
+    {{/* Look for page in the version directory. */ -}}
+    {{ $rootedUrl := printf "/docs/%s/%s/" $version $targetPage -}}
+    {{ if $page.GetPage $rootedUrl -}}
+      {{ $result = $rootedUrl -}}
+    {{ else -}}
+      {{/* Look for page in a subdirectory of the version directory. */ -}}
+      {{ $versDir := printf "/docs/%s/" $version -}}
+      {{/*
+        {{ warnf "[header.html] Page %s: looking for %s in %s" $page.RelPermalink $url $versDir -}}
+      */ -}}
+      {{ $result = "" -}}
+      {{ with $page.GetPage $versDir -}}
+        {{ range .RegularPagesRecursive -}}
+          {{ if in .RelPermalink (printf "/%s/" $targetPage) -}}
+            {{ $result = .RelPermalink -}}
+          {{ end -}}
+        {{ end -}}
+      {{ end -}}
+    {{ end -}}
+  {{ end -}}
+
+{{ end -}}
+
+{{ return $result -}}


### PR DESCRIPTION
- Actual first page reorg, in support of #913 
- Reorgs:
  - v1 latest (`v1/1.69`)
  - next-release (`v1/_dev`)
- The reorg is to move child pages into section subfolders. Note that `children` and `hasParent` front matter fields aren't removed since the currently layouts use them to generate the doc-pages left nav.

> [!NOTE]
> All versioned doc pages will be reorganized in this way. This is a first PR. I'm submitting the reorg piecmeal to make it easier to review -- to avoid having to review 1K+ pages in one go!

### Previews

- Visit https://deploy-preview-924--jaegertracing.netlify.app/docs/next-release/architecture/apis/. Notice how the inter-version page links at the top of the page are present, and point to the right place:
  - For v1: https://deploy-preview-924--jaegertracing.netlify.app/docs/1.69/architecture/apis/
  - For v2: https://deploy-preview-924--jaegertracing.netlify.app/docs/2.6/apis/
- Similarly, visit https://deploy-preview-924--jaegertracing.netlify.app/docs/2.6/apis/, and see that the link to v1 latest is correctly:
  - https://deploy-preview-924--jaegertracing.netlify.app/docs/1.69/architecture/apis/
- Visit https://deploy-preview-924--jaegertracing.netlify.app/docs/1.69/deployment/security/, and see that the link to the v2 page is correctly:
  - https://deploy-preview-924--jaegertracing.netlify.app/docs/2.6/security/
- https://deploy-preview-924--jaegertracing.netlify.app/docs/1.69/monitoring/ links to v2 https://deploy-preview-924--jaegertracing.netlify.app/docs/2.6/monitoring/ as it should (at the moment)

### Redirect tests

- https://deploy-preview-924--jaegertracing.netlify.app/docs/1.69/apis/ --> redirects to architecture/apis/
- https://deploy-preview-924--jaegertracing.netlify.app/docs/1.69/spm/ --> deployment/spm/
- https://deploy-preview-924--jaegertracing.netlify.app/docs/next-release/sampling/ --> architecture/sampling/