### PR TITLE
Move all mentorship pages into Mentorship section, and other docsy prep

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,3 +1,9 @@
 ---
 title: 'Jaeger: open source, distributed tracing platform'
+linkTitle: Jaeger
+description: Monitor and troubleshoot workflows in complex distributed systems
+show_banner: true
+cSpell:ignore: Dosu
+# cascade: { type: docs }
+type: home
 ---

--- a/content/mentorship/_index.md
+++ b/content/mentorship/_index.md
@@ -5,8 +5,8 @@ title: Mentorships
 The Jaeger project regularly participates in mentorship programs via CNCF, such as [Outreachy](https://www.outreachy.org/), [Google Summer of Code](https://summerofcode.withgoogle.com/), and [LFX Mentorship](https://mentorship.lfx.linuxfoundation.org/). As a mentee, you will have the opportunity to contribute to an open-source project while working under the guidance of an experienced mentor who is an active contributor to the project and open-source community. The mentees receive an internship stipend.
 
 See also:
-  * [For mentees](../mentorship-for-mentees/)
-  * [For mentors](../mentorship-for-mentors/)
+  * [For mentees](for-mentees/)
+  * [For mentors](for-mentors/)
 
 ## LFX Mentorship September-November 2025 (Term 3)
 

--- a/content/mentorship/for-mentees.md
+++ b/content/mentorship/for-mentees.md
@@ -1,5 +1,7 @@
 ---
 title: Mentorship - For Mentees
+linkTitle: For Mentees
+aliases: [/mentorship-for-mentees]
 ---
 
 ## Application process
@@ -32,7 +34,7 @@ If you need to ask specific questions / clarifications about the project, please
 
 ### Bootcamp
 
-In order to understand the project better and come up with reasonable solutions, it's always helpful to become familiar with Jaeger and its code base. We strongly recommend going through the [Bootcamp](../get-involved/#bootcamp).
+In order to understand the project better and come up with reasonable solutions, it's always helpful to become familiar with Jaeger and its code base. We strongly recommend going through the [Bootcamp](../../get-involved/#bootcamp).
 
 ### Evaluation criteria
 
@@ -109,7 +111,7 @@ Why the log is important:
   your approach will work in the end. A basic proof of concept provides assurance of the final outcome,
   can help highlight the sub-problems to tackle individually, while also giving you a chance
   to explore the various alternative solutions and identify the best option.
-- You are welcome to join the [monthly Jaeger video calls](../get-in-touch/).
+- You are welcome to join the [monthly Jaeger video calls](../../get-in-touch/).
 - Write unit tests and, if applicable, run live integration tests locally. Tests give assurance
   to yourself that what you’ve written works, documents the expected behavior to readers of the code,
   and prevents regressions from future contributions.

--- a/content/mentorship/for-mentors.md
+++ b/content/mentorship/for-mentors.md
@@ -1,5 +1,7 @@
 ---
 title: Mentorship - For Mentors
+linkTitle: For Mentors
+aliases: [/mentorship-for-mentors]
 ---
 
 ## Retrospective

--- a/hugo.docsy.yaml
+++ b/hugo.docsy.yaml
@@ -73,10 +73,13 @@ params:
 menu:
   main:
     - name: Docs
-      url: /docs/ # Eventually /docs/latest/
+      url: /docs/2.11/ # TODO: eventually /docs/{{% param latestV2 %}}/ or /docs/latest/
       weight: -10
     - name: Blog
       url: https://medium.com/jaegertracing/latest
+      post:
+        <sup><i class="ps-1 fa-solid fa-up-right-from-square fa-xs"
+        aria-hidden="true"></i></sup>
     - name: Download
       pageRef: /download/
 

--- a/layouts/_shortcodes/doc_versions.md
+++ b/layouts/_shortcodes/doc_versions.md
@@ -1,0 +1,13 @@
+{{/*
+  Shortcode: versions
+  Usage:
+*/}}
+
+{{ $versions := .Page.Pages -}}
+
+{{ range $versions -}}
+  {{ if not .IsSection -}}
+    {{ continue -}}
+  {{ end -}}
+- [{{ .Params.linkTitle }}]({{ .RelPermalink }})
+{{ end -}}

--- a/package.json
+++ b/package.json
@@ -30,13 +30,15 @@
     "diff:check": "npm run _diff:check || (echo; echo 'WARNING: the files above have not been committed'; echo)",
     "fix:filenames": "npm run _filenames-to-kebab-case",
     "fix:format": "npm run _check:format -- --write",
+    "fix": "npm run fix:format && npm run fix:filenames",
     "make:public": "git init public",
     "precheck:links:all": "npm run build",
     "precheck:links": "npm run build",
     "seq": "bash -c 'for cmd in \"$@\"; do npm run $cmd || exit 1; done' - ",
     "serve:docsy": "WKSP=\"dev.yaml,hugo.docsy\" npm run _serve --",
     "serve": "npm run _serve --",
-    "test": "npm run check:format && npm run check:links:all",
+    "test:only": "npm run check:format && npm run check:links:all",
+    "test": "echo 'RUNNING fix AND test ...'; npm run fix && npm run test:only",
     "update:packages": "npx npm-check-updates -u --dep 'prod,dev,optional,peer' '!bulma*'"
   },
   "devDependencies": {

--- a/themes/jaeger-docs/layouts/_default/section.html
+++ b/themes/jaeger-docs/layouts/_default/section.html
@@ -1,0 +1,17 @@
+{{ define "main" }}
+<article class="article article--docs">
+  <div class="container">
+    <header>
+      <p class="title is-1">
+        {{ .Title }}
+      </p>
+    </header>
+
+    <hr class="hr" />
+
+    <section class="content content--docs is-medium">
+      {{ .Content }}
+    </section>
+  </div>
+</article>
+{{ end }}

--- a/themes/jaeger-docs/layouts/partials/navbar.html
+++ b/themes/jaeger-docs/layouts/partials/navbar.html
@@ -135,8 +135,8 @@
             <a class="navbar-item" href="/get-involved/">Get involved</a>
             <a class="navbar-item" href="/get-in-touch/">Get in touch</a>
             <a class="navbar-item" href="/mentorship/">Mentorships</a>
-            <a class="navbar-item" href="/mentorship-for-mentees/">Mentorships - For Mentees</a>
-            <a class="navbar-item" href="/mentorship-for-mentors/">Mentorships - For Mentors</a>
+            <a class="navbar-item" href="/mentorship/for-mentees/">Mentorships - For Mentees</a>
+            <a class="navbar-item" href="/mentorship/for-mentors/">Mentorships - For Mentors</a>
             <a class="navbar-item" href="/news/">News</a>
             <a class="navbar-item" href="/roadmap/">Roadmap</a>
             <a class="navbar-item" href="https://github.com/cncf/artwork/tree/master/projects/jaeger">Branding</a>


### PR DESCRIPTION
- Contributes to #746 by doing some prep work.
- Relocates all mentoring pages, placing them under the `/mentoring/` section (that already exists)
- Adds aliases so that the old paths will redirect to the new page locations
- Adds a few other Docsy related config and shortcodes

The only change introduced by this PR is the relocation of the mentorship pages:

```console
$ (cd public && git diff -bw --ignore-blank-lines -I "build-timestamp|mentorship.for-m" -- ':(exclude)*.xml' ':(exclude)*.(map|js)') | grep ^diff | head
diff --git a/docs/index.html b/docs/index.html
diff --git a/mentorship-for-mentees/index.html b/mentorship-for-mentees/index.html
diff --git a/mentorship-for-mentors/index.html b/mentorship-for-mentors/index.html
diff --git a/mentorship/index.html b/mentorship/index.html
```

The change `/docs/index.html` can be ignored since it's impossible to reach that page in the current site config (that page redirects to the current version's doc landing page.)

**Previews**:

- https://deploy-preview-998--jaegertracing.netlify.app/mentorship/
- https://deploy-preview-998--jaegertracing.netlify.app/mentorship/for-mentees/
- https://deploy-preview-998--jaegertracing.netlify.app/mentorship/for-mentors/

**Redirect tests**:

- https://deploy-preview-998--jaegertracing.netlify.app/mentorship-for-mentees/
- https://deploy-preview-998--jaegertracing.netlify.app/mentorship-for-mentors/