### PR TITLE
docs: clarify tag search behavior in Jaeger UI (fixes jaegertracing/jaeger#7333)

### DIFF
--- a/content/docs/v1/1.71/deployment/frontend-ui.md
+++ b/content/docs/v1/1.71/deployment/frontend-ui.md
@@ -186,6 +186,12 @@ Arguments:
 
 Example: `#{startTime | add 1000000}`
 
+## Tag Search Behavior
+
+Jaeger UI indexes and allows searching for tags/attributes only if their values are strings. If a tag is set as an array (e.g., `["value"]`), it will not be searchable in the UI. This is important for users who want to search for specific tags, such as request IDs, in the Jaeger UI.
+
+When instrumenting your application, ensure that important tags (such as request IDs) are set as string values, not arrays. For example, when using OpenTelemetry SDKs, avoid configurations that result in array values for tags you wish to search. This behavior is discussed in [issue #7333](https://github.com/jaegertracing/jaeger/issues/7333).
+
 ## Embedded Mode
 
 Starting with version 1.9, Jaeger UI provides an "embedded" layout mode which is intended to support integrating Jaeger UI into other applications. Currently (as of `v0`), the approach taken is to remove various UI elements from the page to make the UI better suited for space-constrained layouts.


### PR DESCRIPTION
>Which problem is this PR solving?
Resolves jaegertracing/jaeger#7333
Users were confused about which tags are searchable in the Jaeger UI, especially when tags are set as arrays (e.g., by some OpenTelemetry SDK configurations). The documentation did not clearly state that only string-valued tags are indexed and searchable.

>Description of the changes
-Adds a new section "Tag Search Behavior" to the Jaeger UI documentation.
-Clearly explains that only string-valued tags are indexed and searchable in the UI, and that array-valued tags are not.
-Advises users to ensure important tags (such as request IDs) are set as strings, not arrays, when instrumenting their applications.
-References the related GitHub issue for context.

>How was this change tested?
-This is a documentation-only change. The content and formatting were reviewed for clarity and correctness.
-No code, UI, or test changes were required.

>Checklist
[x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
[x] I have signed all commits
[n/a] I have added unit tests for the new functionality (documentation-only)
[n/a] I have run lint and test steps successfully (documentation-only)
