### PR TITLE
Fix operator 404, and more

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -26,6 +26,7 @@ emsgsize
 errorf
 expvar
 fargate
+findRESubmatch
 flink
 fluentd
 glvs

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -1,0 +1,6 @@
+---
+title: Documentation
+linkTitle: Docs
+params:
+  redirect: /docs/latest 301!
+---

--- a/content/docs/v1/1.21/deployment/opentelemetry.md
+++ b/content/docs/v1/1.21/deployment/opentelemetry.md
@@ -1,6 +1,8 @@
 ---
 title: OpenTelemetry
-aliases: [../opentelemetry]
+aliases:
+  - ../opentelemetry
+  - /docs/opentelemetry
 hasparent: true
 ---
 

--- a/content/docs/v1/1.63/client-libraries/_index.md
+++ b/content/docs/v1/1.63/client-libraries/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Client Libraries
+aliases: [/docs/client-libraries]
 weight: 5
 children:
 - title: Client Features

--- a/content/docs/v1/1.63/client-libraries/client-features.md
+++ b/content/docs/v1/1.63/client-libraries/client-features.md
@@ -1,6 +1,8 @@
 ---
 title: Client Library Features
-aliases: [../client-features]
+aliases:
+  - ../client-features
+  - /docs/client-features
 widescreen: true
 hasparent: true
 weight: 5

--- a/layouts/_partials/redirects.txt
+++ b/layouts/_partials/redirects.txt
@@ -5,25 +5,34 @@
 {{ $latestV2 := site.Params.latestv2 -}}
 {{ $latest   := $latestV2 -}}
 
-/docs    /docs/{{ $latest }}     301!
 /docs/latest     /docs/{{ $latest }}
-/docs/latest/*     /docs/{{ $latest }}/:splat
+/docs/latest/*   /docs/{{ $latest }}/:splat
 
-{{ $pages := slice "get-in-touch" "roadmap" "news" "report-security-issue" -}}
-{{ range $pages }}
+{{ range (slice "get-in-touch" "roadmap" "news" "report-security-issue") }}
 /docs/{{ . }}     /{{ . }}
 {{ end -}}
 
-{{ $v1Pages := slice "cli" "client-features" "client-libraries" "opentelemetry" -}}
-{{ range $v1Pages }}
+{{ range (slice "cli" "operator") }}
 /docs/{{ . }}     /docs/{{ $latestV1 }}/{{ . }}
 {{ end -}}
 
-{{ $v2Pages := slice "apis" "architecture" "deployment" "faq" "features" "frontend-ui" "getting-started" "monitoring" "operator" "performance-tuning" "sampling" "security" "troubleshooting" "windows" -}}
-{{ range $v2Pages }}
+{{/* Get all sections and pages directly under v2/_dev */}}
+{{ $pages := slice -}}
+{{ with site.GetPage (printf "/docs/%s" $latest) -}}
+  {{ $docDir := path.Dir .File.Path -}}
+  {{ range (union .RegularPagesRecursive .Sections) -}}
+    {{ $dir := strings.TrimPrefix (add $docDir "/") (path.Dir .File.Path) -}}
+    {{ $entry := strings.TrimSuffix ".md" (path.Base .File.Path) -}}
+    {{ $pages = $pages | append (cond (ne $entry "_index") $entry $dir) -}}
+  {{ end }}
+{{ end -}}
+{{ $pages = $pages | uniq | sort -}}
+
+{{ range $pages }}
 /docs/{{ . }}     /docs/{{ $latest }}/{{ . }}
 {{ end -}}
 
 {{/* Generic redirect rule generation */ -}}
 
-{{ partial "redirects/pages.txt" . | partial "func/trim-lines.html" -}}
+{{ partial "redirects/pages.txt" . }}
+{{ partial "redirects/redirect.txt" . }}

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -1,5 +1,39 @@
 {{/* Netlify redirects. See https://www.netlify.com/docs/redirects/ */ -}}
 
+{{/*
+
+This section is for redirect rules that are order dependent, and must come
+before other rules:
+
+*/ -}}
+
+{{/* No order-dependent rules at the moment */ -}}
+
+{{/*
+
+All other site redirect rules will get formatted and sorted so make it easier to
+detect duplicates and other errors.
+
+*/ -}}
+
 {{ $redirects := partial "redirects.txt" . -}}
-{{ $lines := split $redirects "\n" | complement (slice "") | sort -}}
-{{ delimit $lines "\n" }}
+{{ $rawLines := split $redirects "\n" | complement (slice "") -}}
+{{ $lines := slice -}}
+{{ $prevRedirectRule := "" -}}
+{{ range $line := $rawLines -}}
+  {{ $matches := findRESubmatch `^\s*(\S+)\s+(.+)\s*$` (trim $line " \t") -}}
+  {{ with index $matches 0 -}}
+    {{ $fromURL := index . 1 -}}
+    {{ $toURLwithOptionalModifiers := index . 2 -}}
+    {{ $redirectRule := printf "%-35s %s" $fromURL $toURLwithOptionalModifiers -}}
+    {{ if eq $prevRedirectRule $redirectRule -}}
+      {{ warnf "Duplicate redirect rule: %s" $redirectRule -}}
+    {{ end -}}
+    {{ $lines = $lines | append $redirectRule -}}
+    {{ $prevRedirectRule = $redirectRule -}}
+  {{ else -}}
+    {{ errorf "Redirect rule with unexpected format: %s" $line -}}
+  {{ end -}}
+{{ end -}}
+
+{{ delimit (sort $lines) "\n" }}


### PR DESCRIPTION
- Contributes to:
  - #928
  - #929
- Fixes the following redirects:
  - `/docs/operator` -> `/docs/1.69/operator`, rather than 2.6
  - `/docs/client-features` -> `/docs/1.63/client-libraries/client-features/`
  - `/docs/client-libraries` -> `/docs/1.63/client-libraries/`
  - `/docs/opentelemetry` -> `/docs/1.21/deployment/opentelemetry/`
- Replaces hardcoded `$v2Pages` list by dynamically computed list of (recursive) pages under `v2/_dev`
- Adds code to prettify and sort redirect rules. This makes it easier to review for changes and duplicates
