### PR TITLE
[CI] Consolidate build-related files

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -9,7 +9,7 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  build-and-check-links:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -17,37 +17,8 @@ jobs:
     - uses: actions/setup-node@v4
       with: { node-version-file: .nvmrc }
     - run: npm install
-
-    - name: ✨ Setup Hugo
-      env:
-        # should match one from netlify.toml
-        HUGO_VERSION: 0.147.6
-      run: |
-        mkdir ~/hugo
-        cd ~/hugo
-        curl -L "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz" --output hugo.tar.gz
-        tar -xvzf hugo.tar.gz
-        sudo mv hugo /usr/local/bin
-        hugo version
-
-    - name: Build
-      run: |
-        make build
-
-    - name: Setup Go to install htmltest
-      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-      with:
-        go-version: 1.24.x
-
-    - name: Install htmltest
-      run: |
-        go install github.com/wjdp/htmltest@latest
-
-    - name: Strict link checking for newer versions
-      run: make check-links
-
-    - name: Relaxed link checking for older versions
-      run: make check-links-older
+    - name: Build and check links
+      run: npm run check:links:all # command also builds the site
 
   spellcheck:
     runs-on: ubuntu-latest
@@ -56,9 +27,7 @@ jobs:
     - uses: actions/setup-node@v4
       with: { node-version-file: .nvmrc }
     - run: npm install
-    - name: Spellcheck
-      run: |
-        make spellcheck
+    - run: npm run check:spelling
 
   block-pr-from-main-branch:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ endif
 # generate currently doesn't do anything, but can be useful in the future.
 generate:
 
+develop: generate
+	npm run serve
 
 clean:
 	rm -rf $(HTMLTEST_DIR) public/* resources

--- a/README.md
+++ b/README.md
@@ -2,34 +2,30 @@
 
 # Jaeger website
 
-This repo houses all the assets used to build the Jaeger website, available at https://jaegertracing.io.
+This repo houses all the assets used to build the Jaeger website, available at <https://jaegertracing.io>.
 
 The site is built with [Hugo](https://gohugo.io/) and hosted by [Netlify](https://www.netlify.com/).
 
 ## Setup
 
-Install the "extended" Hugo binary from [hugo/releases](https://github.com/gohugoio/hugo/releases) (use one of the `hugo_extended_*` binaries) or
-use a package manager if it is available for your operating system.
-
->  The "extended" version of Hugo supports [Sass](https://sass-lang.org), which is necessary to build the site locally.
-
-The currently used version of Hugo is defined in the [`netlify.toml`](./netlify.toml) configuration file.
-
-Install the active LTS version of Node.js, then run the following command from the directory of this repo's clone:
+Install the active LTS version of Node.js, then run the following command from
+the directory of this repo's clone:
 
 ```bash
 npm install
 ```
+
+This will also install the required version of Hugo.
 
 ## Running the site locally
 
 If you want to develop the site locally, you can run a single command (assuming that you've run the [setup](#setup)):
 
 ```bash
-make develop
+npm run serve
 ```
 
-This will start up a local server on localhost port 1313. When you make changes to either the content of the website (in [`content`](content)) *or* to the Sass and JavaScript assets of the page (in [`themes/jaeger-docs/assets`](themes/jaeger-docs/assets)), the browser will automatically update to reflect those changes (usually in under one second).
+This will start up a local server on [localhost:1313](http://localhost:1313). When you make changes to either the content of the website (in [`content`](content)) *or* to the Sass and JavaScript assets of the page (in [`themes/jaeger-docs/assets`](themes/jaeger-docs/assets)), the browser will automatically update to reflect those changes (usually in under one second).
 
 ## Publishing the site
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,12 @@ This will also install the required version of Hugo.
 If you want to develop the site locally, you can run a single command (assuming that you've run the [setup](#setup)):
 
 ```bash
-npm run serve
+make develop
 ```
 
-This will start up a local server on [localhost:1313](http://localhost:1313). When you make changes to either the content of the website (in [`content`](content)) *or* to the Sass and JavaScript assets of the page (in [`themes/jaeger-docs/assets`](themes/jaeger-docs/assets)), the browser will automatically update to reflect those changes (usually in under one second).
+Alternatively, you can run `npm run serve`.
+
+These commands will start up a local server on [localhost:1313](http://localhost:1313). When you make changes to either the content of the website (in [`content`](content)) *or* to the Sass and JavaScript assets of the page (in [`themes/jaeger-docs/assets`](themes/jaeger-docs/assets)), the browser will automatically update to reflect those changes (usually in under one second).
 
 ## Publishing the site
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,13 +1,6 @@
 [build]
 publish = "public"
-command = "make netlify-production-build"
+command = "npm run build:preview"
 
-[build.environment]
-# should match one from .github/workflows/ci-test.yml
-HUGO_VERSION = "0.147.6"
-
-[context.deploy-preview]
-command = "make netlify-deploy-preview"
-
-[context.branch-deploy]
-command = "make netlify-branch-deploy"
+[context.production]
+command = "npm run build:production"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "_diff:check": "git diff --name-only --exit-code",
     "_filename-error": "echo 'ERROR: the following files violate naming conventions; fix using: `npm run fix:filenames`'; echo; npm run -s _ls-bad-filenames; exit 1",
     "_filenames-to-kebab-case": "find assets content -name '*_*' ! -name '[_.]*' -exec sh -c 'mv \"$1\" \"${1//_/-}\"' _ {} \\;",
-    "_hugo-dev": "npm run _hugo -- -e dev -DFE",
+    "_hugo-dev": "npm run _hugo -- -e dev -DFE --logLevel info",
     "_hugo": "set -x; hugo --cleanDestinationDir --config hugo.yaml,hugo.${WKSP-pre-docsy}.yaml",
     "_ls-bad-filenames": "find assets content -name '*_*' ! -name '[_.]*'",
     "_serve": "npm run _hugo-dev -- serve --minify --disableFastRender --renderToMemory",
@@ -22,19 +22,18 @@
     "check:links:all": "npm run _check:links:all",
     "check:links:internal": "HTMLTEST_ARGS='--skip-external' npm run _check:links",
     "check:links": "npm run _check:links",
-    "check:spelling": "npx --no-install cspell --no-progress -c .cspell.yml content 'layouts/**/*.md'",
-    "clean": "rm -Rf public/",
+    "check:spelling": "make _spellcheck",
+    "clean": "make clean",
     "diff:check": "npm run _diff:check || (echo; echo 'WARNING: the files above have not been committed'; echo)",
     "fix:filenames": "npm run _filenames-to-kebab-case",
     "fix:format": "npm run _check:format -- --write",
     "make:public": "git init public",
     "precheck:links:all": "npm run build",
     "precheck:links": "npm run build",
