### PR TITLE
Upgrade Docsy to eliminate peer dependency failures with hugo-extended

### DIFF
--- a/content/docs/v1/1.70/_index.md
+++ b/content/docs/v1/1.70/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-linkTitle: 1.70
+linkTitle: '1.70'
 weight: -170
 children:
 - title: Features

--- a/content/docs/v2/2.10/_index.md
+++ b/content/docs/v2/2.10/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-linkTitle: 2.10
+linkTitle: '2.10'
 weight: -210
 children:
 - title: Getting Started

--- a/hugo.dev.yaml
+++ b/hugo.dev.yaml
@@ -4,6 +4,6 @@ ignoreFiles:
   # Ignore all v1 versions except 1.74 and _dev
   - 'content/docs/v1/1\.([6-9]|[1-6]\d|7[0-3])/'
 
-  # Ignore all v2 versions except 2.11 and _dev
-  - 'content/docs/v2/2\.(\d|10)/'
+  # Ignore all v2 versions except for 2.10, 2.11, and _dev
+  - 'content/docs/v2/2\.(\d)/'
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "autoprefixer": "^10.4.21",
     "cspell": "^9.2.1",
-    "docsy": "github:google/docsy#d57e6a8d4e03e870be8e451e9a6c88d04b0f5513",
+    "docsy": "github:google/docsy#945745aaa2f8138ffef9f057261fe5f5f855af87",
     "postcss-cli": "^11.0.1",
     "prettier": "^3.6.2"
   },


### PR DESCRIPTION
- Upgrades Docsy. As of this version, we should no longer see peer dependency failures, like we saw before in #949
- Fixes `linkTitles` containing version IDs that end with 0. Such entries must be strings (and hence quoted). Otherwise, they're interpreted as a YAML number and the trailing 0s are dropped.