### PR TITLE
getting-started.md - the compose file is no longer called `-v2`

### DIFF
--- a/content/docs/v2/2.3/getting-started.md
+++ b/content/docs/v2/2.3/getting-started.md
@@ -59,7 +59,7 @@ We recommend running Jaeger and HotROD together via `docker compose`:
 ```bash
 git clone https://github.com/jaegertracing/jaeger.git jaeger
 cd jaeger/examples/hotrod
-docker compose -f docker-compose-v2.yml up
+docker compose up
 # press Ctrl-C to exit
 ```
 

--- a/content/docs/v2/2.4/getting-started.md
+++ b/content/docs/v2/2.4/getting-started.md
@@ -59,7 +59,7 @@ We recommend running Jaeger and HotROD together via `docker compose`:
 ```bash
 git clone https://github.com/jaegertracing/jaeger.git jaeger
 cd jaeger/examples/hotrod
-docker compose -f docker-compose-v2.yml up
+docker compose up
 # press Ctrl-C to exit
 ```
 

--- a/content/docs/v2/2.5/getting-started.md
+++ b/content/docs/v2/2.5/getting-started.md
@@ -59,7 +59,7 @@ We recommend running Jaeger and HotROD together via `docker compose`:
 ```bash
 git clone https://github.com/jaegertracing/jaeger.git jaeger
 cd jaeger/examples/hotrod
-docker compose -f docker-compose-v2.yml up
+docker compose up
 # press Ctrl-C to exit
 ```
 

--- a/content/docs/v2/2.6/getting-started.md
+++ b/content/docs/v2/2.6/getting-started.md
@@ -59,7 +59,7 @@ We recommend running Jaeger and HotROD together via `docker compose`:
 ```bash
 git clone https://github.com/jaegertracing/jaeger.git jaeger
 cd jaeger/examples/hotrod
-docker compose -f docker-compose-v2.yml up
+docker compose -f docker-compose.yml up
 # press Ctrl-C to exit
 ```
 

--- a/content/docs/v2/2.6/getting-started.md
+++ b/content/docs/v2/2.6/getting-started.md
@@ -59,7 +59,7 @@ We recommend running Jaeger and HotROD together via `docker compose`:
 ```bash
 git clone https://github.com/jaegertracing/jaeger.git jaeger
 cd jaeger/examples/hotrod
-docker compose -f docker-compose.yml up
+docker compose up
 # press Ctrl-C to exit
 ```
 


### PR DESCRIPTION
The documentation says run `docker compose -f docker-compose-v2.yml up`, but now there is no `v2` in the compose file's name

Honestly, I did not run the tests :)