### PR TITLE
[docsy] Fix cli/tools-list, and add render-link hook

### DIFF
--- a/assets/scss/_external_link.scss
+++ b/assets/scss/_external_link.scss
@@ -1,0 +1,39 @@
+// This is a copy of the external-link icon from OTel.io:
+// https://github.com/chalin/opentelemetry.io/blob/cce8d540c134889f08703c464b79c54924a2e90f/assets/scss/_external_link.scss
+//
+// External-link icon after an external link
+//
+// To ensure that the external-link icon word-wraps along with the preceding
+// word, rather than by itself, we (1) start content with $nbsp, and (2) ensure
+// that `display` is 'inline'.
+//
+// For a discussion concerning this topic, see
+// https://stackoverflow.com/questions/16100956/prevent-after-element-from-wrapping-to-next-line.
+
+$nbsp: \00A0;
+
+@mixin external-link-icon() {
+  @extend .fas;
+  display: inline;
+  @include font-size(60%);
+  opacity: 0.8;
+  vertical-align: text-top;
+  content: fa-content($nbsp + $fa-var-external-link-alt);
+}
+
+.td-sidebar-nav a[target='_blank']:after,
+a.external-link:after {
+  @include external-link-icon();
+}
+
+.td-footer a.external-link:after {
+  display: none !important;
+}
+
+// Can't quite use this yet since (1) breadcrumbs currently use external links,
+// (2) we can't currently easily turn this off for footer icons.
+//
+// a[href^="http://"]:not(.btn):not(.external-link):after,
+// a[href^="https://"]:not(.btn):not(.external-link):after {
+//   @include external-link-icon();
+// }

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1,5 +1,6 @@
-@import 'td/code-dark';
+@import 'external_link';
 @import 'home';
+@import 'td/code-dark';
 
 $navbar-brand-size: 52px;
 $navbar-brand-base: 38px;

--- a/themes/basetheme/layouts/shortcodes/cli/tools-list.html
+++ b/themes/basetheme/layouts/shortcodes/cli/tools-list.html
@@ -1,4 +1,7 @@
 {{ $versionFromPath := index (split .Page.RelPermalink "/") 2 }}
+{{ if hasSuffix $versionFromPath "dev" -}}
+  {{ $versionFromPath = "next-release" -}}
+{{ end -}}
 {{ $isNextRelease := eq $versionFromPath "next-release" }}
 {{ $version := cond ($isNextRelease) site.Params.latest $versionFromPath }}
 {{ $data    := index site.Data.cli $version }}

--- a/themes/docsy-overrides/layouts/_markup/render-link.html
+++ b/themes/docsy-overrides/layouts/_markup/render-link.html
@@ -1,0 +1,13 @@
+{{ $dest := .Destination -}}
+{{ $isExternal := hasPrefix $dest "http" -}}
+
+<a href="{{ $dest | safeURL }}"
+  {{- with .Title}} title="{{ . }}"{{ end -}}
+  {{- if $isExternal }} target="_blank" rel="noopener"
+    {{- $noExternalIcon := in .Text "hk-no-external-icon" -}}
+    {{ if not $noExternalIcon }} class="external-link"{{ end -}}
+  {{ end -}}
+>
+  {{- .Text | safeHTML -}}
+</a>
+{{- /**/ -}}


### PR DESCRIPTION
- Contributes to #746
- Updates `cli/tools-list` to recognize `1.dev` version
- Adds render-link hook for use under Docsy. It adds an icon to external links, similar to the current site
- With these changes, all link checking passes for the Docsy-based site

No change to the generated site files, other than the timestamp:

```console
$ (cd public && git diff -bw --ignore-blank-lines -- ':(exclude)*.xml')             
diff --git a/index.html b/index.html
index 70ba49269..94d4a6432 100644
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 
 
 <meta charset="utf-8" />
-<meta name="build-timestamp" content="2025-11-08 13:54 EST" />
+<meta name="build-timestamp" content="2025-11-08 17:14 EST" />
 <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
 
 <meta name="description" content="Monitor and troubleshoot workflows in complex distributed systems" />
```