-    "precheck:spelling": "make .cspell/project-names.g.txt",
     "seq": "bash -c 'for cmd in \"$@\"; do npm run $cmd || exit 1; done' - ",
     "serve": "npm run _serve --",
     "test": "npm run check:format && npm run check:links:all",
-    "update:pkgs": "npx npm-check-updates -u"
+    "update:pkgs": "npx npm-check-updates -u '!bulma*'"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.21",
@@ -48,6 +47,7 @@
     "bulma-tooltip": "2.0.2"
   },
   "peerDependencies": {
+    "hugo-extended": "0.147.6",
     "netlify-cli": "^21.5.0",
     "npm-check-updates": "^18.0.1"
   },

--- a/scripts/spellcheck.sh
+++ b/scripts/spellcheck.sh
@@ -11,7 +11,8 @@ if ! sort -c --ignore-case "$PROJ_WORDS"; then
     exit 1
 fi
 
-npm run check:spelling
+npx --no-install cspell --no-progress -c .cspell.yml content 'layouts/**/*.md'
+
 if [ $? -ne 0 ]; then
     echo "Misspelling(s) found."
     exit 1

--- a/themes/jaeger-docs/layouts/partials/navbar.html
+++ b/themes/jaeger-docs/layouts/partials/navbar.html
@@ -9,7 +9,7 @@
 {{ $latestV2      := site.Params.latestV2 -}}
 {{ $docs          := where site.Pages "Section" "docs" -}}
 {{ $isDocsPage    := eq .Section "docs" -}}
-{{ $isPreview     := eq (getenv "HUGO_PREVIEW") "true" -}}
+{{ $isPreview     := not hugo.IsProduction -}}
 {{ $path := "" -}}
 {{ with .File -}}
   {{ $path = .Path -}}


### PR DESCRIPTION
- Fixes #921
- Makes the NPM scripts the primary method used to run build & CI commands. The makefile is still there, but plays a supporting role.
- Adds `hugo-extended` package as a means of getting the version of Hugo that the project needs. This greatly simplifies the ci-test.yml workflow
- FYI: this will also simplify the Docsy-based build, which will only require `WKSP=docsy`. The CI scripts remain the same.