### PR TITLE
Recover custom code-highlighting styles of the jaeger-docs theme

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -5,8 +5,6 @@ title: Jaeger
 disableKinds: [taxonomy]
 theme: [basetheme, jaeger-docs]
 disableAliases: true # We do redirects via Netlify's _redirects file
-pygmentsCodeFences: true
-pygmentsUseClasses: true
 
 #
 # Language settings
@@ -33,6 +31,10 @@ outputFormats:
 
 outputs:
   home: [HTML, JSON, REDIRECTS]
+
+markup:
+  highlight:
+    noClasses: false
 
 params:
   tagline: Monitor and troubleshoot workflows in complex distributed systems


### PR DESCRIPTION
- Fixes #982
- The current `jaeger-docs` theme has custom Chroma-compatible style definitions (see https://github.com/jaegertracing/documentation/blob/main/themes/jaeger-docs/assets/sass/syntax.sass). This PR sets `noClasses: false` so that those classes can be used once again. (I'm not sure why classes were being used before, despite the absence of this setting. It must be a change in behavior of Hugo.)
- Followup to #980

### Before

See https://www.jaegertracing.io/docs/2.11/architecture/sampling/#file-based-sampling-configuration (or https://deploy-preview-980--jaegertracing.netlify.app/docs/2.11/architecture/sampling/#file-based-sampling-configuration):

> <img width="555" height="295" alt="image" src="https://github.com/user-attachments/assets/f986a7a3-4295-459a-b342-bee32973020c" />

### After

See https://deploy-preview-983--jaegertracing.netlify.app/docs/2.11/architecture/sampling/#file-based-sampling-configuration, the preview for this PR

> <img width="555" height="293" alt="image" src="https://github.com/user-attachments/assets/a7448b98-4cd9-4b3a-9bdb-51ee47603220" />

This matches what it was before #980.

> [!NOTE]
> The official Jaeger Netlify account has built this PR successfully:
> 
> <img width="539" height="71" alt="image" src="https://github.com/user-attachments/assets/e07d298c-e685-44d7-ac08-859a0421af50" />
