### PR TITLE
[docsy/cleanup] Add code-block lang ID, add admonition

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ of the [Apache License](LICENSE).
 If you are adding a new file it should have a header like below.  The easiest
 way to add such header is to run `make fmt`.
 
-```
+```go
 // Copyright (c) 2018 The Jaeger Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -73,7 +73,7 @@ pass it on as an open-source patch.  The rules are pretty simple: if you
 can certify the below (from
 [developercertificate.org](http://developercertificate.org/)):
 
-```
+```text
 Developer Certificate of Origin
 Version 1.1
 
@@ -127,7 +127,7 @@ git config --global user.email "MY_NAME@example.com"
 
 If you want signing to be automatic you can set up some aliases:
 
-```
+```shell
 git config --add alias.amend "commit -s --amend"
 git config --add alias.c "commit -s"
 ```

--- a/content/docs/v1/1.74/architecture/apis.md
+++ b/content/docs/v1/1.74/architecture/apis.md
@@ -44,7 +44,7 @@ Since Jaeger v1.11, the official protocol between user applications and **jaeger
 
 The payload in [jaeger.thrift] format can be submitted in an HTTP POST request to the  `/api/traces` endpoint, for example, `https://jaeger-collector:14268/api/traces`. The `Batch` struct needs to be encoded using Thrift's `binary` encoding, and the HTTP request should specify the content type header:
 
-```
+```http
 Content-Type: application/vnd.apache.thrift.binary
 ```
 

--- a/content/docs/v1/1.74/deployment/_index.md
+++ b/content/docs/v1/1.74/deployment/_index.md
@@ -293,7 +293,7 @@ docker run \
 The schema tool also supports TLS. You need to make a custom cqlshrc file like
 so:
 
-```
+```ini
 # Creating schema in a cassandra cluster requiring client TLS certificates.
 #
 # Create a volume for the schema docker container containing four files:
@@ -460,11 +460,13 @@ For example:
   }
   EOF
   ```
+
 * Run elasticsearch initializer with `ES_USE_ILM=true`:
 
   ```shell
   docker run -it --rm --net=host -e ES_USE_ILM=true jaegertracing/jaeger-es-rollover:latest init http://localhost:9200 # <1>
   ```
+
   <1> If you need to initialize archive storage, add `-e ARCHIVE=true`.
 
   {{< info >}}
@@ -617,6 +619,7 @@ https://promlabs.com/blog/2020/11/26/an-update-on-promql-compatibility-across-ve
 #### Configuration
 
 ##### Minimal
+
 ```sh
 docker run \
   -e METRICS_STORAGE_TYPE=prometheus \
@@ -624,13 +627,16 @@ docker run \
 ```
 
 ##### All options
+
 To view the full list of configuration options, you can run the following command:
+
 ```sh
 docker run \
   -e METRICS_STORAGE_TYPE=prometheus \
   jaegertracing/jaeger-query:{{< currentVersion >}} \
   --help
 ```
+
 #### TLS support
 
 Jaeger supports TLS client to Prometheus server connections as long as you've [configured

--- a/content/docs/v1/1.74/deployment/frontend-ui.md
+++ b/content/docs/v1/1.74/deployment/frontend-ui.md
@@ -194,7 +194,7 @@ The embedded mode is induced and configured via URL query parameters.
 
 To enter embedded mode, the `uiEmbed=v0` query parameter and value must be added to the URL. For example, the following URL will show the trace with ID `abc123` in embedded mode:
 
-```
+```text
 http://localhost:16686/trace/abc123?uiEmbed=v0
 ```
 
@@ -213,7 +213,7 @@ To integrate the Search Trace Page to our application we have to indicate to the
 
 For example:
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -233,7 +233,7 @@ The following query parameter can be used to configure the layout of the search 
 
 * `uiSearchHideGraph=1` - disables the display of the scatter plot above the search results
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -258,6 +258,7 @@ For example:
 ```sh
 http://localhost:16686/trace/{trace-id}?uiEmbed=v0
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view.png)](/img/frontend-ui/embed-trace-view.png)
 
 If we have navigated to this view from the search traces page we'll have a button to go back to the results page.
@@ -270,36 +271,40 @@ The following query parameters can be used to configure the layout of the trace 
 
 * `uiTimelineCollapseTitle=1` causes the trace header to start out collapsed, which hides the summary and the minimap.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineCollapseTitle=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-collapse.png)](/img/frontend-ui/embed-trace-view-with-collapse.png)
 
 * `uiTimelineHideMinimap=1` removes the minimap, entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)
 
 * `uiTimelineHideSummary=1` - removes the trace summary information (number of services, etc.) entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-summary.png)](/img/frontend-ui/embed-trace-view-with-hide-summary.png)
 
 We can also combine the options:
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)

--- a/content/docs/v1/1.74/deployment/operator.md
+++ b/content/docs/v1/1.74/deployment/operator.md
@@ -76,6 +76,7 @@ To install the operator, run:
 kubectl create namespace observability # <1>
 kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/download/v{{< currentVersion >}}/jaeger-operator.yaml -n observability # <2>
 ```
+
 <1> This creates the namespace used by default in the deployment files. If you want to install the Jaeger operator in a different namespace, you must edit the deployment files to change `observability` to the desired namespace value.
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
@@ -105,6 +106,7 @@ oc login -u <privileged user>
 oc new-project observability # <1>
 oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/v{{< currentVersion >}}/jaeger-operator.yaml -n observability # <2>
 ```
+
 <1> This creates the namespace used by default in the deployment files. If you want to install the Jaeger operator in a different namespace, you must edit the deployment files to change `observability` to the desired namespace value.
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
@@ -340,6 +342,7 @@ spec:
       es:
         server-urls: http://elasticsearch:9200
 ```
+
 <1> Identifies the Kafka configuration used by **jaeger-collector** to produce the messages, and by **jaeger-ingester** to consume them.
 
 <2> The deadlock interval is disabled by default (set to 0), to prevent **jaeger-ingester** from being terminated when no messages arrive. It can be configured to specify the number of minutes to wait for a message before terminating.
@@ -459,6 +462,7 @@ spec:
     cassandraCreateSchema:
       enabled: false # <1>
 ```
+
 <1> Defaults to `true`
 
 Further aspects of the batch job can be configured as well. An example with all the possible options is shown below:
@@ -480,6 +484,7 @@ spec:
       datacenter: "datacenter3"
       mode: "test"
 ```
+
 <1> The same works for `production` and `streaming`.
 
 <2> These options are for the regular Jaeger components, like `collector` and `query`.
@@ -575,6 +580,7 @@ spec:
           memory: 4Gi
       redundancyPolicy: ZeroRedundancy # <4>
 ```
+
 <1> Number of Elasticsearch nodes. For high availability use at least 3 nodes. Do not use 2 nodes as "split brain" problem can happen.
 
 <2> Persistent storage configuration. In this case AWS `gp2` with `5Gi` size. When omitted `emptyDir` is used. Elasticsearch operator provisions `PersistentVolumeClaim` and `PersistentVolume` which are not removed with Jaeger instance. The same volumes can be mounted if Jaeger with the same name and namespace is crated. Some storages might fail in `default` namespace because of OpenShift SCC policy.
@@ -782,6 +788,7 @@ spec:
       - name: myapp
         image: acme/myapp:myversion
 ```
+
 <1> Either `"true"` (as string) or the Jaeger instance name.
 
 A complete sample deployment is available at [`deploy/examples/business-application-injected-sidecar.yaml`](https://github.com/jaegertracing/jaeger-operator/blob/main/examples/business-application-injected-sidecar.yaml).
@@ -906,6 +913,7 @@ oc create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/mai
 oc adm policy add-scc-to-user daemonset-with-hostport -z jaeger-agent-daemonset # <3>
 oc apply -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/main/examples/openshift/agent-as-daemonset.yaml # <4>
 ```
+
 <1> The `SecurityContextConstraints` with the `allowHostPorts` policy
 
 <2> The `ServiceAccount` to be used by **jaeger-agent**
@@ -1427,7 +1435,7 @@ spec:
 
 The Jaeger Operator starts a Prometheus-compatible endpoint on `0.0.0.0:8383/metrics` with internal metrics that can be used to monitor the process. Interesting metrics to watch are:
 
-```
+```ini
 # Total number of reconciliations and their outcomes (cumulative)
 controller_runtime_reconcile_total{controller="jaeger-controller",result="error"}
 controller_runtime_reconcile_total{controller="jaeger-controller",result="success"}

--- a/content/docs/v1/1.74/deployment/spm.md
+++ b/content/docs/v1/1.74/deployment/spm.md
@@ -141,7 +141,8 @@ Two metric names will be created:
       `le >= span duration` will be incremented for each span.
 
 The following formula aims to provide some guidance on the number of new time series created:
-```
+
+```go
 num_status_codes * num_span_kinds * (1 + num_latency_buckets) * num_operations
 
 Where:
@@ -151,7 +152,8 @@ Where:
 ```
 
 Plugging those numbers in, assuming default configuration:
-```
+
+```go
 max = 324 * num_operations
 typical = 72 * num_operations
 ```
@@ -321,9 +323,11 @@ If there are error spans appearing in Jaeger, but no corresponding error metrics
   the `status.code` label in the metric that the span should belong to.
 - If there are no `status.code` labels, check the OpenTelemetry Collector
   configuration file, particularly for the presence of the following configuration:
+
   ```yaml
   exclude_dimensions: ['status.code']
   ```
+
   This label is used by Jaeger to determine if a request is erroneous.
 
 ### Inspect the OpenTelemetry Collector

--- a/content/docs/v1/1.74/monitoring.md
+++ b/content/docs/v1/1.74/monitoring.md
@@ -42,6 +42,6 @@ The log level can be adjusted via `--log-level` command line switch; default lev
 
 Jaeger has the ability to trace some of its own components, namely the requests to the Query service. For example, if you start `all-in-one` as described in [Getting Started](../getting-started/), and refresh the UI screen a few times, you will see `jaeger-all-in-one` populated in the Services dropdown. If you prefer not to see these traces in the Jaeger UI, you can disable them by running Jaeger backend components with `OTEL_TRACES_SAMPLER=always_off` environment variable, for example:
 
-```
+```sh
 docker run -e OTEL_TRACES_SAMPLER=always_off -p 16686:16686 jaegertracing/all-in-one:{{< currentVersion >}}
 ```

--- a/content/docs/v1/1.74/troubleshooting.md
+++ b/content/docs/v1/1.74/troubleshooting.md
@@ -24,7 +24,7 @@ OpenTelemetry SDKs can be configured with an exporter that prints recorded spans
 
 If you are using one of the Jaeger SDKs, they default to a probabilistic sampling strategy with `1-in-1000` chance that the trace will be recorded. The strategy can be changed by setting these environment variables:
 
-```
+```sh
 JAEGER_SAMPLER_TYPE=const
 JAEGER_SAMPLER_PARAM=1
 ```
@@ -41,9 +41,9 @@ If you suspect the remote sampling is not working correctly, try these steps:
 
 1. Make sure that the SDK is actually configured to use remote sampling, points to the correct sampling service address (see [APIs](../architecture/apis/#remote-sampling-configuration-stable)), and that address is reachable from your application's [networking namespace](#networking-namespace).
 1. Verify that the server is returning the appropriate sampling strategy for your service:
-```
-    $ curl "jaeger-collector:14268/api/sampling?service=foobar"
-    {"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
+```console
+$ curl "jaeger-collector:14268/api/sampling?service=foobar"
+{"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
 ```
 
 ## Networking Namespace

--- a/content/docs/v1/_dev/architecture/apis.md
+++ b/content/docs/v1/_dev/architecture/apis.md
@@ -44,7 +44,7 @@ Since Jaeger v1.11, the official protocol between user applications and **jaeger
 
 The payload in [jaeger.thrift] format can be submitted in an HTTP POST request to the  `/api/traces` endpoint, for example, `https://jaeger-collector:14268/api/traces`. The `Batch` struct needs to be encoded using Thrift's `binary` encoding, and the HTTP request should specify the content type header:
 
-```
+```http
 Content-Type: application/vnd.apache.thrift.binary
 ```
 

--- a/content/docs/v1/_dev/deployment/_index.md
+++ b/content/docs/v1/_dev/deployment/_index.md
@@ -293,7 +293,7 @@ docker run \
 The schema tool also supports TLS. You need to make a custom cqlshrc file like
 so:
 
-```
+```ini
 # Creating schema in a cassandra cluster requiring client TLS certificates.
 #
 # Create a volume for the schema docker container containing four files:
@@ -460,11 +460,13 @@ For example:
   }
   EOF
   ```
+
 * Run elasticsearch initializer with `ES_USE_ILM=true`:
 
   ```shell
   docker run -it --rm --net=host -e ES_USE_ILM=true jaegertracing/jaeger-es-rollover:latest init http://localhost:9200 # <1>
   ```
+
   <1> If you need to initialize archive storage, add `-e ARCHIVE=true`.
 
   {{< info >}}
@@ -617,6 +619,7 @@ https://promlabs.com/blog/2020/11/26/an-update-on-promql-compatibility-across-ve
 #### Configuration
 
 ##### Minimal
+
 ```sh
 docker run \
   -e METRICS_STORAGE_TYPE=prometheus \
@@ -624,13 +627,16 @@ docker run \
 ```
 
 ##### All options
+
 To view the full list of configuration options, you can run the following command:
+
 ```sh
 docker run \
   -e METRICS_STORAGE_TYPE=prometheus \
   jaegertracing/jaeger-query:{{< currentVersion >}} \
   --help
 ```
+
 #### TLS support
 
 Jaeger supports TLS client to Prometheus server connections as long as you've [configured

--- a/content/docs/v1/_dev/deployment/frontend-ui.md
+++ b/content/docs/v1/_dev/deployment/frontend-ui.md
@@ -194,7 +194,7 @@ The embedded mode is induced and configured via URL query parameters.
 
 To enter embedded mode, the `uiEmbed=v0` query parameter and value must be added to the URL. For example, the following URL will show the trace with ID `abc123` in embedded mode:
 
-```
+```text
 http://localhost:16686/trace/abc123?uiEmbed=v0
 ```
 
@@ -213,7 +213,7 @@ To integrate the Search Trace Page to our application we have to indicate to the
 
 For example:
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -233,7 +233,7 @@ The following query parameter can be used to configure the layout of the search 
 
 * `uiSearchHideGraph=1` - disables the display of the scatter plot above the search results
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -258,6 +258,7 @@ For example:
 ```sh
 http://localhost:16686/trace/{trace-id}?uiEmbed=v0
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view.png)](/img/frontend-ui/embed-trace-view.png)
 
 If we have navigated to this view from the search traces page we'll have a button to go back to the results page.
@@ -270,36 +271,40 @@ The following query parameters can be used to configure the layout of the trace 
 
 * `uiTimelineCollapseTitle=1` causes the trace header to start out collapsed, which hides the summary and the minimap.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineCollapseTitle=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-collapse.png)](/img/frontend-ui/embed-trace-view-with-collapse.png)
 
 * `uiTimelineHideMinimap=1` removes the minimap, entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)
 
 * `uiTimelineHideSummary=1` - removes the trace summary information (number of services, etc.) entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-summary.png)](/img/frontend-ui/embed-trace-view-with-hide-summary.png)
 
 We can also combine the options:
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)

--- a/content/docs/v1/_dev/deployment/operator.md
+++ b/content/docs/v1/_dev/deployment/operator.md
@@ -76,6 +76,7 @@ To install the operator, run:
 kubectl create namespace observability # <1>
 kubectl create -f https://github.com/jaegertracing/jaeger-operator/releases/download/v{{< currentVersion >}}/jaeger-operator.yaml -n observability # <2>
 ```
+
 <1> This creates the namespace used by default in the deployment files. If you want to install the Jaeger operator in a different namespace, you must edit the deployment files to change `observability` to the desired namespace value.
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
@@ -105,6 +106,7 @@ oc login -u <privileged user>
 oc new-project observability # <1>
 oc create -f https://github.com/jaegertracing/jaeger-operator/releases/download/v{{< currentVersion >}}/jaeger-operator.yaml -n observability # <2>
 ```
+
 <1> This creates the namespace used by default in the deployment files. If you want to install the Jaeger operator in a different namespace, you must edit the deployment files to change `observability` to the desired namespace value.
 
 <2> This installs the "Custom Resource Definition" for the `apiVersion: jaegertracing.io/v1`
@@ -340,6 +342,7 @@ spec:
       es:
         server-urls: http://elasticsearch:9200
 ```
+
 <1> Identifies the Kafka configuration used by **jaeger-collector** to produce the messages, and by **jaeger-ingester** to consume them.
 
 <2> The deadlock interval is disabled by default (set to 0), to prevent **jaeger-ingester** from being terminated when no messages arrive. It can be configured to specify the number of minutes to wait for a message before terminating.
@@ -459,6 +462,7 @@ spec:
     cassandraCreateSchema:
       enabled: false # <1>
 ```
+
 <1> Defaults to `true`
 
 Further aspects of the batch job can be configured as well. An example with all the possible options is shown below:
@@ -480,6 +484,7 @@ spec:
       datacenter: "datacenter3"
       mode: "test"
 ```
+
 <1> The same works for `production` and `streaming`.
 
 <2> These options are for the regular Jaeger components, like `collector` and `query`.
@@ -575,6 +580,7 @@ spec:
           memory: 4Gi
       redundancyPolicy: ZeroRedundancy # <4>
 ```
+
 <1> Number of Elasticsearch nodes. For high availability use at least 3 nodes. Do not use 2 nodes as "split brain" problem can happen.
 
 <2> Persistent storage configuration. In this case AWS `gp2` with `5Gi` size. When omitted `emptyDir` is used. Elasticsearch operator provisions `PersistentVolumeClaim` and `PersistentVolume` which are not removed with Jaeger instance. The same volumes can be mounted if Jaeger with the same name and namespace is crated. Some storages might fail in `default` namespace because of OpenShift SCC policy.
@@ -782,6 +788,7 @@ spec:
       - name: myapp
         image: acme/myapp:myversion
 ```
+
 <1> Either `"true"` (as string) or the Jaeger instance name.
 
 A complete sample deployment is available at [`deploy/examples/business-application-injected-sidecar.yaml`](https://github.com/jaegertracing/jaeger-operator/blob/main/examples/business-application-injected-sidecar.yaml).
@@ -906,6 +913,7 @@ oc create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/mai
 oc adm policy add-scc-to-user daemonset-with-hostport -z jaeger-agent-daemonset # <3>
 oc apply -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/main/examples/openshift/agent-as-daemonset.yaml # <4>
 ```
+
 <1> The `SecurityContextConstraints` with the `allowHostPorts` policy
 
 <2> The `ServiceAccount` to be used by **jaeger-agent**
@@ -1427,7 +1435,7 @@ spec:
 
 The Jaeger Operator starts a Prometheus-compatible endpoint on `0.0.0.0:8383/metrics` with internal metrics that can be used to monitor the process. Interesting metrics to watch are:
 
-```
+```ini
 # Total number of reconciliations and their outcomes (cumulative)
 controller_runtime_reconcile_total{controller="jaeger-controller",result="error"}
 controller_runtime_reconcile_total{controller="jaeger-controller",result="success"}

--- a/content/docs/v1/_dev/deployment/spm.md
+++ b/content/docs/v1/_dev/deployment/spm.md
@@ -141,7 +141,8 @@ Two metric names will be created:
       `le >= span duration` will be incremented for each span.
 
 The following formula aims to provide some guidance on the number of new time series created:
-```
+
+```go
 num_status_codes * num_span_kinds * (1 + num_latency_buckets) * num_operations
 
 Where:
@@ -151,7 +152,8 @@ Where:
 ```
 
 Plugging those numbers in, assuming default configuration:
-```
+
+```go
 max = 324 * num_operations
 typical = 72 * num_operations
 ```
@@ -321,9 +323,11 @@ If there are error spans appearing in Jaeger, but no corresponding error metrics
   the `status.code` label in the metric that the span should belong to.
 - If there are no `status.code` labels, check the OpenTelemetry Collector
   configuration file, particularly for the presence of the following configuration:
+
   ```yaml
   exclude_dimensions: ['status.code']
   ```
+
   This label is used by Jaeger to determine if a request is erroneous.
 
 ### Inspect the OpenTelemetry Collector

--- a/content/docs/v1/_dev/monitoring.md
+++ b/content/docs/v1/_dev/monitoring.md
@@ -42,6 +42,6 @@ The log level can be adjusted via `--log-level` command line switch; default lev
 
 Jaeger has the ability to trace some of its own components, namely the requests to the Query service. For example, if you start `all-in-one` as described in [Getting Started](../getting-started/), and refresh the UI screen a few times, you will see `jaeger-all-in-one` populated in the Services dropdown. If you prefer not to see these traces in the Jaeger UI, you can disable them by running Jaeger backend components with `OTEL_TRACES_SAMPLER=always_off` environment variable, for example:
 
-```
+```sh
 docker run -e OTEL_TRACES_SAMPLER=always_off -p 16686:16686 jaegertracing/all-in-one:{{< currentVersion >}}
 ```

--- a/content/docs/v1/_dev/troubleshooting.md
+++ b/content/docs/v1/_dev/troubleshooting.md
@@ -24,7 +24,7 @@ OpenTelemetry SDKs can be configured with an exporter that prints recorded spans
 
 If you are using one of the Jaeger SDKs, they default to a probabilistic sampling strategy with `1-in-1000` chance that the trace will be recorded. The strategy can be changed by setting these environment variables:
 
-```
+```sh
 JAEGER_SAMPLER_TYPE=const
 JAEGER_SAMPLER_PARAM=1
 ```
@@ -41,9 +41,9 @@ If you suspect the remote sampling is not working correctly, try these steps:
 
 1. Make sure that the SDK is actually configured to use remote sampling, points to the correct sampling service address (see [APIs](../architecture/apis/#remote-sampling-configuration-stable)), and that address is reachable from your application's [networking namespace](#networking-namespace).
 1. Verify that the server is returning the appropriate sampling strategy for your service:
-```
-    $ curl "jaeger-collector:14268/api/sampling?service=foobar"
-    {"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
+```console
+$ curl "jaeger-collector:14268/api/sampling?service=foobar"
+{"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
 ```
 
 ## Networking Namespace

--- a/content/docs/v2/2.0/architecture/apis.md
+++ b/content/docs/v2/2.0/architecture/apis.md
@@ -48,11 +48,11 @@ Jaeger can receive trace data in multiple formats on different ports.
 
 ### OpenTelemetry Protocol (stable)
 
-Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats: 
+Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats:
   * binary gRPC
   * Protobuf over HTTP
   * JSON over HTTP
-  
+
 Only tracing data is accepted, since Jaeger does not store other telemetry types. For more details on the OTLP receiver see the [official documentation][otlp-rcvr].
 
 [otlp-rcvr]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md
@@ -66,7 +66,7 @@ Jaeger's legacy Protobuf format is defined in [collector.proto] IDL file. Suppor
 
 Jaeger's legacy Thrift format is defined in [jaeger.thrift] IDL file, and is only maintained for backwards compatibility. The Thrift payload can be submitted in an HTTP POST request to the  `/api/traces` endpoint, for example, `https://jaeger-collector:14268/api/traces`. The `Batch` struct needs to be encoded using Thrift's `binary` encoding, and the HTTP request should specify the content type header:
 
-```
+```http
 Content-Type: application/vnd.apache.thrift.binary
 ```
 

--- a/content/docs/v2/2.0/architecture/spm.md
+++ b/content/docs/v2/2.0/architecture/spm.md
@@ -141,7 +141,8 @@ Two metric names will be created:
       `le >= span duration` will be incremented for each span.
 
 The following formula aims to provide some guidance on the number of new time series created:
-```
+
+```go
 num_status_codes * num_span_kinds * (1 + num_latency_buckets) * num_operations
 
 Where:
@@ -151,7 +152,8 @@ Where:
 ```
 
 Plugging those numbers in, assuming default configuration:
-```
+
+```go
 max = 324 * num_operations
 typical = 72 * num_operations
 ```
@@ -323,9 +325,11 @@ If there are error spans appearing in Jaeger, but no corresponding error metrics
   the `status.code` label in the metric that the span should belong to.
 - If there are no `status.code` labels, check the OpenTelemetry Collector
   configuration file, particularly for the presence of the following configuration:
+
   ```yaml
   exclude_dimensions: ['status.code']
   ```
+
   This label is used by Jaeger to determine if a request is erroneous.
 
 ### Inspect the OpenTelemetry Collector

--- a/content/docs/v2/2.0/deployment/_index.md
+++ b/content/docs/v2/2.0/deployment/_index.md
@@ -35,41 +35,44 @@ Jaeger can be customized via configuration YAML file (see [Configuration](./conf
 **jaeger** is stateless and thus many instances of **jaeger** can be run in parallel. **jaeger** instances require almost no configuration, except for storage location, such as:
 
 Cassandra:
-```
-  jaeger_storage:
-    backends:
-      some_storage:
-        cassandra:
-          schema:
-            keyspace: "jaeger_v1_dc1"
-          connection:
-            auth:
-              basic:
-                username: "cassandra"
-                password: "cassandra"
-            tls:
-              insecure: true
+
+```yaml
+jaeger_storage:
+  backends:
+    some_storage:
+      cassandra:
+        schema:
+          keyspace: "jaeger_v1_dc1"
+        connection:
+          auth:
+            basic:
+              username: "cassandra"
+              password: "cassandra"
+          tls:
+            insecure: true
 ```
 
 OpenSearch:
-```
-  jaeger_storage:
-    backends:
-      some_storage:
-        opensearch:
-          index_prefix: "jaeger-main"
+
+```yaml
+jaeger_storage:
+  backends:
+    some_storage:
+      opensearch:
+        index_prefix: "jaeger-main"
 ```
 
 ElasticSearch:
-```
-  jaeger_storage:
-    backends:
-      some_storage:
-        elasticsearch:
-          index_prefix: "jaeger-main"
-      another_storage:
-        elasticsearch:
-          index_prefix: "jaeger-archive"
+
+```yaml
+jaeger_storage:
+  backends:
+    some_storage:
+      elasticsearch:
+        index_prefix: "jaeger-main"
+    another_storage:
+      elasticsearch:
+        index_prefix: "jaeger-archive"
 ```
 
 ## Query Configuration
@@ -84,7 +87,7 @@ Sometimes these adjustments themselves make the trace hard to understand. For ex
 
 **jaeger** query extension supports configuration in the config file
 
-```
+```yaml
 query:
   max_clock_skew_adjust: 30s
 ```
@@ -95,7 +98,7 @@ query:
 
 The base path for all **jaeger** query extension HTTP routes can be set to a non-root value, e.g. `/jaeger` would cause all UI URLs to start with `/jaeger`. This can be useful when running **jaeger** behind a reverse proxy. Here is example code to set the base path.
 
-```
+```yaml
 query:
   base_path: /
   static-files: /go/bin/jaeger-ui-build/build

--- a/content/docs/v2/2.0/deployment/frontend-ui.md
+++ b/content/docs/v2/2.0/deployment/frontend-ui.md
@@ -155,7 +155,7 @@ The embedded mode is induced and configured via URL query parameters.
 
 To enter embedded mode, the `uiEmbed=v0` query parameter and value must be added to the URL. For example, the following URL will show the trace with ID `abc123` in embedded mode:
 
-```
+```text
 http://localhost:16686/trace/abc123?uiEmbed=v0
 ```
 
@@ -174,7 +174,7 @@ To integrate the Search Trace Page to our application we have to indicate to the
 
 For example:
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -194,7 +194,7 @@ The following query parameter can be used to configure the layout of the search 
 
 * `uiSearchHideGraph=1` - disables the display of the scatter plot above the search results
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -219,6 +219,7 @@ For example:
 ```sh
 http://localhost:16686/trace/{trace-id}?uiEmbed=v0
 ```
+
 ![Embed Trace view](/img/frontend-ui/embed-trace-view.png)
 
 If we have navigated to this view from the search traces page we'll have a button to go back to the results page.
@@ -231,36 +232,40 @@ The following query parameters can be used to configure the layout of the trace 
 
 * `uiTimelineCollapseTitle=1` causes the trace header to start out collapsed, which hides the summary and the minimap.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineCollapseTitle=1
 ```
+
 ![Embed Trace view](/img/frontend-ui/embed-trace-view-with-collapse.png)
 
 * `uiTimelineHideMinimap=1` removes the minimap, entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1
 ```
+
 ![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)
 
 * `uiTimelineHideSummary=1` - removes the trace summary information (number of services, etc.) entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideSummary=1
 ```
+
 ![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-summary.png)
 
 We can also combine the options:
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1&
     uiTimelineHideSummary=1
 ```
+
 ![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)

--- a/content/docs/v2/2.0/getting-started.md
+++ b/content/docs/v2/2.0/getting-started.md
@@ -8,7 +8,7 @@ weight: 1
 
 The easiest way to run Jaeger is by starting a Docker container:
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 5778:5778 \
   -p 16686:16686 \
@@ -41,7 +41,7 @@ Using this application you can:
 - Find sources of latency and lack of concurrency.
 - Explore highly contextualized logging.
 - Use baggage propagation to diagnose inter-request contention (queueing) and time spent in a service.
-- Use open source libraries from `opentelemetry-contrib` to get vendor-neutral instrumentation 
+- Use open source libraries from `opentelemetry-contrib` to get vendor-neutral instrumentation
 for free.
 
 ### Running

--- a/content/docs/v2/2.0/operations/monitoring.md
+++ b/content/docs/v2/2.0/operations/monitoring.md
@@ -44,6 +44,6 @@ The log level can be adjusted via `--log-level` command line switch; default lev
 
 Jaeger has the ability to trace some of its own components, namely the requests to the Query service. For example, if you start `all-in-one` as described in [Getting Started](../../getting-started/), and refresh the UI screen a few times, you will see `jaeger-all-in-one` populated in the Services dropdown. If you prefer not to see these traces in the Jaeger UI, you can disable them by running Jaeger backend components with `OTEL_TRACES_SAMPLER=always_off` environment variable, for example:
 
-```
+```sh
 docker run -e OTEL_TRACES_SAMPLER=always_off -p 16686:16686 jaegertracing/all-in-one:{{< currentVersion >}}
 ```

--- a/content/docs/v2/2.0/operations/troubleshooting.md
+++ b/content/docs/v2/2.0/operations/troubleshooting.md
@@ -40,9 +40,9 @@ If you suspect the remote sampling is not working correctly, try these steps:
 1. Make sure that the SDK is actually configured to use remote sampling, points to the correct sampling service address (see [APIs](../../architecture/apis/#remote-sampling-configuration-stable)), and that address is reachable from your application's [networking namespace](#networking-namespace).
 1. Look at the root span of the traces that are captured in Jaeger. If you are using Jaeger SDKs, the root span will contain the tags `sampler.type` and `sampler.param`, which indicate which strategy was used. (TBD - do OpenTelemetry SDKs record that?)
 1. Verify that the server is returning the appropriate sampling strategy for your service:
-```
-    $ curl "jaeger-collector:14268/api/sampling?service=foobar"
-    {"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
+```console
+$ curl "jaeger-collector:14268/api/sampling?service=foobar"
+{"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
 ```
 
 ## Bypass intermediate collectors

--- a/content/docs/v2/2.0/storage/cassandra.md
+++ b/content/docs/v2/2.0/storage/cassandra.md
@@ -66,7 +66,7 @@ docker run \
 The schema tool also supports TLS. You need to make a custom cqlshrc file like
 so:
 
-```
+```ini
 # Creating schema in a cassandra cluster requiring client TLS certificates.
 #
 # Create a volume for the schema docker container containing four files:

--- a/content/docs/v2/2.0/storage/elasticsearch.md
+++ b/content/docs/v2/2.0/storage/elasticsearch.md
@@ -145,11 +145,13 @@ To enable ILM support:
   }
   EOF
   ```
+
 * Run elasticsearch initializer with `ES_USE_ILM=true`:
 
   ```shell
   docker run -it --rm --net=host -e ES_USE_ILM=true jaegertracing/jaeger-es-rollover:latest init http://localhost:9200 # <1>
   ```
+
   <1> If you need to initialize archive storage, add `-e ARCHIVE=true`.
 
   {{< info >}}

--- a/content/docs/v2/2.1/architecture/apis.md
+++ b/content/docs/v2/2.1/architecture/apis.md
@@ -50,11 +50,11 @@ Jaeger can receive trace data in multiple formats on different ports.
 
 **Status**: Stable
 
-Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats: 
+Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats:
   * binary gRPC
   * Protobuf over HTTP
   * JSON over HTTP
-  
+
 Only tracing data is accepted, since Jaeger does not store other telemetry types. For more details on the OTLP receiver see the [official documentation][otlp-rcvr].
 
 [otlp-rcvr]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md
@@ -72,7 +72,7 @@ Jaeger's legacy Protobuf format is defined in [collector.proto] IDL file. Suppor
 
 Jaeger's legacy Thrift format is defined in [jaeger.thrift] IDL file, and is only maintained for backwards compatibility. The Thrift payload can be submitted in an HTTP POST request to the  `/api/traces` endpoint, for example, `https://jaeger-collector:14268/api/traces`. The `Batch` struct needs to be encoded using Thrift's `binary` encoding, and the HTTP request should specify the content type header:
 
-```
+```http
 Content-Type: application/vnd.apache.thrift.binary
 ```
 

--- a/content/docs/v2/2.1/architecture/spm.md
+++ b/content/docs/v2/2.1/architecture/spm.md
@@ -61,7 +61,7 @@ An example configuration is available in the Jaeger repository: [config-spm.yaml
 * Enable the [SpanMetrics Connector][spanmetrics-conn] in the pipeline:
 ```yaml
 # Declare an exporter for metrics produced by the connector.
-# For example, a Prometheus server may be configured to scrape 
+# For example, a Prometheus server may be configured to scrape
 # the metrics from this endpoint.
 exporters:
   prometheus:
@@ -73,7 +73,7 @@ connectors:
     # any connector configuration options
     ...
 
-# Enable the spanmetrics connector to bridge 
+# Enable the spanmetrics connector to bridge
 # the traces pipeline into the metrics pipeline.
 service:
   pipelines:
@@ -85,6 +85,7 @@ service:
       receivers: [spanmetrics]
       exporters: [prometheus]
 ```
+
 * Define a remote PromQL-compatible storage under `metric_backends:` in the `jaeger_storage` extension:
 ```yaml
 extensions:
@@ -97,6 +98,7 @@ extensions:
         prometheus:
           endpoint: http://prometheus:9090
 ```
+
 * Reference this metrics store in the `jaeger_query` extension:
 ```yaml
 extensions:
@@ -104,6 +106,7 @@ extensions:
     traces: some_trace_storage
     metrics_storage: some_metrics_storage
 ```
+
 * Set the `monitor.menuEnabled=true` property in the [Jaeger UI configuration](../../deployment/frontend-ui/#monitor).
 
 ## Architecture
@@ -194,7 +197,8 @@ Two metric names will be created:
       `le >= span duration` will be incremented for each span.
 
 The following formula aims to provide some guidance on the number of new time series created:
-```
+
+```go
 num_status_codes * num_span_kinds * (1 + num_latency_buckets) * num_operations
 
 Where:
@@ -204,7 +208,8 @@ Where:
 ```
 
 Plugging those numbers in, assuming default configuration:
-```
+
+```go
 max = 324 * num_operations
 typical = 72 * num_operations
 ```
@@ -246,7 +251,7 @@ service:
       address: 0.0.0.0:8888
 ```
 
-The `/metrics` endpoint on this port can be used to check if UI queries for SPM data are successful: 
+The `/metrics` endpoint on this port can be used to check if UI queries for SPM data are successful:
 
 ```shell
 curl -s http://jaeger:8888/metrics | grep jaeger_metricstore
@@ -320,8 +325,9 @@ service:
 ```
 
 Outputting logs that resemble the following (formatted for readability):
-```
-2024-11-26T19:09:43.152Z debug metricsstore/reader.go:258 Prometheus query results	
+
+```json
+2024-11-26T19:09:43.152Z debug metricsstore/reader.go:258 Prometheus query results
 {
   "kind": "extension",
   "name": "jaeger_storage",
@@ -367,9 +373,11 @@ If there are error spans appearing in Jaeger, but no corresponding error metrics
   the `status.code` label in the metric that the span should belong to.
 - If there are no `status.code` labels, check the OpenTelemetry Collector
   configuration file, particularly for the presence of the following configuration:
+
   ```yaml
   exclude_dimensions: ['status.code']
   ```
+
   This label is used by Jaeger to determine if a request is erroneous.
 
 ### Inspect the OpenTelemetry Collector

--- a/content/docs/v2/2.1/deployment/_index.md
+++ b/content/docs/v2/2.1/deployment/_index.md
@@ -31,7 +31,7 @@ See [APIs](../architecture/apis/) for the list of all API ports.
 
 ## Configuration
 
-Jaeger can be customized via configuration YAML file (see [Configuration](./configuration/)). 
+Jaeger can be customized via configuration YAML file (see [Configuration](./configuration/)).
 
 Jaeger **collector** is stateless and thus many instances of **collector** can be run in parallel. **collector** instances require almost no configuration, except for storage location, such as [Cassandra](../storage/cassandra/#configuration) or [Elasticsearch](../storage/elasticsearch/#configuration).
 
@@ -47,7 +47,7 @@ Sometimes these adjustments themselves make the trace hard to understand. For ex
 
 The `jaeger_query` extension supports a configuration property that controls how much clock skew adjustment should be allowed.
 
-```
+```yaml
 extensions:
   jaeger_query:
     max_clock_skew_adjust: 30s
@@ -59,7 +59,7 @@ extensions:
 
 The base path for all `jaeger_query` extension HTTP routes can be set to a non-root value, e.g. `/jaeger` would cause all UI URLs to start with `/jaeger`. This can be useful when running Jaeger behind a reverse proxy. Here is example code to set the base path.
 
-```
+```yaml
 extensions:
   jaeger_query:
     base_path: /

--- a/content/docs/v2/2.1/deployment/frontend-ui.md
+++ b/content/docs/v2/2.1/deployment/frontend-ui.md
@@ -194,7 +194,7 @@ The embedded mode is induced and configured via URL query parameters.
 
 To enter embedded mode, the `uiEmbed=v0` query parameter and value must be added to the URL. For example, the following URL will show the trace with ID `abc123` in embedded mode:
 
-```
+```text
 http://localhost:16686/trace/abc123?uiEmbed=v0
 ```
 
@@ -213,7 +213,7 @@ To integrate the Search Trace Page to our application we have to indicate to the
 
 For example:
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -233,7 +233,7 @@ The following query parameter can be used to configure the layout of the search 
 
 * `uiSearchHideGraph=1` - disables the display of the scatter plot above the search results
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -258,6 +258,7 @@ For example:
 ```sh
 http://localhost:16686/trace/{trace-id}?uiEmbed=v0
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view.png)](/img/frontend-ui/embed-trace-view.png)
 
 If we have navigated to this view from the search traces page we'll have a button to go back to the results page.
@@ -270,36 +271,40 @@ The following query parameters can be used to configure the layout of the trace 
 
 * `uiTimelineCollapseTitle=1` causes the trace header to start out collapsed, which hides the summary and the minimap.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineCollapseTitle=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-collapse.png)](/img/frontend-ui/embed-trace-view-with-collapse.png)
 
 * `uiTimelineHideMinimap=1` removes the minimap, entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)
 
 * `uiTimelineHideSummary=1` - removes the trace summary information (number of services, etc.) entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-summary.png)](/img/frontend-ui/embed-trace-view-with-hide-summary.png)
 
 We can also combine the options:
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)

--- a/content/docs/v2/2.1/getting-started.md
+++ b/content/docs/v2/2.1/getting-started.md
@@ -10,7 +10,7 @@ If you are new to distributed tracing, please check the [Introduction](../) page
 
 The easiest way to run Jaeger is by starting it in a container:
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \
@@ -37,7 +37,7 @@ Using this application you can:
 - Find sources of latency and lack of concurrency.
 - Explore highly contextualized logging.
 - Use baggage propagation to diagnose inter-request contention (queueing) and time spent in a service.
-- Use open source libraries from `opentelemetry-contrib` to get vendor-neutral instrumentation 
+- Use open source libraries from `opentelemetry-contrib` to get vendor-neutral instrumentation
 for free.
 
 We recommend running Jaeger and HotROD together via `docker compose`:

--- a/content/docs/v2/2.1/operations/monitoring.md
+++ b/content/docs/v2/2.1/operations/monitoring.md
@@ -13,13 +13,13 @@ Please refer to [OpenTelemetry Collector documentation](https://opentelemetry.io
 
 Here's a sample `curl` call to obtain the metrics:
 
-```
+```sh
 curl -s http://jaeger-collector:8888/metrics
 ```
 
 The following metrics are of special interest:
 
-```
+```ini
 otelcol_receiver_accepted_spans
 otelcol_receiver_refused_spans
 
@@ -31,7 +31,7 @@ The first two metrics describe how many spans are being received by Jaeger. The 
 
 The labels on the metrics allow to separate different receivers and exporters. For example, the first metric with all labels might look like this (formatted for readability):
 
-```
+```ini
 otelcol_receiver_accepted_spans{
     receiver="otlp",
     service_instance_id="f91d66c2-0445-42bf-a062-32aaed09facf",

--- a/content/docs/v2/2.1/operations/troubleshooting.md
+++ b/content/docs/v2/2.1/operations/troubleshooting.md
@@ -29,9 +29,9 @@ If you suspect the remote sampling is not working correctly, try these steps:
 
 1. Make sure that the SDK is actually configured to use remote sampling, points to the correct sampling service address (see [APIs](../../architecture/apis/#remote-sampling-configuration)), and that address is reachable from your application's [networking namespace](#network-connectivity).
 1. Verify that the server is returning the appropriate sampling strategy for your service:
-```
-    $ curl "jaeger-collector:14268/api/sampling?service=foobar"
-    {"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
+```console
+$ curl "jaeger-collector:14268/api/sampling?service=foobar"
+{"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
 ```
 
 ## Bypass intermediate collectors
@@ -54,7 +54,7 @@ Jaeger provides useful debugging information when the log level is set to `debug
 
 For the cases where it's not possible or desirable to increase the logging verbosity, the `/metrics` endpoint can be used to check how trace data is being received and processed by Jaeger. See [Monitoring](../monitoring/#logging) for more details on configuring metrics production. Here's a sample `curl` call to obtain the metrics:
 
-```
+```sh
 curl -s http://jaeger-collector:8888/metrics
 ```
 

--- a/content/docs/v2/2.1/storage/cassandra.md
+++ b/content/docs/v2/2.1/storage/cassandra.md
@@ -72,7 +72,7 @@ your Cassandra cluster correctly. You can specify paths to the TLS certificates 
 The schema tool also supports TLS. You need to make a custom cqlshrc file like
 so:
 
-```
+```ini
 # Creating schema in a cassandra cluster requiring client TLS certificates.
 #
 # Create a volume for the schema docker container containing four files:

--- a/content/docs/v2/2.1/storage/elasticsearch.md
+++ b/content/docs/v2/2.1/storage/elasticsearch.md
@@ -143,6 +143,7 @@ To enable ILM support:
   }
   EOF
   ```
+
 * Run elasticsearch initializer with `ES_USE_ILM=true`:
 
   ```shell
@@ -151,6 +152,7 @@ To enable ILM support:
     jaegertracing/jaeger-es-rollover:latest \
     init http://localhost:9200 # <1>
   ```
+
   <1> If you need to initialize archive storage, add `-e ARCHIVE=true`.
 
   {{< info >}}

--- a/content/docs/v2/2.10/architecture/apis.md
+++ b/content/docs/v2/2.10/architecture/apis.md
@@ -53,11 +53,11 @@ Jaeger can receive trace data in multiple formats on different ports.
 
 **Status**: Stable
 
-Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats: 
+Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats:
   * [Protobuf via gRPC][otlp.grpc]
   * [Protobuf over HTTP][otlp.http]
   * [JSON over HTTP][otlp.http]
-  
+
 Only tracing data is accepted, since Jaeger does not store other telemetry types. For more details on the OTLP receiver see the [official documentation][otlp-rcvr].
 
 [otlp-rcvr]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md
@@ -75,7 +75,7 @@ Jaeger's legacy Protobuf format is defined in [collector.proto] IDL file. Suppor
 
 Jaeger's legacy Thrift format is defined in [jaeger.thrift] IDL file, and is only maintained for backwards compatibility. The Thrift payload can be submitted in an HTTP POST request to the  `/api/traces` endpoint, for example, `https://jaeger-collector:14268/api/traces`. The `Batch` struct needs to be encoded using Thrift's `binary` encoding, and the HTTP request should specify the content type header:
 
-```
+```http
 Content-Type: application/vnd.apache.thrift.binary
 ```
 
@@ -129,11 +129,11 @@ the gRPC Remote Storage API.
 To use a remote storage backend, you must deploy a gRPC server that implements
 the following services:
 
-* **[TraceReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/trace_storage.proto)**  
+* **[TraceReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/trace_storage.proto)**
   Enables Jaeger to read traces from the storage backend.
-* **[DependencyReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/dependency_storage.proto)**  
+* **[DependencyReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/dependency_storage.proto)**
   Used to load service dependency graphs from storage.
-* **[TraceService](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/trace/v1/trace_service.proto)**  
+* **[TraceService](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/trace/v1/trace_service.proto)**
   Allows trace data to be pushed to the storage. This service can run on a separate port if needed.
 
 For more information, please refer to

--- a/content/docs/v2/2.10/architecture/spm.md
+++ b/content/docs/v2/2.10/architecture/spm.md
@@ -87,6 +87,7 @@ service:
       receivers: [spanmetrics]
       exporters: [prometheus]
 ```
+
 * Define a remote PromQL-compatible storage under `metric_backends:` in the `jaeger_storage` extension:
 ```yaml
 extensions:
@@ -99,6 +100,7 @@ extensions:
         prometheus:
           endpoint: http://prometheus:9090
 ```
+
 * Reference this metrics store in the `jaeger_query` extension:
 ```yaml
 extensions:
@@ -106,6 +108,7 @@ extensions:
     traces: some_trace_storage
     metrics_storage: some_metrics_storage
 ```
+
 * Set the `monitor.menuEnabled=true` property in the [Jaeger UI configuration](../../deployment/frontend-ui/#monitor).
 
 ### Option 2: Elasticsearch/OpenSearch Backend Configuration
@@ -292,7 +295,8 @@ Two metric names will be created:
       `le >= span duration` will be incremented for each span.
 
 The following formula aims to provide some guidance on the number of new time series created:
-```
+
+```go
 num_status_codes * num_span_kinds * (1 + num_latency_buckets) * num_operations
 
 Where:
@@ -302,7 +306,8 @@ Where:
 ```
 
 Plugging those numbers in, assuming default configuration:
-```
+
+```go
 max = 324 * num_operations
 typical = 72 * num_operations
 ```
@@ -418,7 +423,8 @@ service:
 ```
 
 Outputting logs that resemble the following (formatted for readability):
-```
+
+```json
 2024-11-26T19:09:43.152Z debug metricsstore/reader.go:258 Prometheus query results
 {
   "kind": "extension",
@@ -465,9 +471,11 @@ If there are error spans appearing in Jaeger, but no corresponding error metrics
   the `status.code` label in the metric that the span should belong to.
 - If there are no `status.code` labels, check the OpenTelemetry Collector
   configuration file, particularly for the presence of the following configuration:
+
   ```yaml
   exclude_dimensions: ['status.code']
   ```
+
   This label is used by Jaeger to determine if a request is erroneous.
 
 ### Inspect the OpenTelemetry Collector

--- a/content/docs/v2/2.10/deployment/_index.md
+++ b/content/docs/v2/2.10/deployment/_index.md
@@ -20,7 +20,7 @@ Jaeger backend is released as a single binary or container image (see [Downloads
 
 An explicit YAML configuration file must be provided via the `--config` command line argument (see [Configuration](./configuration/)). When running in a container, the path to the config file must be mapped into the container file system (the `-v ...` mapping below):
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \

--- a/content/docs/v2/2.10/deployment/configuration.md
+++ b/content/docs/v2/2.10/deployment/configuration.md
@@ -44,7 +44,8 @@ One category of environment variables that Jaeger v2 does recognize automaticall
 ### Config Overrides
 
 Another way to override certain config values is by passing them via `--set` command line flags:
-```
+
+```sh
 --set=receivers.otlp.protocols.grpc.endpoint=0.0.0.0:4317
 ```
 
@@ -110,7 +111,7 @@ Sometimes these adjustments themselves make the trace hard to understand. For ex
 
 The `jaeger_query` extension supports a configuration property that controls how much clock skew adjustment should be allowed.
 
-```
+```yaml
 extensions:
   jaeger_query:
     max_clock_skew_adjust: 30s
@@ -122,7 +123,7 @@ extensions:
 
 The base path for all `jaeger_query` extension HTTP routes can be set to a non-root value, e.g. `/jaeger` would cause all UI URLs to start with `/jaeger`. This can be useful when running Jaeger behind a reverse proxy. Here is example code to set the base path.
 
-```
+```yaml
 extensions:
   jaeger_query:
     base_path: /

--- a/content/docs/v2/2.10/deployment/frontend-ui.md
+++ b/content/docs/v2/2.10/deployment/frontend-ui.md
@@ -213,7 +213,7 @@ The embedded mode is induced and configured via URL query parameters.
 
 To enter embedded mode, the `uiEmbed=v0` query parameter and value must be added to the URL. For example, the following URL will show the trace with ID `abc123` in embedded mode:
 
-```
+```text
 http://localhost:16686/trace/abc123?uiEmbed=v0
 ```
 
@@ -232,7 +232,7 @@ To integrate the Search Trace Page to our application we have to indicate to the
 
 For example:
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -252,7 +252,7 @@ The following query parameter can be used to configure the layout of the search 
 
 * `uiSearchHideGraph=1` - disables the display of the scatter plot above the search results
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -277,6 +277,7 @@ For example:
 ```sh
 http://localhost:16686/trace/{trace-id}?uiEmbed=v0
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view.png)](/img/frontend-ui/embed-trace-view.png)
 
 If we have navigated to this view from the search traces page we'll have a button to go back to the results page.
@@ -289,36 +290,40 @@ The following query parameters can be used to configure the layout of the trace 
 
 * `uiTimelineCollapseTitle=1` causes the trace header to start out collapsed, which hides the summary and the minimap.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineCollapseTitle=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-collapse.png)](/img/frontend-ui/embed-trace-view-with-collapse.png)
 
 * `uiTimelineHideMinimap=1` removes the minimap, entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)
 
 * `uiTimelineHideSummary=1` - removes the trace summary information (number of services, etc.) entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-summary.png)](/img/frontend-ui/embed-trace-view-with-hide-summary.png)
 
 We can also combine the options:
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)

--- a/content/docs/v2/2.10/getting-started.md
+++ b/content/docs/v2/2.10/getting-started.md
@@ -10,7 +10,7 @@ If you are new to distributed tracing, please check the [Introduction](../) page
 
 The easiest way to run Jaeger is by starting it in a container:
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \
@@ -24,7 +24,7 @@ This runs the **all-in-one** configuration of Jaeger ([see Architecture](../arch
 
 In order to run Jaeger in other roles ([see Architecture](../architecture/)), an explicit configuration file ([see Configuration](../deployment/configuration/)) must be provided via the `--config` command line argument. When running in a container, the path to the config file must be mapped into the container file system (the `-v ...` mapping below):
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \

--- a/content/docs/v2/2.10/operations/monitoring.md
+++ b/content/docs/v2/2.10/operations/monitoring.md
@@ -13,13 +13,13 @@ Please refer to [OpenTelemetry Collector documentation](https://opentelemetry.io
 
 Here's a sample `curl` call to obtain the metrics:
 
-```
+```sh
 curl -s http://jaeger-collector:8888/metrics
 ```
 
 The following metrics are of special interest:
 
-```
+```ini
 otelcol_receiver_accepted_spans
 otelcol_receiver_refused_spans
 
@@ -31,7 +31,7 @@ The first two metrics describe how many spans are being received by Jaeger. The 
 
 The labels on the metrics allow to separate different receivers and exporters. For example, the first metric with all labels might look like this (formatted for readability):
 
-```
+```ini
 otelcol_receiver_accepted_spans{
     receiver="otlp",
     service_instance_id="f91d66c2-0445-42bf-a062-32aaed09facf",

--- a/content/docs/v2/2.10/operations/troubleshooting.md
+++ b/content/docs/v2/2.10/operations/troubleshooting.md
@@ -29,9 +29,9 @@ If you suspect the remote sampling is not working correctly, try these steps:
 
 1. Make sure that the SDK is actually configured to use remote sampling, points to the correct sampling service address (see [APIs](../../architecture/apis/#remote-sampling-configuration)), and that address is reachable from your application's [networking namespace](#network-connectivity).
 1. Verify that the server is returning the appropriate sampling strategy for your service:
-```
-    $ curl "jaeger-collector:14268/api/sampling?service=foobar"
-    {"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
+```console
+$ curl "jaeger-collector:14268/api/sampling?service=foobar"
+{"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
 ```
 
 ## Bypass intermediate collectors
@@ -54,7 +54,7 @@ Jaeger provides useful debugging information when the log level is set to `debug
 
 For the cases where it's not possible or desirable to increase the logging verbosity, the `/metrics` endpoint can be used to check how trace data is being received and processed by Jaeger. See [Monitoring](../monitoring/#logging) for more details on configuring metrics production. Here's a sample `curl` call to obtain the metrics:
 
-```
+```sh
 curl -s http://jaeger-collector:8888/metrics
 ```
 

--- a/content/docs/v2/2.10/storage/cassandra.md
+++ b/content/docs/v2/2.10/storage/cassandra.md
@@ -72,7 +72,7 @@ your Cassandra cluster correctly. You can specify paths to the TLS certificates 
 The schema tool also supports TLS. You need to make a custom cqlshrc file like
 so:
 
-```
+```ini
 # Creating schema in a cassandra cluster requiring client TLS certificates.
 #
 # Create a volume for the schema docker container containing four files:

--- a/content/docs/v2/2.10/storage/elasticsearch.md
+++ b/content/docs/v2/2.10/storage/elasticsearch.md
@@ -143,6 +143,7 @@ To enable ILM support:
   }
   EOF
   ```
+
 * Run elasticsearch initializer with `ES_USE_ILM=true`:
 
   ```shell
@@ -151,6 +152,7 @@ To enable ILM support:
     jaegertracing/jaeger-es-rollover:latest \
     init http://localhost:9200 # <1>
   ```
+
   <1> If you need to initialize archive storage, add `-e ARCHIVE=true`.
 
   {{< info >}}

--- a/content/docs/v2/2.11/architecture/apis.md
+++ b/content/docs/v2/2.11/architecture/apis.md
@@ -53,11 +53,11 @@ Jaeger can receive trace data in multiple formats on different ports.
 
 **Status**: Stable
 
-Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats: 
+Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats:
   * [Protobuf via gRPC][otlp.grpc]
   * [Protobuf over HTTP][otlp.http]
   * [JSON over HTTP][otlp.http]
-  
+
 Only tracing data is accepted, since Jaeger does not store other telemetry types. For more details on the OTLP receiver see the [official documentation][otlp-rcvr].
 
 [otlp-rcvr]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md
@@ -75,7 +75,7 @@ Jaeger's legacy Protobuf format is defined in [collector.proto] IDL file. Suppor
 
 Jaeger's legacy Thrift format is defined in [jaeger.thrift] IDL file, and is only maintained for backwards compatibility. The Thrift payload can be submitted in an HTTP POST request to the  `/api/traces` endpoint, for example, `https://jaeger-collector:14268/api/traces`. The `Batch` struct needs to be encoded using Thrift's `binary` encoding, and the HTTP request should specify the content type header:
 
-```
+```http
 Content-Type: application/vnd.apache.thrift.binary
 ```
 
@@ -129,11 +129,11 @@ the gRPC Remote Storage API.
 To use a remote storage backend, you must deploy a gRPC server that implements
 the following services:
 
-* **[TraceReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/trace_storage.proto)**  
+* **[TraceReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/trace_storage.proto)**
   Enables Jaeger to read traces from the storage backend.
-* **[DependencyReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/dependency_storage.proto)**  
+* **[DependencyReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/dependency_storage.proto)**
   Used to load service dependency graphs from storage.
-* **[TraceService](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/trace/v1/trace_service.proto)**  
+* **[TraceService](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/trace/v1/trace_service.proto)**
   Allows trace data to be pushed to the storage. This service can run on a separate port if needed.
 
 For more information, please refer to

--- a/content/docs/v2/2.11/architecture/spm.md
+++ b/content/docs/v2/2.11/architecture/spm.md
@@ -87,6 +87,7 @@ service:
       receivers: [spanmetrics]
       exporters: [prometheus]
 ```
+
 * Define a remote PromQL-compatible storage under `metric_backends:` in the `jaeger_storage` extension:
 ```yaml
 extensions:
@@ -99,6 +100,7 @@ extensions:
         prometheus:
           endpoint: http://prometheus:9090
 ```
+
 * Reference this metrics store in the `jaeger_query` extension:
 ```yaml
 extensions:
@@ -106,6 +108,7 @@ extensions:
     traces: some_trace_storage
     metrics_storage: some_metrics_storage
 ```
+
 * Set the `monitor.menuEnabled=true` property in the [Jaeger UI configuration](../../deployment/frontend-ui/#monitor).
 
 ### Option 2: Elasticsearch/OpenSearch Backend Configuration
@@ -292,7 +295,8 @@ Two metric names will be created:
       `le >= span duration` will be incremented for each span.
 
 The following formula aims to provide some guidance on the number of new time series created:
-```
+
+```go
 num_status_codes * num_span_kinds * (1 + num_latency_buckets) * num_operations
 
 Where:
@@ -302,7 +306,8 @@ Where:
 ```
 
 Plugging those numbers in, assuming default configuration:
-```
+
+```go
 max = 324 * num_operations
 typical = 72 * num_operations
 ```
@@ -418,7 +423,8 @@ service:
 ```
 
 Outputting logs that resemble the following (formatted for readability):
-```
+
+```json
 2024-11-26T19:09:43.152Z debug metricsstore/reader.go:258 Prometheus query results
 {
   "kind": "extension",
@@ -465,9 +471,11 @@ If there are error spans appearing in Jaeger, but no corresponding error metrics
   the `status.code` label in the metric that the span should belong to.
 - If there are no `status.code` labels, check the OpenTelemetry Collector
   configuration file, particularly for the presence of the following configuration:
+
   ```yaml
   exclude_dimensions: ['status.code']
   ```
+
   This label is used by Jaeger to determine if a request is erroneous.
 
 ### Inspect the OpenTelemetry Collector

--- a/content/docs/v2/2.11/deployment/_index.md
+++ b/content/docs/v2/2.11/deployment/_index.md
@@ -20,7 +20,7 @@ Jaeger backend is released as a single binary or container image (see [Downloads
 
 An explicit YAML configuration file must be provided via the `--config` command line argument (see [Configuration](./configuration/)). When running in a container, the path to the config file must be mapped into the container file system (the `-v ...` mapping below):
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \

--- a/content/docs/v2/2.11/deployment/configuration.md
+++ b/content/docs/v2/2.11/deployment/configuration.md
@@ -44,7 +44,8 @@ One category of environment variables that Jaeger v2 does recognize automaticall
 ### Config Overrides
 
 Another way to override certain config values is by passing them via `--set` command line flags:
-```
+
+```sh
 --set=receivers.otlp.protocols.grpc.endpoint=0.0.0.0:4317
 ```
 
@@ -110,7 +111,7 @@ Sometimes these adjustments themselves make the trace hard to understand. For ex
 
 The `jaeger_query` extension supports a configuration property that controls how much clock skew adjustment should be allowed.
 
-```
+```yaml
 extensions:
   jaeger_query:
     max_clock_skew_adjust: 30s
@@ -122,7 +123,7 @@ extensions:
 
 The base path for all `jaeger_query` extension HTTP routes can be set to a non-root value, e.g. `/jaeger` would cause all UI URLs to start with `/jaeger`. This can be useful when running Jaeger behind a reverse proxy. Here is example code to set the base path.
 
-```
+```yaml
 extensions:
   jaeger_query:
     base_path: /

--- a/content/docs/v2/2.11/deployment/frontend-ui.md
+++ b/content/docs/v2/2.11/deployment/frontend-ui.md
@@ -213,7 +213,7 @@ The embedded mode is induced and configured via URL query parameters.
 
 To enter embedded mode, the `uiEmbed=v0` query parameter and value must be added to the URL. For example, the following URL will show the trace with ID `abc123` in embedded mode:
 
-```
+```text
 http://localhost:16686/trace/abc123?uiEmbed=v0
 ```
 
@@ -232,7 +232,7 @@ To integrate the Search Trace Page to our application we have to indicate to the
 
 For example:
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -252,7 +252,7 @@ The following query parameter can be used to configure the layout of the search 
 
 * `uiSearchHideGraph=1` - disables the display of the scatter plot above the search results
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -277,6 +277,7 @@ For example:
 ```sh
 http://localhost:16686/trace/{trace-id}?uiEmbed=v0
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view.png)](/img/frontend-ui/embed-trace-view.png)
 
 If we have navigated to this view from the search traces page we'll have a button to go back to the results page.
@@ -289,36 +290,40 @@ The following query parameters can be used to configure the layout of the trace 
 
 * `uiTimelineCollapseTitle=1` causes the trace header to start out collapsed, which hides the summary and the minimap.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineCollapseTitle=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-collapse.png)](/img/frontend-ui/embed-trace-view-with-collapse.png)
 
 * `uiTimelineHideMinimap=1` removes the minimap, entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)
 
 * `uiTimelineHideSummary=1` - removes the trace summary information (number of services, etc.) entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-summary.png)](/img/frontend-ui/embed-trace-view-with-hide-summary.png)
 
 We can also combine the options:
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)

--- a/content/docs/v2/2.11/getting-started.md
+++ b/content/docs/v2/2.11/getting-started.md
@@ -10,7 +10,7 @@ If you are new to distributed tracing, please check the [Introduction](../) page
 
 The easiest way to run Jaeger is by starting it in a container:
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \
@@ -24,7 +24,7 @@ This runs the **all-in-one** configuration of Jaeger ([see Architecture](../arch
 
 In order to run Jaeger in other roles ([see Architecture](../architecture/)), an explicit configuration file ([see Configuration](../deployment/configuration/)) must be provided via the `--config` command line argument. When running in a container, the path to the config file must be mapped into the container file system (the `-v ...` mapping below):
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \

--- a/content/docs/v2/2.11/operations/monitoring.md
+++ b/content/docs/v2/2.11/operations/monitoring.md
@@ -13,13 +13,13 @@ Please refer to [OpenTelemetry Collector documentation](https://opentelemetry.io
 
 Here's a sample `curl` call to obtain the metrics:
 
-```
+```sh
 curl -s http://jaeger-collector:8888/metrics
 ```
 
 The following metrics are of special interest:
 
-```
+```ini
 otelcol_receiver_accepted_spans
 otelcol_receiver_refused_spans
 
@@ -31,7 +31,7 @@ The first two metrics describe how many spans are being received by Jaeger. The 
 
 The labels on the metrics allow to separate different receivers and exporters. For example, the first metric with all labels might look like this (formatted for readability):
 
-```
+```ini
 otelcol_receiver_accepted_spans{
     receiver="otlp",
     service_instance_id="f91d66c2-0445-42bf-a062-32aaed09facf",

--- a/content/docs/v2/2.11/operations/troubleshooting.md
+++ b/content/docs/v2/2.11/operations/troubleshooting.md
@@ -29,9 +29,9 @@ If you suspect the remote sampling is not working correctly, try these steps:
 
 1. Make sure that the SDK is actually configured to use remote sampling, points to the correct sampling service address (see [APIs](../../architecture/apis/#remote-sampling-configuration)), and that address is reachable from your application's [networking namespace](#network-connectivity).
 1. Verify that the server is returning the appropriate sampling strategy for your service:
-```
-    $ curl "jaeger-collector:14268/api/sampling?service=foobar"
-    {"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
+```console
+$ curl "jaeger-collector:14268/api/sampling?service=foobar"
+{"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
 ```
 
 ## Bypass intermediate collectors
@@ -54,7 +54,7 @@ Jaeger provides useful debugging information when the log level is set to `debug
 
 For the cases where it's not possible or desirable to increase the logging verbosity, the `/metrics` endpoint can be used to check how trace data is being received and processed by Jaeger. See [Monitoring](../monitoring/#logging) for more details on configuring metrics production. Here's a sample `curl` call to obtain the metrics:
 
-```
+```sh
 curl -s http://jaeger-collector:8888/metrics
 ```
 

--- a/content/docs/v2/2.11/storage/cassandra.md
+++ b/content/docs/v2/2.11/storage/cassandra.md
@@ -72,7 +72,7 @@ your Cassandra cluster correctly. You can specify paths to the TLS certificates 
 The schema tool also supports TLS. You need to make a custom cqlshrc file like
 so:
 
-```
+```ini
 # Creating schema in a cassandra cluster requiring client TLS certificates.
 #
 # Create a volume for the schema docker container containing four files:

--- a/content/docs/v2/2.11/storage/elasticsearch.md
+++ b/content/docs/v2/2.11/storage/elasticsearch.md
@@ -143,6 +143,7 @@ To enable ILM support:
   }
   EOF
   ```
+
 * Run elasticsearch initializer with `ES_USE_ILM=true`:
 
   ```shell
@@ -151,6 +152,7 @@ To enable ILM support:
     jaegertracing/jaeger-es-rollover:latest \
     init http://localhost:9200 # <1>
   ```
+
   <1> If you need to initialize archive storage, add `-e ARCHIVE=true`.
 
   {{< info >}}

--- a/content/docs/v2/2.2/architecture/apis.md
+++ b/content/docs/v2/2.2/architecture/apis.md
@@ -53,11 +53,11 @@ Jaeger can receive trace data in multiple formats on different ports.
 
 **Status**: Stable
 
-Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats: 
+Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats:
   * [Protobuf via gRPC][otlp.grpc]
   * [Protobuf over HTTP][otlp.http]
   * [JSON over HTTP][otlp.http]
-  
+
 Only tracing data is accepted, since Jaeger does not store other telemetry types. For more details on the OTLP receiver see the [official documentation][otlp-rcvr].
 
 [otlp-rcvr]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md
@@ -75,7 +75,7 @@ Jaeger's legacy Protobuf format is defined in [collector.proto] IDL file. Suppor
 
 Jaeger's legacy Thrift format is defined in [jaeger.thrift] IDL file, and is only maintained for backwards compatibility. The Thrift payload can be submitted in an HTTP POST request to the  `/api/traces` endpoint, for example, `https://jaeger-collector:14268/api/traces`. The `Batch` struct needs to be encoded using Thrift's `binary` encoding, and the HTTP request should specify the content type header:
 
-```
+```http
 Content-Type: application/vnd.apache.thrift.binary
 ```
 

--- a/content/docs/v2/2.2/architecture/spm.md
+++ b/content/docs/v2/2.2/architecture/spm.md
@@ -61,7 +61,7 @@ An example configuration is available in the Jaeger repository: [config-spm.yaml
 * Enable the [SpanMetrics Connector][spanmetrics-conn] in the pipeline:
 ```yaml
 # Declare an exporter for metrics produced by the connector.
-# For example, a Prometheus server may be configured to scrape 
+# For example, a Prometheus server may be configured to scrape
 # the metrics from this endpoint.
 exporters:
   prometheus:
@@ -73,7 +73,7 @@ connectors:
     # any connector configuration options
     ...
 
-# Enable the spanmetrics connector to bridge 
+# Enable the spanmetrics connector to bridge
 # the traces pipeline into the metrics pipeline.
 service:
   pipelines:
@@ -85,6 +85,7 @@ service:
       receivers: [spanmetrics]
       exporters: [prometheus]
 ```
+
 * Define a remote PromQL-compatible storage under `metric_backends:` in the `jaeger_storage` extension:
 ```yaml
 extensions:
@@ -97,6 +98,7 @@ extensions:
         prometheus:
           endpoint: http://prometheus:9090
 ```
+
 * Reference this metrics store in the `jaeger_query` extension:
 ```yaml
 extensions:
@@ -104,6 +106,7 @@ extensions:
     traces: some_trace_storage
     metrics_storage: some_metrics_storage
 ```
+
 * Set the `monitor.menuEnabled=true` property in the [Jaeger UI configuration](../../deployment/frontend-ui/#monitor).
 
 ## Architecture
@@ -194,7 +197,8 @@ Two metric names will be created:
       `le >= span duration` will be incremented for each span.
 
 The following formula aims to provide some guidance on the number of new time series created:
-```
+
+```go
 num_status_codes * num_span_kinds * (1 + num_latency_buckets) * num_operations
 
 Where:
@@ -204,7 +208,8 @@ Where:
 ```
 
 Plugging those numbers in, assuming default configuration:
-```
+
+```go
 max = 324 * num_operations
 typical = 72 * num_operations
 ```
@@ -246,7 +251,7 @@ service:
       address: 0.0.0.0:8888
 ```
 
-The `/metrics` endpoint on this port can be used to check if UI queries for SPM data are successful: 
+The `/metrics` endpoint on this port can be used to check if UI queries for SPM data are successful:
 
 ```shell
 curl -s http://jaeger:8888/metrics | grep jaeger_metricstore
@@ -320,8 +325,9 @@ service:
 ```
 
 Outputting logs that resemble the following (formatted for readability):
-```
-2024-11-26T19:09:43.152Z debug metricsstore/reader.go:258 Prometheus query results	
+
+```json
+2024-11-26T19:09:43.152Z debug metricsstore/reader.go:258 Prometheus query results
 {
   "kind": "extension",
   "name": "jaeger_storage",
@@ -367,9 +373,11 @@ If there are error spans appearing in Jaeger, but no corresponding error metrics
   the `status.code` label in the metric that the span should belong to.
 - If there are no `status.code` labels, check the OpenTelemetry Collector
   configuration file, particularly for the presence of the following configuration:
+
   ```yaml
   exclude_dimensions: ['status.code']
   ```
+
   This label is used by Jaeger to determine if a request is erroneous.
 
 ### Inspect the OpenTelemetry Collector

--- a/content/docs/v2/2.2/deployment/_index.md
+++ b/content/docs/v2/2.2/deployment/_index.md
@@ -47,7 +47,7 @@ Sometimes these adjustments themselves make the trace hard to understand. For ex
 
 The `jaeger_query` extension supports a configuration property that controls how much clock skew adjustment should be allowed.
 
-```
+```yaml
 extensions:
   jaeger_query:
     max_clock_skew_adjust: 30s
@@ -59,7 +59,7 @@ extensions:
 
 The base path for all `jaeger_query` extension HTTP routes can be set to a non-root value, e.g. `/jaeger` would cause all UI URLs to start with `/jaeger`. This can be useful when running Jaeger behind a reverse proxy. Here is example code to set the base path.
 
-```
+```yaml
 extensions:
   jaeger_query:
     base_path: /

--- a/content/docs/v2/2.2/deployment/frontend-ui.md
+++ b/content/docs/v2/2.2/deployment/frontend-ui.md
@@ -194,7 +194,7 @@ The embedded mode is induced and configured via URL query parameters.
 
 To enter embedded mode, the `uiEmbed=v0` query parameter and value must be added to the URL. For example, the following URL will show the trace with ID `abc123` in embedded mode:
 
-```
+```text
 http://localhost:16686/trace/abc123?uiEmbed=v0
 ```
 
@@ -213,7 +213,7 @@ To integrate the Search Trace Page to our application we have to indicate to the
 
 For example:
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -233,7 +233,7 @@ The following query parameter can be used to configure the layout of the search 
 
 * `uiSearchHideGraph=1` - disables the display of the scatter plot above the search results
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -258,6 +258,7 @@ For example:
 ```sh
 http://localhost:16686/trace/{trace-id}?uiEmbed=v0
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view.png)](/img/frontend-ui/embed-trace-view.png)
 
 If we have navigated to this view from the search traces page we'll have a button to go back to the results page.
@@ -270,36 +271,40 @@ The following query parameters can be used to configure the layout of the trace 
 
 * `uiTimelineCollapseTitle=1` causes the trace header to start out collapsed, which hides the summary and the minimap.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineCollapseTitle=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-collapse.png)](/img/frontend-ui/embed-trace-view-with-collapse.png)
 
 * `uiTimelineHideMinimap=1` removes the minimap, entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)
 
 * `uiTimelineHideSummary=1` - removes the trace summary information (number of services, etc.) entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-summary.png)](/img/frontend-ui/embed-trace-view-with-hide-summary.png)
 
 We can also combine the options:
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)

--- a/content/docs/v2/2.2/getting-started.md
+++ b/content/docs/v2/2.2/getting-started.md
@@ -10,7 +10,7 @@ If you are new to distributed tracing, please check the [Introduction](../) page
 
 The easiest way to run Jaeger is by starting it in a container:
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \
@@ -37,7 +37,7 @@ Using this application you can:
 - Find sources of latency and lack of concurrency.
 - Explore highly contextualized logging.
 - Use baggage propagation to diagnose inter-request contention (queueing) and time spent in a service.
-- Use open source libraries from `opentelemetry-contrib` to get vendor-neutral instrumentation 
+- Use open source libraries from `opentelemetry-contrib` to get vendor-neutral instrumentation
 for free.
 
 We recommend running Jaeger and HotROD together via `docker compose`:

--- a/content/docs/v2/2.2/operations/monitoring.md
+++ b/content/docs/v2/2.2/operations/monitoring.md
@@ -13,13 +13,13 @@ Please refer to [OpenTelemetry Collector documentation](https://opentelemetry.io
 
 Here's a sample `curl` call to obtain the metrics:
 
-```
+```sh
 curl -s http://jaeger-collector:8888/metrics
 ```
 
 The following metrics are of special interest:
 
-```
+```ini
 otelcol_receiver_accepted_spans
 otelcol_receiver_refused_spans
 
@@ -31,7 +31,7 @@ The first two metrics describe how many spans are being received by Jaeger. The 
 
 The labels on the metrics allow to separate different receivers and exporters. For example, the first metric with all labels might look like this (formatted for readability):
 
-```
+```ini
 otelcol_receiver_accepted_spans{
     receiver="otlp",
     service_instance_id="f91d66c2-0445-42bf-a062-32aaed09facf",

--- a/content/docs/v2/2.2/operations/troubleshooting.md
+++ b/content/docs/v2/2.2/operations/troubleshooting.md
@@ -29,9 +29,9 @@ If you suspect the remote sampling is not working correctly, try these steps:
 
 1. Make sure that the SDK is actually configured to use remote sampling, points to the correct sampling service address (see [APIs](../../architecture/apis/#remote-sampling-configuration)), and that address is reachable from your application's [networking namespace](#network-connectivity).
 1. Verify that the server is returning the appropriate sampling strategy for your service:
-```
-    $ curl "jaeger-collector:14268/api/sampling?service=foobar"
-    {"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
+```console
+$ curl "jaeger-collector:14268/api/sampling?service=foobar"
+{"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
 ```
 
 ## Bypass intermediate collectors
@@ -54,7 +54,7 @@ Jaeger provides useful debugging information when the log level is set to `debug
 
 For the cases where it's not possible or desirable to increase the logging verbosity, the `/metrics` endpoint can be used to check how trace data is being received and processed by Jaeger. See [Monitoring](../monitoring/#logging) for more details on configuring metrics production. Here's a sample `curl` call to obtain the metrics:
 
-```
+```sh
 curl -s http://jaeger-collector:8888/metrics
 ```
 

--- a/content/docs/v2/2.2/storage/cassandra.md
+++ b/content/docs/v2/2.2/storage/cassandra.md
@@ -72,7 +72,7 @@ your Cassandra cluster correctly. You can specify paths to the TLS certificates 
 The schema tool also supports TLS. You need to make a custom cqlshrc file like
 so:
 
-```
+```ini
 # Creating schema in a cassandra cluster requiring client TLS certificates.
 #
 # Create a volume for the schema docker container containing four files:

--- a/content/docs/v2/2.2/storage/elasticsearch.md
+++ b/content/docs/v2/2.2/storage/elasticsearch.md
@@ -143,6 +143,7 @@ To enable ILM support:
   }
   EOF
   ```
+
 * Run elasticsearch initializer with `ES_USE_ILM=true`:
 
   ```shell
@@ -151,6 +152,7 @@ To enable ILM support:
     jaegertracing/jaeger-es-rollover:latest \
     init http://localhost:9200 # <1>
   ```
+
   <1> If you need to initialize archive storage, add `-e ARCHIVE=true`.
 
   {{< info >}}

--- a/content/docs/v2/2.3/architecture/apis.md
+++ b/content/docs/v2/2.3/architecture/apis.md
@@ -53,11 +53,11 @@ Jaeger can receive trace data in multiple formats on different ports.
 
 **Status**: Stable
 
-Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats: 
+Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats:
   * [Protobuf via gRPC][otlp.grpc]
   * [Protobuf over HTTP][otlp.http]
   * [JSON over HTTP][otlp.http]
-  
+
 Only tracing data is accepted, since Jaeger does not store other telemetry types. For more details on the OTLP receiver see the [official documentation][otlp-rcvr].
 
 [otlp-rcvr]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md
@@ -75,7 +75,7 @@ Jaeger's legacy Protobuf format is defined in [collector.proto] IDL file. Suppor
 
 Jaeger's legacy Thrift format is defined in [jaeger.thrift] IDL file, and is only maintained for backwards compatibility. The Thrift payload can be submitted in an HTTP POST request to the  `/api/traces` endpoint, for example, `https://jaeger-collector:14268/api/traces`. The `Batch` struct needs to be encoded using Thrift's `binary` encoding, and the HTTP request should specify the content type header:
 
-```
+```http
 Content-Type: application/vnd.apache.thrift.binary
 ```
 

--- a/content/docs/v2/2.3/architecture/spm.md
+++ b/content/docs/v2/2.3/architecture/spm.md
@@ -61,7 +61,7 @@ An example configuration is available in the Jaeger repository: [config-spm.yaml
 * Enable the [SpanMetrics Connector][spanmetrics-conn] in the pipeline:
 ```yaml
 # Declare an exporter for metrics produced by the connector.
-# For example, a Prometheus server may be configured to scrape 
+# For example, a Prometheus server may be configured to scrape
 # the metrics from this endpoint.
 exporters:
   prometheus:
@@ -73,7 +73,7 @@ connectors:
     # any connector configuration options
     ...
 
-# Enable the spanmetrics connector to bridge 
+# Enable the spanmetrics connector to bridge
 # the traces pipeline into the metrics pipeline.
 service:
   pipelines:
@@ -85,6 +85,7 @@ service:
       receivers: [spanmetrics]
       exporters: [prometheus]
 ```
+
 * Define a remote PromQL-compatible storage under `metric_backends:` in the `jaeger_storage` extension:
 ```yaml
 extensions:
@@ -97,6 +98,7 @@ extensions:
         prometheus:
           endpoint: http://prometheus:9090
 ```
+
 * Reference this metrics store in the `jaeger_query` extension:
 ```yaml
 extensions:
@@ -104,6 +106,7 @@ extensions:
     traces: some_trace_storage
     metrics_storage: some_metrics_storage
 ```
+
 * Set the `monitor.menuEnabled=true` property in the [Jaeger UI configuration](../../deployment/frontend-ui/#monitor).
 
 ## Architecture
@@ -194,7 +197,8 @@ Two metric names will be created:
       `le >= span duration` will be incremented for each span.
 
 The following formula aims to provide some guidance on the number of new time series created:
-```
+
+```go
 num_status_codes * num_span_kinds * (1 + num_latency_buckets) * num_operations
 
 Where:
@@ -204,7 +208,8 @@ Where:
 ```
 
 Plugging those numbers in, assuming default configuration:
-```
+
+```go
 max = 324 * num_operations
 typical = 72 * num_operations
 ```
@@ -246,7 +251,7 @@ service:
       address: 0.0.0.0:8888
 ```
 
-The `/metrics` endpoint on this port can be used to check if UI queries for SPM data are successful: 
+The `/metrics` endpoint on this port can be used to check if UI queries for SPM data are successful:
 
 ```shell
 curl -s http://jaeger:8888/metrics | grep jaeger_metricstore
@@ -320,8 +325,9 @@ service:
 ```
 
 Outputting logs that resemble the following (formatted for readability):
-```
-2024-11-26T19:09:43.152Z debug metricsstore/reader.go:258 Prometheus query results	
+
+```json
+2024-11-26T19:09:43.152Z debug metricsstore/reader.go:258 Prometheus query results
 {
   "kind": "extension",
   "name": "jaeger_storage",
@@ -367,9 +373,11 @@ If there are error spans appearing in Jaeger, but no corresponding error metrics
   the `status.code` label in the metric that the span should belong to.
 - If there are no `status.code` labels, check the OpenTelemetry Collector
   configuration file, particularly for the presence of the following configuration:
+
   ```yaml
   exclude_dimensions: ['status.code']
   ```
+
   This label is used by Jaeger to determine if a request is erroneous.
 
 ### Inspect the OpenTelemetry Collector

--- a/content/docs/v2/2.3/deployment/_index.md
+++ b/content/docs/v2/2.3/deployment/_index.md
@@ -16,7 +16,7 @@ children:
 
 Jaeger backend is released as a single binary or container image (see [Downloads](../../../download/)). Despite that, it can be configured to operate in different **roles**, such as all-in-one, collector, query, and ingester (see [Architecture](../architecture/)). An explicit configuration file can be provided via the `--config` command line argument. When running in a container, the path to the config file must be mapped into the container file system (the `-v ...` mapping below):
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \
@@ -59,7 +59,7 @@ Sometimes these adjustments themselves make the trace hard to understand. For ex
 
 The `jaeger_query` extension supports a configuration property that controls how much clock skew adjustment should be allowed.
 
-```
+```yaml
 extensions:
   jaeger_query:
     max_clock_skew_adjust: 30s
@@ -71,7 +71,7 @@ extensions:
 
 The base path for all `jaeger_query` extension HTTP routes can be set to a non-root value, e.g. `/jaeger` would cause all UI URLs to start with `/jaeger`. This can be useful when running Jaeger behind a reverse proxy. Here is example code to set the base path.
 
-```
+```yaml
 extensions:
   jaeger_query:
     base_path: /

--- a/content/docs/v2/2.3/deployment/frontend-ui.md
+++ b/content/docs/v2/2.3/deployment/frontend-ui.md
@@ -194,7 +194,7 @@ The embedded mode is induced and configured via URL query parameters.
 
 To enter embedded mode, the `uiEmbed=v0` query parameter and value must be added to the URL. For example, the following URL will show the trace with ID `abc123` in embedded mode:
 
-```
+```text
 http://localhost:16686/trace/abc123?uiEmbed=v0
 ```
 
@@ -213,7 +213,7 @@ To integrate the Search Trace Page to our application we have to indicate to the
 
 For example:
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -233,7 +233,7 @@ The following query parameter can be used to configure the layout of the search 
 
 * `uiSearchHideGraph=1` - disables the display of the scatter plot above the search results
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -258,6 +258,7 @@ For example:
 ```sh
 http://localhost:16686/trace/{trace-id}?uiEmbed=v0
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view.png)](/img/frontend-ui/embed-trace-view.png)
 
 If we have navigated to this view from the search traces page we'll have a button to go back to the results page.
@@ -270,36 +271,40 @@ The following query parameters can be used to configure the layout of the trace 
 
 * `uiTimelineCollapseTitle=1` causes the trace header to start out collapsed, which hides the summary and the minimap.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineCollapseTitle=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-collapse.png)](/img/frontend-ui/embed-trace-view-with-collapse.png)
 
 * `uiTimelineHideMinimap=1` removes the minimap, entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)
 
 * `uiTimelineHideSummary=1` - removes the trace summary information (number of services, etc.) entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-summary.png)](/img/frontend-ui/embed-trace-view-with-hide-summary.png)
 
 We can also combine the options:
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)

--- a/content/docs/v2/2.3/getting-started.md
+++ b/content/docs/v2/2.3/getting-started.md
@@ -10,7 +10,7 @@ If you are new to distributed tracing, please check the [Introduction](../) page
 
 The easiest way to run Jaeger is by starting it in a container:
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \
@@ -24,7 +24,7 @@ This runs the **all-in-one** configuration of Jaeger ([see Architecture](../arch
 
 In order to run Jaeger in other roles ([see Architecture](../architecture/)), an explicit configuration file ([see Configuration](../deployment/configuration/)) must be provided via the `--config` command line argument. When running in a container, the path to the config file must be mapped into the container file system (the `-v ...` mapping below):
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \

--- a/content/docs/v2/2.3/operations/monitoring.md
+++ b/content/docs/v2/2.3/operations/monitoring.md
@@ -13,13 +13,13 @@ Please refer to [OpenTelemetry Collector documentation](https://opentelemetry.io
 
 Here's a sample `curl` call to obtain the metrics:
 
-```
+```sh
 curl -s http://jaeger-collector:8888/metrics
 ```
 
 The following metrics are of special interest:
 
-```
+```ini
 otelcol_receiver_accepted_spans
 otelcol_receiver_refused_spans
 
@@ -31,7 +31,7 @@ The first two metrics describe how many spans are being received by Jaeger. The 
 
 The labels on the metrics allow to separate different receivers and exporters. For example, the first metric with all labels might look like this (formatted for readability):
 
-```
+```ini
 otelcol_receiver_accepted_spans{
     receiver="otlp",
     service_instance_id="f91d66c2-0445-42bf-a062-32aaed09facf",

--- a/content/docs/v2/2.3/operations/troubleshooting.md
+++ b/content/docs/v2/2.3/operations/troubleshooting.md
@@ -29,9 +29,9 @@ If you suspect the remote sampling is not working correctly, try these steps:
 
 1. Make sure that the SDK is actually configured to use remote sampling, points to the correct sampling service address (see [APIs](../../architecture/apis/#remote-sampling-configuration)), and that address is reachable from your application's [networking namespace](#network-connectivity).
 1. Verify that the server is returning the appropriate sampling strategy for your service:
-```
-    $ curl "jaeger-collector:14268/api/sampling?service=foobar"
-    {"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
+```console
+$ curl "jaeger-collector:14268/api/sampling?service=foobar"
+{"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
 ```
 
 ## Bypass intermediate collectors
@@ -54,7 +54,7 @@ Jaeger provides useful debugging information when the log level is set to `debug
 
 For the cases where it's not possible or desirable to increase the logging verbosity, the `/metrics` endpoint can be used to check how trace data is being received and processed by Jaeger. See [Monitoring](../monitoring/#logging) for more details on configuring metrics production. Here's a sample `curl` call to obtain the metrics:
 
-```
+```sh
 curl -s http://jaeger-collector:8888/metrics
 ```
 

--- a/content/docs/v2/2.3/storage/cassandra.md
+++ b/content/docs/v2/2.3/storage/cassandra.md
@@ -72,7 +72,7 @@ your Cassandra cluster correctly. You can specify paths to the TLS certificates 
 The schema tool also supports TLS. You need to make a custom cqlshrc file like
 so:
 
-```
+```ini
 # Creating schema in a cassandra cluster requiring client TLS certificates.
 #
 # Create a volume for the schema docker container containing four files:

--- a/content/docs/v2/2.3/storage/elasticsearch.md
+++ b/content/docs/v2/2.3/storage/elasticsearch.md
@@ -143,6 +143,7 @@ To enable ILM support:
   }
   EOF
   ```
+
 * Run elasticsearch initializer with `ES_USE_ILM=true`:
 
   ```shell
@@ -151,6 +152,7 @@ To enable ILM support:
     jaegertracing/jaeger-es-rollover:latest \
     init http://localhost:9200 # <1>
   ```
+
   <1> If you need to initialize archive storage, add `-e ARCHIVE=true`.
 
   {{< info >}}

--- a/content/docs/v2/2.4/architecture/apis.md
+++ b/content/docs/v2/2.4/architecture/apis.md
@@ -53,11 +53,11 @@ Jaeger can receive trace data in multiple formats on different ports.
 
 **Status**: Stable
 
-Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats: 
+Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats:
   * [Protobuf via gRPC][otlp.grpc]
   * [Protobuf over HTTP][otlp.http]
   * [JSON over HTTP][otlp.http]
-  
+
 Only tracing data is accepted, since Jaeger does not store other telemetry types. For more details on the OTLP receiver see the [official documentation][otlp-rcvr].
 
 [otlp-rcvr]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md
@@ -75,7 +75,7 @@ Jaeger's legacy Protobuf format is defined in [collector.proto] IDL file. Suppor
 
 Jaeger's legacy Thrift format is defined in [jaeger.thrift] IDL file, and is only maintained for backwards compatibility. The Thrift payload can be submitted in an HTTP POST request to the  `/api/traces` endpoint, for example, `https://jaeger-collector:14268/api/traces`. The `Batch` struct needs to be encoded using Thrift's `binary` encoding, and the HTTP request should specify the content type header:
 
-```
+```http
 Content-Type: application/vnd.apache.thrift.binary
 ```
 

--- a/content/docs/v2/2.4/architecture/spm.md
+++ b/content/docs/v2/2.4/architecture/spm.md
@@ -61,7 +61,7 @@ An example configuration is available in the Jaeger repository: [config-spm.yaml
 * Enable the [SpanMetrics Connector][spanmetrics-conn] in the pipeline:
 ```yaml
 # Declare an exporter for metrics produced by the connector.
-# For example, a Prometheus server may be configured to scrape 
+# For example, a Prometheus server may be configured to scrape
 # the metrics from this endpoint.
 exporters:
   prometheus:
@@ -73,7 +73,7 @@ connectors:
     # any connector configuration options
     ...
 
-# Enable the spanmetrics connector to bridge 
+# Enable the spanmetrics connector to bridge
 # the traces pipeline into the metrics pipeline.
 service:
   pipelines:
@@ -85,6 +85,7 @@ service:
       receivers: [spanmetrics]
       exporters: [prometheus]
 ```
+
 * Define a remote PromQL-compatible storage under `metric_backends:` in the `jaeger_storage` extension:
 ```yaml
 extensions:
@@ -97,6 +98,7 @@ extensions:
         prometheus:
           endpoint: http://prometheus:9090
 ```
+
 * Reference this metrics store in the `jaeger_query` extension:
 ```yaml
 extensions:
@@ -104,6 +106,7 @@ extensions:
     traces: some_trace_storage
     metrics_storage: some_metrics_storage
 ```
+
 * Set the `monitor.menuEnabled=true` property in the [Jaeger UI configuration](../../deployment/frontend-ui/#monitor).
 
 ## Architecture
@@ -194,7 +197,8 @@ Two metric names will be created:
       `le >= span duration` will be incremented for each span.
 
 The following formula aims to provide some guidance on the number of new time series created:
-```
+
+```go
 num_status_codes * num_span_kinds * (1 + num_latency_buckets) * num_operations
 
 Where:
@@ -204,7 +208,8 @@ Where:
 ```
 
 Plugging those numbers in, assuming default configuration:
-```
+
+```go
 max = 324 * num_operations
 typical = 72 * num_operations
 ```
@@ -246,7 +251,7 @@ service:
       address: 0.0.0.0:8888
 ```
 
-The `/metrics` endpoint on this port can be used to check if UI queries for SPM data are successful: 
+The `/metrics` endpoint on this port can be used to check if UI queries for SPM data are successful:
 
 ```shell
 curl -s http://jaeger:8888/metrics | grep jaeger_metricstore
@@ -320,8 +325,9 @@ service:
 ```
 
 Outputting logs that resemble the following (formatted for readability):
-```
-2024-11-26T19:09:43.152Z debug metricsstore/reader.go:258 Prometheus query results	
+
+```json
+2024-11-26T19:09:43.152Z debug metricsstore/reader.go:258 Prometheus query results
 {
   "kind": "extension",
   "name": "jaeger_storage",
@@ -367,9 +373,11 @@ If there are error spans appearing in Jaeger, but no corresponding error metrics
   the `status.code` label in the metric that the span should belong to.
 - If there are no `status.code` labels, check the OpenTelemetry Collector
   configuration file, particularly for the presence of the following configuration:
+
   ```yaml
   exclude_dimensions: ['status.code']
   ```
+
   This label is used by Jaeger to determine if a request is erroneous.
 
 ### Inspect the OpenTelemetry Collector

--- a/content/docs/v2/2.4/deployment/_index.md
+++ b/content/docs/v2/2.4/deployment/_index.md
@@ -16,7 +16,7 @@ children:
 
 Jaeger backend is released as a single binary or container image (see [Downloads](../../../download/)). Despite that, it can be configured to operate in different **roles**, such as all-in-one, collector, query, and ingester (see [Architecture](../architecture/)). An explicit configuration file can be provided via the `--config` command line argument. When running in a container, the path to the config file must be mapped into the container file system (the `-v ...` mapping below):
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \
@@ -59,7 +59,7 @@ Sometimes these adjustments themselves make the trace hard to understand. For ex
 
 The `jaeger_query` extension supports a configuration property that controls how much clock skew adjustment should be allowed.
 
-```
+```yaml
 extensions:
   jaeger_query:
     max_clock_skew_adjust: 30s
@@ -71,7 +71,7 @@ extensions:
 
 The base path for all `jaeger_query` extension HTTP routes can be set to a non-root value, e.g. `/jaeger` would cause all UI URLs to start with `/jaeger`. This can be useful when running Jaeger behind a reverse proxy. Here is example code to set the base path.
 
-```
+```yaml
 extensions:
   jaeger_query:
     base_path: /

--- a/content/docs/v2/2.4/deployment/configuration.md
+++ b/content/docs/v2/2.4/deployment/configuration.md
@@ -32,7 +32,8 @@ One category of environment variables that Jaeger v2 does recognize automaticall
 ### Config Overrides
 
 Another way to override certain config values is by passing them via `--set` command line flags:
-```
+
+```sh
 --set=receivers.otlp.protocols.grpc.endpoint=0.0.0.0:4317
 ```
 

--- a/content/docs/v2/2.4/deployment/frontend-ui.md
+++ b/content/docs/v2/2.4/deployment/frontend-ui.md
@@ -194,7 +194,7 @@ The embedded mode is induced and configured via URL query parameters.
 
 To enter embedded mode, the `uiEmbed=v0` query parameter and value must be added to the URL. For example, the following URL will show the trace with ID `abc123` in embedded mode:
 
-```
+```text
 http://localhost:16686/trace/abc123?uiEmbed=v0
 ```
 
@@ -213,7 +213,7 @@ To integrate the Search Trace Page to our application we have to indicate to the
 
 For example:
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -233,7 +233,7 @@ The following query parameter can be used to configure the layout of the search 
 
 * `uiSearchHideGraph=1` - disables the display of the scatter plot above the search results
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -258,6 +258,7 @@ For example:
 ```sh
 http://localhost:16686/trace/{trace-id}?uiEmbed=v0
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view.png)](/img/frontend-ui/embed-trace-view.png)
 
 If we have navigated to this view from the search traces page we'll have a button to go back to the results page.
@@ -270,36 +271,40 @@ The following query parameters can be used to configure the layout of the trace 
 
 * `uiTimelineCollapseTitle=1` causes the trace header to start out collapsed, which hides the summary and the minimap.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineCollapseTitle=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-collapse.png)](/img/frontend-ui/embed-trace-view-with-collapse.png)
 
 * `uiTimelineHideMinimap=1` removes the minimap, entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)
 
 * `uiTimelineHideSummary=1` - removes the trace summary information (number of services, etc.) entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-summary.png)](/img/frontend-ui/embed-trace-view-with-hide-summary.png)
 
 We can also combine the options:
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)

--- a/content/docs/v2/2.4/getting-started.md
+++ b/content/docs/v2/2.4/getting-started.md
@@ -10,7 +10,7 @@ If you are new to distributed tracing, please check the [Introduction](../) page
 
 The easiest way to run Jaeger is by starting it in a container:
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \
@@ -24,7 +24,7 @@ This runs the **all-in-one** configuration of Jaeger ([see Architecture](../arch
 
 In order to run Jaeger in other roles ([see Architecture](../architecture/)), an explicit configuration file ([see Configuration](../deployment/configuration/)) must be provided via the `--config` command line argument. When running in a container, the path to the config file must be mapped into the container file system (the `-v ...` mapping below):
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \

--- a/content/docs/v2/2.4/operations/monitoring.md
+++ b/content/docs/v2/2.4/operations/monitoring.md
@@ -13,13 +13,13 @@ Please refer to [OpenTelemetry Collector documentation](https://opentelemetry.io
 
 Here's a sample `curl` call to obtain the metrics:
 
-```
+```sh
 curl -s http://jaeger-collector:8888/metrics
 ```
 
 The following metrics are of special interest:
 
-```
+```ini
 otelcol_receiver_accepted_spans
 otelcol_receiver_refused_spans
 
@@ -31,7 +31,7 @@ The first two metrics describe how many spans are being received by Jaeger. The 
 
 The labels on the metrics allow to separate different receivers and exporters. For example, the first metric with all labels might look like this (formatted for readability):
 
-```
+```ini
 otelcol_receiver_accepted_spans{
     receiver="otlp",
     service_instance_id="f91d66c2-0445-42bf-a062-32aaed09facf",

--- a/content/docs/v2/2.4/operations/troubleshooting.md
+++ b/content/docs/v2/2.4/operations/troubleshooting.md
@@ -29,9 +29,9 @@ If you suspect the remote sampling is not working correctly, try these steps:
 
 1. Make sure that the SDK is actually configured to use remote sampling, points to the correct sampling service address (see [APIs](../../architecture/apis/#remote-sampling-configuration)), and that address is reachable from your application's [networking namespace](#network-connectivity).
 1. Verify that the server is returning the appropriate sampling strategy for your service:
-```
-    $ curl "jaeger-collector:14268/api/sampling?service=foobar"
-    {"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
+```console
+$ curl "jaeger-collector:14268/api/sampling?service=foobar"
+{"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
 ```
 
 ## Bypass intermediate collectors
@@ -54,7 +54,7 @@ Jaeger provides useful debugging information when the log level is set to `debug
 
 For the cases where it's not possible or desirable to increase the logging verbosity, the `/metrics` endpoint can be used to check how trace data is being received and processed by Jaeger. See [Monitoring](../monitoring/#logging) for more details on configuring metrics production. Here's a sample `curl` call to obtain the metrics:
 
-```
+```sh
 curl -s http://jaeger-collector:8888/metrics
 ```
 

--- a/content/docs/v2/2.4/storage/cassandra.md
+++ b/content/docs/v2/2.4/storage/cassandra.md
@@ -72,7 +72,7 @@ your Cassandra cluster correctly. You can specify paths to the TLS certificates 
 The schema tool also supports TLS. You need to make a custom cqlshrc file like
 so:
 
-```
+```ini
 # Creating schema in a cassandra cluster requiring client TLS certificates.
 #
 # Create a volume for the schema docker container containing four files:

--- a/content/docs/v2/2.4/storage/elasticsearch.md
+++ b/content/docs/v2/2.4/storage/elasticsearch.md
@@ -143,6 +143,7 @@ To enable ILM support:
   }
   EOF
   ```
+
 * Run elasticsearch initializer with `ES_USE_ILM=true`:
 
   ```shell
@@ -151,6 +152,7 @@ To enable ILM support:
     jaegertracing/jaeger-es-rollover:latest \
     init http://localhost:9200 # <1>
   ```
+
   <1> If you need to initialize archive storage, add `-e ARCHIVE=true`.
 
   {{< info >}}

--- a/content/docs/v2/2.5/architecture/apis.md
+++ b/content/docs/v2/2.5/architecture/apis.md
@@ -53,11 +53,11 @@ Jaeger can receive trace data in multiple formats on different ports.
 
 **Status**: Stable
 
-Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats: 
+Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats:
   * [Protobuf via gRPC][otlp.grpc]
   * [Protobuf over HTTP][otlp.http]
   * [JSON over HTTP][otlp.http]
-  
+
 Only tracing data is accepted, since Jaeger does not store other telemetry types. For more details on the OTLP receiver see the [official documentation][otlp-rcvr].
 
 [otlp-rcvr]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md
@@ -75,7 +75,7 @@ Jaeger's legacy Protobuf format is defined in [collector.proto] IDL file. Suppor
 
 Jaeger's legacy Thrift format is defined in [jaeger.thrift] IDL file, and is only maintained for backwards compatibility. The Thrift payload can be submitted in an HTTP POST request to the  `/api/traces` endpoint, for example, `https://jaeger-collector:14268/api/traces`. The `Batch` struct needs to be encoded using Thrift's `binary` encoding, and the HTTP request should specify the content type header:
 
-```
+```http
 Content-Type: application/vnd.apache.thrift.binary
 ```
 

--- a/content/docs/v2/2.5/architecture/spm.md
+++ b/content/docs/v2/2.5/architecture/spm.md
@@ -61,7 +61,7 @@ An example configuration is available in the Jaeger repository: [config-spm.yaml
 * Enable the [SpanMetrics Connector][spanmetrics-conn] in the pipeline:
 ```yaml
 # Declare an exporter for metrics produced by the connector.
-# For example, a Prometheus server may be configured to scrape 
+# For example, a Prometheus server may be configured to scrape
 # the metrics from this endpoint.
 exporters:
   prometheus:
@@ -73,7 +73,7 @@ connectors:
     # any connector configuration options
     ...
 
-# Enable the spanmetrics connector to bridge 
+# Enable the spanmetrics connector to bridge
 # the traces pipeline into the metrics pipeline.
 service:
   pipelines:
@@ -85,6 +85,7 @@ service:
       receivers: [spanmetrics]
       exporters: [prometheus]
 ```
+
 * Define a remote PromQL-compatible storage under `metric_backends:` in the `jaeger_storage` extension:
 ```yaml
 extensions:
@@ -97,6 +98,7 @@ extensions:
         prometheus:
           endpoint: http://prometheus:9090
 ```
+
 * Reference this metrics store in the `jaeger_query` extension:
 ```yaml
 extensions:
@@ -104,6 +106,7 @@ extensions:
     traces: some_trace_storage
     metrics_storage: some_metrics_storage
 ```
+
 * Set the `monitor.menuEnabled=true` property in the [Jaeger UI configuration](../../deployment/frontend-ui/#monitor).
 
 ## Architecture
@@ -194,7 +197,8 @@ Two metric names will be created:
       `le >= span duration` will be incremented for each span.
 
 The following formula aims to provide some guidance on the number of new time series created:
-```
+
+```go
 num_status_codes * num_span_kinds * (1 + num_latency_buckets) * num_operations
 
 Where:
@@ -204,7 +208,8 @@ Where:
 ```
 
 Plugging those numbers in, assuming default configuration:
-```
+
+```go
 max = 324 * num_operations
 typical = 72 * num_operations
 ```
@@ -246,7 +251,7 @@ service:
       address: 0.0.0.0:8888
 ```
 
-The `/metrics` endpoint on this port can be used to check if UI queries for SPM data are successful: 
+The `/metrics` endpoint on this port can be used to check if UI queries for SPM data are successful:
 
 ```shell
 curl -s http://jaeger:8888/metrics | grep jaeger_metricstore
@@ -320,8 +325,9 @@ service:
 ```
 
 Outputting logs that resemble the following (formatted for readability):
-```
-2024-11-26T19:09:43.152Z debug metricsstore/reader.go:258 Prometheus query results	
+
+```json
+2024-11-26T19:09:43.152Z debug metricsstore/reader.go:258 Prometheus query results
 {
   "kind": "extension",
   "name": "jaeger_storage",
@@ -367,9 +373,11 @@ If there are error spans appearing in Jaeger, but no corresponding error metrics
   the `status.code` label in the metric that the span should belong to.
 - If there are no `status.code` labels, check the OpenTelemetry Collector
   configuration file, particularly for the presence of the following configuration:
+
   ```yaml
   exclude_dimensions: ['status.code']
   ```
+
   This label is used by Jaeger to determine if a request is erroneous.
 
 ### Inspect the OpenTelemetry Collector

--- a/content/docs/v2/2.5/deployment/_index.md
+++ b/content/docs/v2/2.5/deployment/_index.md
@@ -16,7 +16,7 @@ children:
 
 Jaeger backend is released as a single binary or container image (see [Downloads](../../../download/)). Despite that, it can be configured to operate in different **roles**, such as all-in-one, collector, query, and ingester (see [Architecture](../architecture/)). An explicit configuration file can be provided via the `--config` command line argument. When running in a container, the path to the config file must be mapped into the container file system (the `-v ...` mapping below):
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \
@@ -59,7 +59,7 @@ Sometimes these adjustments themselves make the trace hard to understand. For ex
 
 The `jaeger_query` extension supports a configuration property that controls how much clock skew adjustment should be allowed.
 
-```
+```yaml
 extensions:
   jaeger_query:
     max_clock_skew_adjust: 30s
@@ -71,7 +71,7 @@ extensions:
 
 The base path for all `jaeger_query` extension HTTP routes can be set to a non-root value, e.g. `/jaeger` would cause all UI URLs to start with `/jaeger`. This can be useful when running Jaeger behind a reverse proxy. Here is example code to set the base path.
 
-```
+```yaml
 extensions:
   jaeger_query:
     base_path: /

--- a/content/docs/v2/2.5/deployment/configuration.md
+++ b/content/docs/v2/2.5/deployment/configuration.md
@@ -32,7 +32,8 @@ One category of environment variables that Jaeger v2 does recognize automaticall
 ### Config Overrides
 
 Another way to override certain config values is by passing them via `--set` command line flags:
-```
+
+```sh
 --set=receivers.otlp.protocols.grpc.endpoint=0.0.0.0:4317
 ```
 

--- a/content/docs/v2/2.5/deployment/frontend-ui.md
+++ b/content/docs/v2/2.5/deployment/frontend-ui.md
@@ -194,7 +194,7 @@ The embedded mode is induced and configured via URL query parameters.
 
 To enter embedded mode, the `uiEmbed=v0` query parameter and value must be added to the URL. For example, the following URL will show the trace with ID `abc123` in embedded mode:
 
-```
+```text
 http://localhost:16686/trace/abc123?uiEmbed=v0
 ```
 
@@ -213,7 +213,7 @@ To integrate the Search Trace Page to our application we have to indicate to the
 
 For example:
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -233,7 +233,7 @@ The following query parameter can be used to configure the layout of the search 
 
 * `uiSearchHideGraph=1` - disables the display of the scatter plot above the search results
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -258,6 +258,7 @@ For example:
 ```sh
 http://localhost:16686/trace/{trace-id}?uiEmbed=v0
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view.png)](/img/frontend-ui/embed-trace-view.png)
 
 If we have navigated to this view from the search traces page we'll have a button to go back to the results page.
@@ -270,36 +271,40 @@ The following query parameters can be used to configure the layout of the trace 
 
 * `uiTimelineCollapseTitle=1` causes the trace header to start out collapsed, which hides the summary and the minimap.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineCollapseTitle=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-collapse.png)](/img/frontend-ui/embed-trace-view-with-collapse.png)
 
 * `uiTimelineHideMinimap=1` removes the minimap, entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)
 
 * `uiTimelineHideSummary=1` - removes the trace summary information (number of services, etc.) entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-summary.png)](/img/frontend-ui/embed-trace-view-with-hide-summary.png)
 
 We can also combine the options:
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)

--- a/content/docs/v2/2.5/getting-started.md
+++ b/content/docs/v2/2.5/getting-started.md
@@ -10,7 +10,7 @@ If you are new to distributed tracing, please check the [Introduction](../) page
 
 The easiest way to run Jaeger is by starting it in a container:
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \
@@ -24,7 +24,7 @@ This runs the **all-in-one** configuration of Jaeger ([see Architecture](../arch
 
 In order to run Jaeger in other roles ([see Architecture](../architecture/)), an explicit configuration file ([see Configuration](../deployment/configuration/)) must be provided via the `--config` command line argument. When running in a container, the path to the config file must be mapped into the container file system (the `-v ...` mapping below):
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \

--- a/content/docs/v2/2.5/operations/monitoring.md
+++ b/content/docs/v2/2.5/operations/monitoring.md
@@ -13,13 +13,13 @@ Please refer to [OpenTelemetry Collector documentation](https://opentelemetry.io
 
 Here's a sample `curl` call to obtain the metrics:
 
-```
+```sh
 curl -s http://jaeger-collector:8888/metrics
 ```
 
 The following metrics are of special interest:
 
-```
+```ini
 otelcol_receiver_accepted_spans
 otelcol_receiver_refused_spans
 
@@ -31,7 +31,7 @@ The first two metrics describe how many spans are being received by Jaeger. The 
 
 The labels on the metrics allow to separate different receivers and exporters. For example, the first metric with all labels might look like this (formatted for readability):
 
-```
+```ini
 otelcol_receiver_accepted_spans{
     receiver="otlp",
     service_instance_id="f91d66c2-0445-42bf-a062-32aaed09facf",

--- a/content/docs/v2/2.5/operations/troubleshooting.md
+++ b/content/docs/v2/2.5/operations/troubleshooting.md
@@ -29,9 +29,9 @@ If you suspect the remote sampling is not working correctly, try these steps:
 
 1. Make sure that the SDK is actually configured to use remote sampling, points to the correct sampling service address (see [APIs](../../architecture/apis/#remote-sampling-configuration)), and that address is reachable from your application's [networking namespace](#network-connectivity).
 1. Verify that the server is returning the appropriate sampling strategy for your service:
-```
-    $ curl "jaeger-collector:14268/api/sampling?service=foobar"
-    {"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
+```console
+$ curl "jaeger-collector:14268/api/sampling?service=foobar"
+{"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
 ```
 
 ## Bypass intermediate collectors
@@ -54,7 +54,7 @@ Jaeger provides useful debugging information when the log level is set to `debug
 
 For the cases where it's not possible or desirable to increase the logging verbosity, the `/metrics` endpoint can be used to check how trace data is being received and processed by Jaeger. See [Monitoring](../monitoring/#logging) for more details on configuring metrics production. Here's a sample `curl` call to obtain the metrics:
 
-```
+```sh
 curl -s http://jaeger-collector:8888/metrics
 ```
 

--- a/content/docs/v2/2.5/storage/cassandra.md
+++ b/content/docs/v2/2.5/storage/cassandra.md
@@ -72,7 +72,7 @@ your Cassandra cluster correctly. You can specify paths to the TLS certificates 
 The schema tool also supports TLS. You need to make a custom cqlshrc file like
 so:
 
-```
+```ini
 # Creating schema in a cassandra cluster requiring client TLS certificates.
 #
 # Create a volume for the schema docker container containing four files:

--- a/content/docs/v2/2.5/storage/elasticsearch.md
+++ b/content/docs/v2/2.5/storage/elasticsearch.md
@@ -143,6 +143,7 @@ To enable ILM support:
   }
   EOF
   ```
+
 * Run elasticsearch initializer with `ES_USE_ILM=true`:
 
   ```shell
@@ -151,6 +152,7 @@ To enable ILM support:
     jaegertracing/jaeger-es-rollover:latest \
     init http://localhost:9200 # <1>
   ```
+
   <1> If you need to initialize archive storage, add `-e ARCHIVE=true`.
 
   {{< info >}}

--- a/content/docs/v2/2.6/architecture/apis.md
+++ b/content/docs/v2/2.6/architecture/apis.md
@@ -53,11 +53,11 @@ Jaeger can receive trace data in multiple formats on different ports.
 
 **Status**: Stable
 
-Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats: 
+Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats:
   * [Protobuf via gRPC][otlp.grpc]
   * [Protobuf over HTTP][otlp.http]
   * [JSON over HTTP][otlp.http]
-  
+
 Only tracing data is accepted, since Jaeger does not store other telemetry types. For more details on the OTLP receiver see the [official documentation][otlp-rcvr].
 
 [otlp-rcvr]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md
@@ -75,7 +75,7 @@ Jaeger's legacy Protobuf format is defined in [collector.proto] IDL file. Suppor
 
 Jaeger's legacy Thrift format is defined in [jaeger.thrift] IDL file, and is only maintained for backwards compatibility. The Thrift payload can be submitted in an HTTP POST request to the  `/api/traces` endpoint, for example, `https://jaeger-collector:14268/api/traces`. The `Batch` struct needs to be encoded using Thrift's `binary` encoding, and the HTTP request should specify the content type header:
 
-```
+```http
 Content-Type: application/vnd.apache.thrift.binary
 ```
 
@@ -129,11 +129,11 @@ the gRPC Remote Storage API.
 To use a remote storage backend, you must deploy a gRPC server that implements
 the following services:
 
-* **[TraceReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/trace_storage.proto)**  
+* **[TraceReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/trace_storage.proto)**
   Enables Jaeger to read traces from the storage backend.
-* **[DependencyReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/dependency_storage.proto)**  
+* **[DependencyReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/dependency_storage.proto)**
   Used to load service dependency graphs from storage.
-* **[TraceService](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/trace/v1/trace_service.proto)**  
+* **[TraceService](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/trace/v1/trace_service.proto)**
   Allows trace data to be pushed to the storage. This service can run on a separate port if needed.
 
 For more information, please refer to

--- a/content/docs/v2/2.6/architecture/spm.md
+++ b/content/docs/v2/2.6/architecture/spm.md
@@ -61,7 +61,7 @@ An example configuration is available in the Jaeger repository: [config-spm.yaml
 * Enable the [SpanMetrics Connector][spanmetrics-conn] in the pipeline:
 ```yaml
 # Declare an exporter for metrics produced by the connector.
-# For example, a Prometheus server may be configured to scrape 
+# For example, a Prometheus server may be configured to scrape
 # the metrics from this endpoint.
 exporters:
   prometheus:
@@ -73,7 +73,7 @@ connectors:
     # any connector configuration options
     ...
 
-# Enable the spanmetrics connector to bridge 
+# Enable the spanmetrics connector to bridge
 # the traces pipeline into the metrics pipeline.
 service:
   pipelines:
@@ -85,6 +85,7 @@ service:
       receivers: [spanmetrics]
       exporters: [prometheus]
 ```
+
 * Define a remote PromQL-compatible storage under `metric_backends:` in the `jaeger_storage` extension:
 ```yaml
 extensions:
@@ -97,6 +98,7 @@ extensions:
         prometheus:
           endpoint: http://prometheus:9090
 ```
+
 * Reference this metrics store in the `jaeger_query` extension:
 ```yaml
 extensions:
@@ -104,6 +106,7 @@ extensions:
     traces: some_trace_storage
     metrics_storage: some_metrics_storage
 ```
+
 * Set the `monitor.menuEnabled=true` property in the [Jaeger UI configuration](../../deployment/frontend-ui/#monitor).
 
 ## Architecture
@@ -194,7 +197,8 @@ Two metric names will be created:
       `le >= span duration` will be incremented for each span.
 
 The following formula aims to provide some guidance on the number of new time series created:
-```
+
+```go
 num_status_codes * num_span_kinds * (1 + num_latency_buckets) * num_operations
 
 Where:
@@ -204,7 +208,8 @@ Where:
 ```
 
 Plugging those numbers in, assuming default configuration:
-```
+
+```go
 max = 324 * num_operations
 typical = 72 * num_operations
 ```
@@ -246,7 +251,7 @@ service:
       address: 0.0.0.0:8888
 ```
 
-The `/metrics` endpoint on this port can be used to check if UI queries for SPM data are successful: 
+The `/metrics` endpoint on this port can be used to check if UI queries for SPM data are successful:
 
 ```shell
 curl -s http://jaeger:8888/metrics | grep jaeger_metricstore
@@ -320,8 +325,9 @@ service:
 ```
 
 Outputting logs that resemble the following (formatted for readability):
-```
-2024-11-26T19:09:43.152Z debug metricsstore/reader.go:258 Prometheus query results	
+
+```json
+2024-11-26T19:09:43.152Z debug metricsstore/reader.go:258 Prometheus query results
 {
   "kind": "extension",
   "name": "jaeger_storage",
@@ -367,9 +373,11 @@ If there are error spans appearing in Jaeger, but no corresponding error metrics
   the `status.code` label in the metric that the span should belong to.
 - If there are no `status.code` labels, check the OpenTelemetry Collector
   configuration file, particularly for the presence of the following configuration:
+
   ```yaml
   exclude_dimensions: ['status.code']
   ```
+
   This label is used by Jaeger to determine if a request is erroneous.
 
 ### Inspect the OpenTelemetry Collector

--- a/content/docs/v2/2.6/deployment/_index.md
+++ b/content/docs/v2/2.6/deployment/_index.md
@@ -20,7 +20,7 @@ Jaeger backend is released as a single binary or container image (see [Downloads
 
 An explicit YAML configuration file must be provided via the `--config` command line argument (see [Configuration](./configuration/)). When running in a container, the path to the config file must be mapped into the container file system (the `-v ...` mapping below):
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \

--- a/content/docs/v2/2.6/deployment/configuration.md
+++ b/content/docs/v2/2.6/deployment/configuration.md
@@ -40,7 +40,8 @@ One category of environment variables that Jaeger v2 does recognize automaticall
 ### Config Overrides
 
 Another way to override certain config values is by passing them via `--set` command line flags:
-```
+
+```sh
 --set=receivers.otlp.protocols.grpc.endpoint=0.0.0.0:4317
 ```
 
@@ -106,7 +107,7 @@ Sometimes these adjustments themselves make the trace hard to understand. For ex
 
 The `jaeger_query` extension supports a configuration property that controls how much clock skew adjustment should be allowed.
 
-```
+```yaml
 extensions:
   jaeger_query:
     max_clock_skew_adjust: 30s
@@ -118,7 +119,7 @@ extensions:
 
 The base path for all `jaeger_query` extension HTTP routes can be set to a non-root value, e.g. `/jaeger` would cause all UI URLs to start with `/jaeger`. This can be useful when running Jaeger behind a reverse proxy. Here is example code to set the base path.
 
-```
+```yaml
 extensions:
   jaeger_query:
     base_path: /

--- a/content/docs/v2/2.6/deployment/frontend-ui.md
+++ b/content/docs/v2/2.6/deployment/frontend-ui.md
@@ -194,7 +194,7 @@ The embedded mode is induced and configured via URL query parameters.
 
 To enter embedded mode, the `uiEmbed=v0` query parameter and value must be added to the URL. For example, the following URL will show the trace with ID `abc123` in embedded mode:
 
-```
+```text
 http://localhost:16686/trace/abc123?uiEmbed=v0
 ```
 
@@ -213,7 +213,7 @@ To integrate the Search Trace Page to our application we have to indicate to the
 
 For example:
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -233,7 +233,7 @@ The following query parameter can be used to configure the layout of the search 
 
 * `uiSearchHideGraph=1` - disables the display of the scatter plot above the search results
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -258,6 +258,7 @@ For example:
 ```sh
 http://localhost:16686/trace/{trace-id}?uiEmbed=v0
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view.png)](/img/frontend-ui/embed-trace-view.png)
 
 If we have navigated to this view from the search traces page we'll have a button to go back to the results page.
@@ -270,36 +271,40 @@ The following query parameters can be used to configure the layout of the trace 
 
 * `uiTimelineCollapseTitle=1` causes the trace header to start out collapsed, which hides the summary and the minimap.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineCollapseTitle=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-collapse.png)](/img/frontend-ui/embed-trace-view-with-collapse.png)
 
 * `uiTimelineHideMinimap=1` removes the minimap, entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)
 
 * `uiTimelineHideSummary=1` - removes the trace summary information (number of services, etc.) entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-summary.png)](/img/frontend-ui/embed-trace-view-with-hide-summary.png)
 
 We can also combine the options:
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)

--- a/content/docs/v2/2.6/getting-started.md
+++ b/content/docs/v2/2.6/getting-started.md
@@ -10,7 +10,7 @@ If you are new to distributed tracing, please check the [Introduction](../) page
 
 The easiest way to run Jaeger is by starting it in a container:
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \
@@ -24,7 +24,7 @@ This runs the **all-in-one** configuration of Jaeger ([see Architecture](../arch
 
 In order to run Jaeger in other roles ([see Architecture](../architecture/)), an explicit configuration file ([see Configuration](../deployment/configuration/)) must be provided via the `--config` command line argument. When running in a container, the path to the config file must be mapped into the container file system (the `-v ...` mapping below):
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \

--- a/content/docs/v2/2.6/operations/monitoring.md
+++ b/content/docs/v2/2.6/operations/monitoring.md
@@ -13,13 +13,13 @@ Please refer to [OpenTelemetry Collector documentation](https://opentelemetry.io
 
 Here's a sample `curl` call to obtain the metrics:
 
-```
+```sh
 curl -s http://jaeger-collector:8888/metrics
 ```
 
 The following metrics are of special interest:
 
-```
+```ini
 otelcol_receiver_accepted_spans
 otelcol_receiver_refused_spans
 
@@ -31,7 +31,7 @@ The first two metrics describe how many spans are being received by Jaeger. The 
 
 The labels on the metrics allow to separate different receivers and exporters. For example, the first metric with all labels might look like this (formatted for readability):
 
-```
+```ini
 otelcol_receiver_accepted_spans{
     receiver="otlp",
     service_instance_id="f91d66c2-0445-42bf-a062-32aaed09facf",

--- a/content/docs/v2/2.6/operations/troubleshooting.md
+++ b/content/docs/v2/2.6/operations/troubleshooting.md
@@ -29,9 +29,9 @@ If you suspect the remote sampling is not working correctly, try these steps:
 
 1. Make sure that the SDK is actually configured to use remote sampling, points to the correct sampling service address (see [APIs](../../architecture/apis/#remote-sampling-configuration)), and that address is reachable from your application's [networking namespace](#network-connectivity).
 1. Verify that the server is returning the appropriate sampling strategy for your service:
-```
-    $ curl "jaeger-collector:14268/api/sampling?service=foobar"
-    {"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
+```console
+$ curl "jaeger-collector:14268/api/sampling?service=foobar"
+{"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
 ```
 
 ## Bypass intermediate collectors
@@ -54,7 +54,7 @@ Jaeger provides useful debugging information when the log level is set to `debug
 
 For the cases where it's not possible or desirable to increase the logging verbosity, the `/metrics` endpoint can be used to check how trace data is being received and processed by Jaeger. See [Monitoring](../monitoring/#logging) for more details on configuring metrics production. Here's a sample `curl` call to obtain the metrics:
 
-```
+```sh
 curl -s http://jaeger-collector:8888/metrics
 ```
 

--- a/content/docs/v2/2.6/storage/cassandra.md
+++ b/content/docs/v2/2.6/storage/cassandra.md
@@ -72,7 +72,7 @@ your Cassandra cluster correctly. You can specify paths to the TLS certificates 
 The schema tool also supports TLS. You need to make a custom cqlshrc file like
 so:
 
-```
+```ini
 # Creating schema in a cassandra cluster requiring client TLS certificates.
 #
 # Create a volume for the schema docker container containing four files:

--- a/content/docs/v2/2.6/storage/elasticsearch.md
+++ b/content/docs/v2/2.6/storage/elasticsearch.md
@@ -143,6 +143,7 @@ To enable ILM support:
   }
   EOF
   ```
+
 * Run elasticsearch initializer with `ES_USE_ILM=true`:
 
   ```shell
@@ -151,6 +152,7 @@ To enable ILM support:
     jaegertracing/jaeger-es-rollover:latest \
     init http://localhost:9200 # <1>
   ```
+
   <1> If you need to initialize archive storage, add `-e ARCHIVE=true`.
 
   {{< info >}}

--- a/content/docs/v2/2.7/architecture/apis.md
+++ b/content/docs/v2/2.7/architecture/apis.md
@@ -53,11 +53,11 @@ Jaeger can receive trace data in multiple formats on different ports.
 
 **Status**: Stable
 
-Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats: 
+Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats:
   * [Protobuf via gRPC][otlp.grpc]
   * [Protobuf over HTTP][otlp.http]
   * [JSON over HTTP][otlp.http]
-  
+
 Only tracing data is accepted, since Jaeger does not store other telemetry types. For more details on the OTLP receiver see the [official documentation][otlp-rcvr].
 
 [otlp-rcvr]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md
@@ -75,7 +75,7 @@ Jaeger's legacy Protobuf format is defined in [collector.proto] IDL file. Suppor
 
 Jaeger's legacy Thrift format is defined in [jaeger.thrift] IDL file, and is only maintained for backwards compatibility. The Thrift payload can be submitted in an HTTP POST request to the  `/api/traces` endpoint, for example, `https://jaeger-collector:14268/api/traces`. The `Batch` struct needs to be encoded using Thrift's `binary` encoding, and the HTTP request should specify the content type header:
 
-```
+```http
 Content-Type: application/vnd.apache.thrift.binary
 ```
 
@@ -129,11 +129,11 @@ the gRPC Remote Storage API.
 To use a remote storage backend, you must deploy a gRPC server that implements
 the following services:
 
-* **[TraceReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/trace_storage.proto)**  
+* **[TraceReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/trace_storage.proto)**
   Enables Jaeger to read traces from the storage backend.
-* **[DependencyReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/dependency_storage.proto)**  
+* **[DependencyReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/dependency_storage.proto)**
   Used to load service dependency graphs from storage.
-* **[TraceService](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/trace/v1/trace_service.proto)**  
+* **[TraceService](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/trace/v1/trace_service.proto)**
   Allows trace data to be pushed to the storage. This service can run on a separate port if needed.
 
 For more information, please refer to

--- a/content/docs/v2/2.7/architecture/spm.md
+++ b/content/docs/v2/2.7/architecture/spm.md
@@ -61,7 +61,7 @@ An example configuration is available in the Jaeger repository: [config-spm.yaml
 * Enable the [SpanMetrics Connector][spanmetrics-conn] in the pipeline:
 ```yaml
 # Declare an exporter for metrics produced by the connector.
-# For example, a Prometheus server may be configured to scrape 
+# For example, a Prometheus server may be configured to scrape
 # the metrics from this endpoint.
 exporters:
   prometheus:
@@ -73,7 +73,7 @@ connectors:
     # any connector configuration options
     ...
 
-# Enable the spanmetrics connector to bridge 
+# Enable the spanmetrics connector to bridge
 # the traces pipeline into the metrics pipeline.
 service:
   pipelines:
@@ -85,6 +85,7 @@ service:
       receivers: [spanmetrics]
       exporters: [prometheus]
 ```
+
 * Define a remote PromQL-compatible storage under `metric_backends:` in the `jaeger_storage` extension:
 ```yaml
 extensions:
@@ -97,6 +98,7 @@ extensions:
         prometheus:
           endpoint: http://prometheus:9090
 ```
+
 * Reference this metrics store in the `jaeger_query` extension:
 ```yaml
 extensions:
@@ -104,6 +106,7 @@ extensions:
     traces: some_trace_storage
     metrics_storage: some_metrics_storage
 ```
+
 * Set the `monitor.menuEnabled=true` property in the [Jaeger UI configuration](../../deployment/frontend-ui/#monitor).
 
 ## Architecture
@@ -194,7 +197,8 @@ Two metric names will be created:
       `le >= span duration` will be incremented for each span.
 
 The following formula aims to provide some guidance on the number of new time series created:
-```
+
+```go
 num_status_codes * num_span_kinds * (1 + num_latency_buckets) * num_operations
 
 Where:
@@ -204,7 +208,8 @@ Where:
 ```
 
 Plugging those numbers in, assuming default configuration:
-```
+
+```go
 max = 324 * num_operations
 typical = 72 * num_operations
 ```
@@ -246,7 +251,7 @@ service:
       address: 0.0.0.0:8888
 ```
 
-The `/metrics` endpoint on this port can be used to check if UI queries for SPM data are successful: 
+The `/metrics` endpoint on this port can be used to check if UI queries for SPM data are successful:
 
 ```shell
 curl -s http://jaeger:8888/metrics | grep jaeger_metricstore
@@ -320,8 +325,9 @@ service:
 ```
 
 Outputting logs that resemble the following (formatted for readability):
-```
-2024-11-26T19:09:43.152Z debug metricsstore/reader.go:258 Prometheus query results	
+
+```json
+2024-11-26T19:09:43.152Z debug metricsstore/reader.go:258 Prometheus query results
 {
   "kind": "extension",
   "name": "jaeger_storage",
@@ -367,9 +373,11 @@ If there are error spans appearing in Jaeger, but no corresponding error metrics
   the `status.code` label in the metric that the span should belong to.
 - If there are no `status.code` labels, check the OpenTelemetry Collector
   configuration file, particularly for the presence of the following configuration:
+
   ```yaml
   exclude_dimensions: ['status.code']
   ```
+
   This label is used by Jaeger to determine if a request is erroneous.
 
 ### Inspect the OpenTelemetry Collector

--- a/content/docs/v2/2.7/deployment/_index.md
+++ b/content/docs/v2/2.7/deployment/_index.md
@@ -20,7 +20,7 @@ Jaeger backend is released as a single binary or container image (see [Downloads
 
 An explicit YAML configuration file must be provided via the `--config` command line argument (see [Configuration](./configuration/)). When running in a container, the path to the config file must be mapped into the container file system (the `-v ...` mapping below):
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \

--- a/content/docs/v2/2.7/deployment/configuration.md
+++ b/content/docs/v2/2.7/deployment/configuration.md
@@ -40,7 +40,8 @@ One category of environment variables that Jaeger v2 does recognize automaticall
 ### Config Overrides
 
 Another way to override certain config values is by passing them via `--set` command line flags:
-```
+
+```sh
 --set=receivers.otlp.protocols.grpc.endpoint=0.0.0.0:4317
 ```
 
@@ -106,7 +107,7 @@ Sometimes these adjustments themselves make the trace hard to understand. For ex
 
 The `jaeger_query` extension supports a configuration property that controls how much clock skew adjustment should be allowed.
 
-```
+```yaml
 extensions:
   jaeger_query:
     max_clock_skew_adjust: 30s
@@ -118,7 +119,7 @@ extensions:
 
 The base path for all `jaeger_query` extension HTTP routes can be set to a non-root value, e.g. `/jaeger` would cause all UI URLs to start with `/jaeger`. This can be useful when running Jaeger behind a reverse proxy. Here is example code to set the base path.
 
-```
+```yaml
 extensions:
   jaeger_query:
     base_path: /

--- a/content/docs/v2/2.7/deployment/frontend-ui.md
+++ b/content/docs/v2/2.7/deployment/frontend-ui.md
@@ -213,7 +213,7 @@ The embedded mode is induced and configured via URL query parameters.
 
 To enter embedded mode, the `uiEmbed=v0` query parameter and value must be added to the URL. For example, the following URL will show the trace with ID `abc123` in embedded mode:
 
-```
+```text
 http://localhost:16686/trace/abc123?uiEmbed=v0
 ```
 
@@ -232,7 +232,7 @@ To integrate the Search Trace Page to our application we have to indicate to the
 
 For example:
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -252,7 +252,7 @@ The following query parameter can be used to configure the layout of the search 
 
 * `uiSearchHideGraph=1` - disables the display of the scatter plot above the search results
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -277,6 +277,7 @@ For example:
 ```sh
 http://localhost:16686/trace/{trace-id}?uiEmbed=v0
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view.png)](/img/frontend-ui/embed-trace-view.png)
 
 If we have navigated to this view from the search traces page we'll have a button to go back to the results page.
@@ -289,36 +290,40 @@ The following query parameters can be used to configure the layout of the trace 
 
 * `uiTimelineCollapseTitle=1` causes the trace header to start out collapsed, which hides the summary and the minimap.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineCollapseTitle=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-collapse.png)](/img/frontend-ui/embed-trace-view-with-collapse.png)
 
 * `uiTimelineHideMinimap=1` removes the minimap, entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)
 
 * `uiTimelineHideSummary=1` - removes the trace summary information (number of services, etc.) entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-summary.png)](/img/frontend-ui/embed-trace-view-with-hide-summary.png)
 
 We can also combine the options:
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)

--- a/content/docs/v2/2.7/getting-started.md
+++ b/content/docs/v2/2.7/getting-started.md
@@ -10,7 +10,7 @@ If you are new to distributed tracing, please check the [Introduction](../) page
 
 The easiest way to run Jaeger is by starting it in a container:
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \
@@ -24,7 +24,7 @@ This runs the **all-in-one** configuration of Jaeger ([see Architecture](../arch
 
 In order to run Jaeger in other roles ([see Architecture](../architecture/)), an explicit configuration file ([see Configuration](../deployment/configuration/)) must be provided via the `--config` command line argument. When running in a container, the path to the config file must be mapped into the container file system (the `-v ...` mapping below):
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \

--- a/content/docs/v2/2.7/operations/monitoring.md
+++ b/content/docs/v2/2.7/operations/monitoring.md
@@ -13,13 +13,13 @@ Please refer to [OpenTelemetry Collector documentation](https://opentelemetry.io
 
 Here's a sample `curl` call to obtain the metrics:
 
-```
+```sh
 curl -s http://jaeger-collector:8888/metrics
 ```
 
 The following metrics are of special interest:
 
-```
+```ini
 otelcol_receiver_accepted_spans
 otelcol_receiver_refused_spans
 
@@ -31,7 +31,7 @@ The first two metrics describe how many spans are being received by Jaeger. The 
 
 The labels on the metrics allow to separate different receivers and exporters. For example, the first metric with all labels might look like this (formatted for readability):
 
-```
+```ini
 otelcol_receiver_accepted_spans{
     receiver="otlp",
     service_instance_id="f91d66c2-0445-42bf-a062-32aaed09facf",

--- a/content/docs/v2/2.7/operations/troubleshooting.md
+++ b/content/docs/v2/2.7/operations/troubleshooting.md
@@ -29,9 +29,9 @@ If you suspect the remote sampling is not working correctly, try these steps:
 
 1. Make sure that the SDK is actually configured to use remote sampling, points to the correct sampling service address (see [APIs](../../architecture/apis/#remote-sampling-configuration)), and that address is reachable from your application's [networking namespace](#network-connectivity).
 1. Verify that the server is returning the appropriate sampling strategy for your service:
-```
-    $ curl "jaeger-collector:14268/api/sampling?service=foobar"
-    {"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
+```console
+$ curl "jaeger-collector:14268/api/sampling?service=foobar"
+{"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
 ```
 
 ## Bypass intermediate collectors
@@ -54,7 +54,7 @@ Jaeger provides useful debugging information when the log level is set to `debug
 
 For the cases where it's not possible or desirable to increase the logging verbosity, the `/metrics` endpoint can be used to check how trace data is being received and processed by Jaeger. See [Monitoring](../monitoring/#logging) for more details on configuring metrics production. Here's a sample `curl` call to obtain the metrics:
 
-```
+```sh
 curl -s http://jaeger-collector:8888/metrics
 ```
 

--- a/content/docs/v2/2.7/storage/cassandra.md
+++ b/content/docs/v2/2.7/storage/cassandra.md
@@ -72,7 +72,7 @@ your Cassandra cluster correctly. You can specify paths to the TLS certificates 
 The schema tool also supports TLS. You need to make a custom cqlshrc file like
 so:
 
-```
+```ini
 # Creating schema in a cassandra cluster requiring client TLS certificates.
 #
 # Create a volume for the schema docker container containing four files:

--- a/content/docs/v2/2.7/storage/elasticsearch.md
+++ b/content/docs/v2/2.7/storage/elasticsearch.md
@@ -143,6 +143,7 @@ To enable ILM support:
   }
   EOF
   ```
+
 * Run elasticsearch initializer with `ES_USE_ILM=true`:
 
   ```shell
@@ -151,6 +152,7 @@ To enable ILM support:
     jaegertracing/jaeger-es-rollover:latest \
     init http://localhost:9200 # <1>
   ```
+
   <1> If you need to initialize archive storage, add `-e ARCHIVE=true`.
 
   {{< info >}}

--- a/content/docs/v2/2.8/architecture/apis.md
+++ b/content/docs/v2/2.8/architecture/apis.md
@@ -53,11 +53,11 @@ Jaeger can receive trace data in multiple formats on different ports.
 
 **Status**: Stable
 
-Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats: 
+Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats:
   * [Protobuf via gRPC][otlp.grpc]
   * [Protobuf over HTTP][otlp.http]
   * [JSON over HTTP][otlp.http]
-  
+
 Only tracing data is accepted, since Jaeger does not store other telemetry types. For more details on the OTLP receiver see the [official documentation][otlp-rcvr].
 
 [otlp-rcvr]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md
@@ -75,7 +75,7 @@ Jaeger's legacy Protobuf format is defined in [collector.proto] IDL file. Suppor
 
 Jaeger's legacy Thrift format is defined in [jaeger.thrift] IDL file, and is only maintained for backwards compatibility. The Thrift payload can be submitted in an HTTP POST request to the  `/api/traces` endpoint, for example, `https://jaeger-collector:14268/api/traces`. The `Batch` struct needs to be encoded using Thrift's `binary` encoding, and the HTTP request should specify the content type header:
 
-```
+```http
 Content-Type: application/vnd.apache.thrift.binary
 ```
 
@@ -129,11 +129,11 @@ the gRPC Remote Storage API.
 To use a remote storage backend, you must deploy a gRPC server that implements
 the following services:
 
-* **[TraceReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/trace_storage.proto)**  
+* **[TraceReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/trace_storage.proto)**
   Enables Jaeger to read traces from the storage backend.
-* **[DependencyReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/dependency_storage.proto)**  
+* **[DependencyReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/dependency_storage.proto)**
   Used to load service dependency graphs from storage.
-* **[TraceService](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/trace/v1/trace_service.proto)**  
+* **[TraceService](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/trace/v1/trace_service.proto)**
   Allows trace data to be pushed to the storage. This service can run on a separate port if needed.
 
 For more information, please refer to

--- a/content/docs/v2/2.8/architecture/spm.md
+++ b/content/docs/v2/2.8/architecture/spm.md
@@ -61,7 +61,7 @@ An example configuration is available in the Jaeger repository: [config-spm.yaml
 * Enable the [SpanMetrics Connector][spanmetrics-conn] in the pipeline:
 ```yaml
 # Declare an exporter for metrics produced by the connector.
-# For example, a Prometheus server may be configured to scrape 
+# For example, a Prometheus server may be configured to scrape
 # the metrics from this endpoint.
 exporters:
   prometheus:
@@ -73,7 +73,7 @@ connectors:
     # any connector configuration options
     ...
 
-# Enable the spanmetrics connector to bridge 
+# Enable the spanmetrics connector to bridge
 # the traces pipeline into the metrics pipeline.
 service:
   pipelines:
@@ -85,6 +85,7 @@ service:
       receivers: [spanmetrics]
       exporters: [prometheus]
 ```
+
 * Define a remote PromQL-compatible storage under `metric_backends:` in the `jaeger_storage` extension:
 ```yaml
 extensions:
@@ -97,6 +98,7 @@ extensions:
         prometheus:
           endpoint: http://prometheus:9090
 ```
+
 * Reference this metrics store in the `jaeger_query` extension:
 ```yaml
 extensions:
@@ -104,6 +106,7 @@ extensions:
     traces: some_trace_storage
     metrics_storage: some_metrics_storage
 ```
+
 * Set the `monitor.menuEnabled=true` property in the [Jaeger UI configuration](../../deployment/frontend-ui/#monitor).
 
 ## Architecture
@@ -194,7 +197,8 @@ Two metric names will be created:
       `le >= span duration` will be incremented for each span.
 
 The following formula aims to provide some guidance on the number of new time series created:
-```
+
+```go
 num_status_codes * num_span_kinds * (1 + num_latency_buckets) * num_operations
 
 Where:
@@ -204,7 +208,8 @@ Where:
 ```
 
 Plugging those numbers in, assuming default configuration:
-```
+
+```go
 max = 324 * num_operations
 typical = 72 * num_operations
 ```
@@ -246,7 +251,7 @@ service:
       address: 0.0.0.0:8888
 ```
 
-The `/metrics` endpoint on this port can be used to check if UI queries for SPM data are successful: 
+The `/metrics` endpoint on this port can be used to check if UI queries for SPM data are successful:
 
 ```shell
 curl -s http://jaeger:8888/metrics | grep jaeger_metricstore
@@ -320,8 +325,9 @@ service:
 ```
 
 Outputting logs that resemble the following (formatted for readability):
-```
-2024-11-26T19:09:43.152Z debug metricsstore/reader.go:258 Prometheus query results	
+
+```json
+2024-11-26T19:09:43.152Z debug metricsstore/reader.go:258 Prometheus query results
 {
   "kind": "extension",
   "name": "jaeger_storage",
@@ -367,9 +373,11 @@ If there are error spans appearing in Jaeger, but no corresponding error metrics
   the `status.code` label in the metric that the span should belong to.
 - If there are no `status.code` labels, check the OpenTelemetry Collector
   configuration file, particularly for the presence of the following configuration:
+
   ```yaml
   exclude_dimensions: ['status.code']
   ```
+
   This label is used by Jaeger to determine if a request is erroneous.
 
 ### Inspect the OpenTelemetry Collector

--- a/content/docs/v2/2.8/deployment/_index.md
+++ b/content/docs/v2/2.8/deployment/_index.md
@@ -20,7 +20,7 @@ Jaeger backend is released as a single binary or container image (see [Downloads
 
 An explicit YAML configuration file must be provided via the `--config` command line argument (see [Configuration](./configuration/)). When running in a container, the path to the config file must be mapped into the container file system (the `-v ...` mapping below):
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \

--- a/content/docs/v2/2.8/deployment/configuration.md
+++ b/content/docs/v2/2.8/deployment/configuration.md
@@ -40,7 +40,8 @@ One category of environment variables that Jaeger v2 does recognize automaticall
 ### Config Overrides
 
 Another way to override certain config values is by passing them via `--set` command line flags:
-```
+
+```sh
 --set=receivers.otlp.protocols.grpc.endpoint=0.0.0.0:4317
 ```
 
@@ -106,7 +107,7 @@ Sometimes these adjustments themselves make the trace hard to understand. For ex
 
 The `jaeger_query` extension supports a configuration property that controls how much clock skew adjustment should be allowed.
 
-```
+```yaml
 extensions:
   jaeger_query:
     max_clock_skew_adjust: 30s
@@ -118,7 +119,7 @@ extensions:
 
 The base path for all `jaeger_query` extension HTTP routes can be set to a non-root value, e.g. `/jaeger` would cause all UI URLs to start with `/jaeger`. This can be useful when running Jaeger behind a reverse proxy. Here is example code to set the base path.
 
-```
+```yaml
 extensions:
   jaeger_query:
     base_path: /

--- a/content/docs/v2/2.8/deployment/frontend-ui.md
+++ b/content/docs/v2/2.8/deployment/frontend-ui.md
@@ -213,7 +213,7 @@ The embedded mode is induced and configured via URL query parameters.
 
 To enter embedded mode, the `uiEmbed=v0` query parameter and value must be added to the URL. For example, the following URL will show the trace with ID `abc123` in embedded mode:
 
-```
+```text
 http://localhost:16686/trace/abc123?uiEmbed=v0
 ```
 
@@ -232,7 +232,7 @@ To integrate the Search Trace Page to our application we have to indicate to the
 
 For example:
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -252,7 +252,7 @@ The following query parameter can be used to configure the layout of the search 
 
 * `uiSearchHideGraph=1` - disables the display of the scatter plot above the search results
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -277,6 +277,7 @@ For example:
 ```sh
 http://localhost:16686/trace/{trace-id}?uiEmbed=v0
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view.png)](/img/frontend-ui/embed-trace-view.png)
 
 If we have navigated to this view from the search traces page we'll have a button to go back to the results page.
@@ -289,36 +290,40 @@ The following query parameters can be used to configure the layout of the trace 
 
 * `uiTimelineCollapseTitle=1` causes the trace header to start out collapsed, which hides the summary and the minimap.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineCollapseTitle=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-collapse.png)](/img/frontend-ui/embed-trace-view-with-collapse.png)
 
 * `uiTimelineHideMinimap=1` removes the minimap, entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)
 
 * `uiTimelineHideSummary=1` - removes the trace summary information (number of services, etc.) entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-summary.png)](/img/frontend-ui/embed-trace-view-with-hide-summary.png)
 
 We can also combine the options:
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)

--- a/content/docs/v2/2.8/getting-started.md
+++ b/content/docs/v2/2.8/getting-started.md
@@ -10,7 +10,7 @@ If you are new to distributed tracing, please check the [Introduction](../) page
 
 The easiest way to run Jaeger is by starting it in a container:
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \
@@ -24,7 +24,7 @@ This runs the **all-in-one** configuration of Jaeger ([see Architecture](../arch
 
 In order to run Jaeger in other roles ([see Architecture](../architecture/)), an explicit configuration file ([see Configuration](../deployment/configuration/)) must be provided via the `--config` command line argument. When running in a container, the path to the config file must be mapped into the container file system (the `-v ...` mapping below):
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \

--- a/content/docs/v2/2.8/operations/monitoring.md
+++ b/content/docs/v2/2.8/operations/monitoring.md
@@ -13,13 +13,13 @@ Please refer to [OpenTelemetry Collector documentation](https://opentelemetry.io
 
 Here's a sample `curl` call to obtain the metrics:
 
-```
+```sh
 curl -s http://jaeger-collector:8888/metrics
 ```
 
 The following metrics are of special interest:
 
-```
+```ini
 otelcol_receiver_accepted_spans
 otelcol_receiver_refused_spans
 
@@ -31,7 +31,7 @@ The first two metrics describe how many spans are being received by Jaeger. The 
 
 The labels on the metrics allow to separate different receivers and exporters. For example, the first metric with all labels might look like this (formatted for readability):
 
-```
+```ini
 otelcol_receiver_accepted_spans{
     receiver="otlp",
     service_instance_id="f91d66c2-0445-42bf-a062-32aaed09facf",

--- a/content/docs/v2/2.8/operations/troubleshooting.md
+++ b/content/docs/v2/2.8/operations/troubleshooting.md
@@ -29,9 +29,9 @@ If you suspect the remote sampling is not working correctly, try these steps:
 
 1. Make sure that the SDK is actually configured to use remote sampling, points to the correct sampling service address (see [APIs](../../architecture/apis/#remote-sampling-configuration)), and that address is reachable from your application's [networking namespace](#network-connectivity).
 1. Verify that the server is returning the appropriate sampling strategy for your service:
-```
-    $ curl "jaeger-collector:14268/api/sampling?service=foobar"
-    {"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
+```console
+$ curl "jaeger-collector:14268/api/sampling?service=foobar"
+{"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
 ```
 
 ## Bypass intermediate collectors
@@ -54,7 +54,7 @@ Jaeger provides useful debugging information when the log level is set to `debug
 
 For the cases where it's not possible or desirable to increase the logging verbosity, the `/metrics` endpoint can be used to check how trace data is being received and processed by Jaeger. See [Monitoring](../monitoring/#logging) for more details on configuring metrics production. Here's a sample `curl` call to obtain the metrics:
 
-```
+```sh
 curl -s http://jaeger-collector:8888/metrics
 ```
 

--- a/content/docs/v2/2.8/storage/cassandra.md
+++ b/content/docs/v2/2.8/storage/cassandra.md
@@ -72,7 +72,7 @@ your Cassandra cluster correctly. You can specify paths to the TLS certificates 
 The schema tool also supports TLS. You need to make a custom cqlshrc file like
 so:
 
-```
+```ini
 # Creating schema in a cassandra cluster requiring client TLS certificates.
 #
 # Create a volume for the schema docker container containing four files:

--- a/content/docs/v2/2.8/storage/elasticsearch.md
+++ b/content/docs/v2/2.8/storage/elasticsearch.md
@@ -143,6 +143,7 @@ To enable ILM support:
   }
   EOF
   ```
+
 * Run elasticsearch initializer with `ES_USE_ILM=true`:
 
   ```shell
@@ -151,6 +152,7 @@ To enable ILM support:
     jaegertracing/jaeger-es-rollover:latest \
     init http://localhost:9200 # <1>
   ```
+
   <1> If you need to initialize archive storage, add `-e ARCHIVE=true`.
 
   {{< info >}}

--- a/content/docs/v2/2.9/architecture/apis.md
+++ b/content/docs/v2/2.9/architecture/apis.md
@@ -53,11 +53,11 @@ Jaeger can receive trace data in multiple formats on different ports.
 
 **Status**: Stable
 
-Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats: 
+Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats:
   * [Protobuf via gRPC][otlp.grpc]
   * [Protobuf over HTTP][otlp.http]
   * [JSON over HTTP][otlp.http]
-  
+
 Only tracing data is accepted, since Jaeger does not store other telemetry types. For more details on the OTLP receiver see the [official documentation][otlp-rcvr].
 
 [otlp-rcvr]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md
@@ -75,7 +75,7 @@ Jaeger's legacy Protobuf format is defined in [collector.proto] IDL file. Suppor
 
 Jaeger's legacy Thrift format is defined in [jaeger.thrift] IDL file, and is only maintained for backwards compatibility. The Thrift payload can be submitted in an HTTP POST request to the  `/api/traces` endpoint, for example, `https://jaeger-collector:14268/api/traces`. The `Batch` struct needs to be encoded using Thrift's `binary` encoding, and the HTTP request should specify the content type header:
 
-```
+```http
 Content-Type: application/vnd.apache.thrift.binary
 ```
 
@@ -129,11 +129,11 @@ the gRPC Remote Storage API.
 To use a remote storage backend, you must deploy a gRPC server that implements
 the following services:
 
-* **[TraceReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/trace_storage.proto)**  
+* **[TraceReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/trace_storage.proto)**
   Enables Jaeger to read traces from the storage backend.
-* **[DependencyReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/dependency_storage.proto)**  
+* **[DependencyReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/dependency_storage.proto)**
   Used to load service dependency graphs from storage.
-* **[TraceService](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/trace/v1/trace_service.proto)**  
+* **[TraceService](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/trace/v1/trace_service.proto)**
   Allows trace data to be pushed to the storage. This service can run on a separate port if needed.
 
 For more information, please refer to

--- a/content/docs/v2/2.9/architecture/spm.md
+++ b/content/docs/v2/2.9/architecture/spm.md
@@ -87,6 +87,7 @@ service:
       receivers: [spanmetrics]
       exporters: [prometheus]
 ```
+
 * Define a remote PromQL-compatible storage under `metric_backends:` in the `jaeger_storage` extension:
 ```yaml
 extensions:
@@ -99,6 +100,7 @@ extensions:
         prometheus:
           endpoint: http://prometheus:9090
 ```
+
 * Reference this metrics store in the `jaeger_query` extension:
 ```yaml
 extensions:
@@ -106,6 +108,7 @@ extensions:
     traces: some_trace_storage
     metrics_storage: some_metrics_storage
 ```
+
 * Set the `monitor.menuEnabled=true` property in the [Jaeger UI configuration](../../deployment/frontend-ui/#monitor).
 
 ### Option 2: Elasticsearch/OpenSearch Backend Configuration
@@ -292,7 +295,8 @@ Two metric names will be created:
       `le >= span duration` will be incremented for each span.
 
 The following formula aims to provide some guidance on the number of new time series created:
-```
+
+```go
 num_status_codes * num_span_kinds * (1 + num_latency_buckets) * num_operations
 
 Where:
@@ -302,7 +306,8 @@ Where:
 ```
 
 Plugging those numbers in, assuming default configuration:
-```
+
+```go
 max = 324 * num_operations
 typical = 72 * num_operations
 ```
@@ -418,7 +423,8 @@ service:
 ```
 
 Outputting logs that resemble the following (formatted for readability):
-```
+
+```json
 2024-11-26T19:09:43.152Z debug metricsstore/reader.go:258 Prometheus query results
 {
   "kind": "extension",
@@ -465,9 +471,11 @@ If there are error spans appearing in Jaeger, but no corresponding error metrics
   the `status.code` label in the metric that the span should belong to.
 - If there are no `status.code` labels, check the OpenTelemetry Collector
   configuration file, particularly for the presence of the following configuration:
+
   ```yaml
   exclude_dimensions: ['status.code']
   ```
+
   This label is used by Jaeger to determine if a request is erroneous.
 
 ### Inspect the OpenTelemetry Collector

--- a/content/docs/v2/2.9/deployment/_index.md
+++ b/content/docs/v2/2.9/deployment/_index.md
@@ -20,7 +20,7 @@ Jaeger backend is released as a single binary or container image (see [Downloads
 
 An explicit YAML configuration file must be provided via the `--config` command line argument (see [Configuration](./configuration/)). When running in a container, the path to the config file must be mapped into the container file system (the `-v ...` mapping below):
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \

--- a/content/docs/v2/2.9/deployment/configuration.md
+++ b/content/docs/v2/2.9/deployment/configuration.md
@@ -44,7 +44,8 @@ One category of environment variables that Jaeger v2 does recognize automaticall
 ### Config Overrides
 
 Another way to override certain config values is by passing them via `--set` command line flags:
-```
+
+```sh
 --set=receivers.otlp.protocols.grpc.endpoint=0.0.0.0:4317
 ```
 
@@ -110,7 +111,7 @@ Sometimes these adjustments themselves make the trace hard to understand. For ex
 
 The `jaeger_query` extension supports a configuration property that controls how much clock skew adjustment should be allowed.
 
-```
+```yaml
 extensions:
   jaeger_query:
     max_clock_skew_adjust: 30s
@@ -122,7 +123,7 @@ extensions:
 
 The base path for all `jaeger_query` extension HTTP routes can be set to a non-root value, e.g. `/jaeger` would cause all UI URLs to start with `/jaeger`. This can be useful when running Jaeger behind a reverse proxy. Here is example code to set the base path.
 
-```
+```yaml
 extensions:
   jaeger_query:
     base_path: /

--- a/content/docs/v2/2.9/deployment/frontend-ui.md
+++ b/content/docs/v2/2.9/deployment/frontend-ui.md
@@ -213,7 +213,7 @@ The embedded mode is induced and configured via URL query parameters.
 
 To enter embedded mode, the `uiEmbed=v0` query parameter and value must be added to the URL. For example, the following URL will show the trace with ID `abc123` in embedded mode:
 
-```
+```text
 http://localhost:16686/trace/abc123?uiEmbed=v0
 ```
 
@@ -232,7 +232,7 @@ To integrate the Search Trace Page to our application we have to indicate to the
 
 For example:
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -252,7 +252,7 @@ The following query parameter can be used to configure the layout of the search 
 
 * `uiSearchHideGraph=1` - disables the display of the scatter plot above the search results
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -277,6 +277,7 @@ For example:
 ```sh
 http://localhost:16686/trace/{trace-id}?uiEmbed=v0
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view.png)](/img/frontend-ui/embed-trace-view.png)
 
 If we have navigated to this view from the search traces page we'll have a button to go back to the results page.
@@ -289,36 +290,40 @@ The following query parameters can be used to configure the layout of the trace 
 
 * `uiTimelineCollapseTitle=1` causes the trace header to start out collapsed, which hides the summary and the minimap.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineCollapseTitle=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-collapse.png)](/img/frontend-ui/embed-trace-view-with-collapse.png)
 
 * `uiTimelineHideMinimap=1` removes the minimap, entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)
 
 * `uiTimelineHideSummary=1` - removes the trace summary information (number of services, etc.) entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-summary.png)](/img/frontend-ui/embed-trace-view-with-hide-summary.png)
 
 We can also combine the options:
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)

--- a/content/docs/v2/2.9/getting-started.md
+++ b/content/docs/v2/2.9/getting-started.md
@@ -10,7 +10,7 @@ If you are new to distributed tracing, please check the [Introduction](../) page
 
 The easiest way to run Jaeger is by starting it in a container:
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \
@@ -24,7 +24,7 @@ This runs the **all-in-one** configuration of Jaeger ([see Architecture](../arch
 
 In order to run Jaeger in other roles ([see Architecture](../architecture/)), an explicit configuration file ([see Configuration](../deployment/configuration/)) must be provided via the `--config` command line argument. When running in a container, the path to the config file must be mapped into the container file system (the `-v ...` mapping below):
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \

--- a/content/docs/v2/2.9/operations/monitoring.md
+++ b/content/docs/v2/2.9/operations/monitoring.md
@@ -13,13 +13,13 @@ Please refer to [OpenTelemetry Collector documentation](https://opentelemetry.io
 
 Here's a sample `curl` call to obtain the metrics:
 
-```
+```sh
 curl -s http://jaeger-collector:8888/metrics
 ```
 
 The following metrics are of special interest:
 
-```
+```ini
 otelcol_receiver_accepted_spans
 otelcol_receiver_refused_spans
 
@@ -31,7 +31,7 @@ The first two metrics describe how many spans are being received by Jaeger. The 
 
 The labels on the metrics allow to separate different receivers and exporters. For example, the first metric with all labels might look like this (formatted for readability):
 
-```
+```ini
 otelcol_receiver_accepted_spans{
     receiver="otlp",
     service_instance_id="f91d66c2-0445-42bf-a062-32aaed09facf",

--- a/content/docs/v2/2.9/operations/troubleshooting.md
+++ b/content/docs/v2/2.9/operations/troubleshooting.md
@@ -29,9 +29,9 @@ If you suspect the remote sampling is not working correctly, try these steps:
 
 1. Make sure that the SDK is actually configured to use remote sampling, points to the correct sampling service address (see [APIs](../../architecture/apis/#remote-sampling-configuration)), and that address is reachable from your application's [networking namespace](#network-connectivity).
 1. Verify that the server is returning the appropriate sampling strategy for your service:
-```
-    $ curl "jaeger-collector:14268/api/sampling?service=foobar"
-    {"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
+```console
+$ curl "jaeger-collector:14268/api/sampling?service=foobar"
+{"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
 ```
 
 ## Bypass intermediate collectors
@@ -54,7 +54,7 @@ Jaeger provides useful debugging information when the log level is set to `debug
 
 For the cases where it's not possible or desirable to increase the logging verbosity, the `/metrics` endpoint can be used to check how trace data is being received and processed by Jaeger. See [Monitoring](../monitoring/#logging) for more details on configuring metrics production. Here's a sample `curl` call to obtain the metrics:
 
-```
+```sh
 curl -s http://jaeger-collector:8888/metrics
 ```
 

--- a/content/docs/v2/2.9/storage/cassandra.md
+++ b/content/docs/v2/2.9/storage/cassandra.md
@@ -72,7 +72,7 @@ your Cassandra cluster correctly. You can specify paths to the TLS certificates 
 The schema tool also supports TLS. You need to make a custom cqlshrc file like
 so:
 
-```
+```ini
 # Creating schema in a cassandra cluster requiring client TLS certificates.
 #
 # Create a volume for the schema docker container containing four files:

--- a/content/docs/v2/2.9/storage/elasticsearch.md
+++ b/content/docs/v2/2.9/storage/elasticsearch.md
@@ -143,6 +143,7 @@ To enable ILM support:
   }
   EOF
   ```
+
 * Run elasticsearch initializer with `ES_USE_ILM=true`:
 
   ```shell
@@ -151,6 +152,7 @@ To enable ILM support:
     jaegertracing/jaeger-es-rollover:latest \
     init http://localhost:9200 # <1>
   ```
+
   <1> If you need to initialize archive storage, add `-e ARCHIVE=true`.
 
   {{< info >}}

--- a/content/docs/v2/_dev/architecture/apis.md
+++ b/content/docs/v2/_dev/architecture/apis.md
@@ -53,11 +53,11 @@ Jaeger can receive trace data in multiple formats on different ports.
 
 **Status**: Stable
 
-Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats: 
+Jaeger can receive trace data from the OpenTelemetry SDKs in their native [OpenTelemetry Protocol (OTLP)][otlp]. The OTLP data is accepted in these formats:
   * [Protobuf via gRPC][otlp.grpc]
   * [Protobuf over HTTP][otlp.http]
   * [JSON over HTTP][otlp.http]
-  
+
 Only tracing data is accepted, since Jaeger does not store other telemetry types. For more details on the OTLP receiver see the [official documentation][otlp-rcvr].
 
 [otlp-rcvr]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md
@@ -75,7 +75,7 @@ Jaeger's legacy Protobuf format is defined in [collector.proto] IDL file. Suppor
 
 Jaeger's legacy Thrift format is defined in [jaeger.thrift] IDL file, and is only maintained for backwards compatibility. The Thrift payload can be submitted in an HTTP POST request to the  `/api/traces` endpoint, for example, `https://jaeger-collector:14268/api/traces`. The `Batch` struct needs to be encoded using Thrift's `binary` encoding, and the HTTP request should specify the content type header:
 
-```
+```http
 Content-Type: application/vnd.apache.thrift.binary
 ```
 
@@ -129,11 +129,11 @@ the gRPC Remote Storage API.
 To use a remote storage backend, you must deploy a gRPC server that implements
 the following services:
 
-* **[TraceReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/trace_storage.proto)**  
+* **[TraceReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/trace_storage.proto)**
   Enables Jaeger to read traces from the storage backend.
-* **[DependencyReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/dependency_storage.proto)**  
+* **[DependencyReader](https://github.com/jaegertracing/jaeger-idl/tree/main/proto/storage/v2/dependency_storage.proto)**
   Used to load service dependency graphs from storage.
-* **[TraceService](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/trace/v1/trace_service.proto)**  
+* **[TraceService](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/trace/v1/trace_service.proto)**
   Allows trace data to be pushed to the storage. This service can run on a separate port if needed.
 
 For more information, please refer to

--- a/content/docs/v2/_dev/architecture/spm.md
+++ b/content/docs/v2/_dev/architecture/spm.md
@@ -87,6 +87,7 @@ service:
       receivers: [spanmetrics]
       exporters: [prometheus]
 ```
+
 * Define a remote PromQL-compatible storage under `metric_backends:` in the `jaeger_storage` extension:
 ```yaml
 extensions:
@@ -99,6 +100,7 @@ extensions:
         prometheus:
           endpoint: http://prometheus:9090
 ```
+
 * Reference this metrics store in the `jaeger_query` extension:
 ```yaml
 extensions:
@@ -106,6 +108,7 @@ extensions:
     traces: some_trace_storage
     metrics_storage: some_metrics_storage
 ```
+
 * Set the `monitor.menuEnabled=true` property in the [Jaeger UI configuration](../../deployment/frontend-ui/#monitor).
 
 ### Option 2: Elasticsearch/OpenSearch Backend Configuration
@@ -292,7 +295,8 @@ Two metric names will be created:
       `le >= span duration` will be incremented for each span.
 
 The following formula aims to provide some guidance on the number of new time series created:
-```
+
+```go
 num_status_codes * num_span_kinds * (1 + num_latency_buckets) * num_operations
 
 Where:
@@ -302,7 +306,8 @@ Where:
 ```
 
 Plugging those numbers in, assuming default configuration:
-```
+
+```go
 max = 324 * num_operations
 typical = 72 * num_operations
 ```
@@ -418,7 +423,8 @@ service:
 ```
 
 Outputting logs that resemble the following (formatted for readability):
-```
+
+```json
 2024-11-26T19:09:43.152Z debug metricsstore/reader.go:258 Prometheus query results
 {
   "kind": "extension",
@@ -465,9 +471,11 @@ If there are error spans appearing in Jaeger, but no corresponding error metrics
   the `status.code` label in the metric that the span should belong to.
 - If there are no `status.code` labels, check the OpenTelemetry Collector
   configuration file, particularly for the presence of the following configuration:
+
   ```yaml
   exclude_dimensions: ['status.code']
   ```
+
   This label is used by Jaeger to determine if a request is erroneous.
 
 ### Inspect the OpenTelemetry Collector

--- a/content/docs/v2/_dev/deployment/_index.md
+++ b/content/docs/v2/_dev/deployment/_index.md
@@ -20,7 +20,7 @@ Jaeger backend is released as a single binary or container image (see [Downloads
 
 An explicit YAML configuration file must be provided via the `--config` command line argument (see [Configuration](./configuration/)). When running in a container, the path to the config file must be mapped into the container file system (the `-v ...` mapping below):
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \

--- a/content/docs/v2/_dev/deployment/configuration.md
+++ b/content/docs/v2/_dev/deployment/configuration.md
@@ -44,7 +44,8 @@ One category of environment variables that Jaeger v2 does recognize automaticall
 ### Config Overrides
 
 Another way to override certain config values is by passing them via `--set` command line flags:
-```
+
+```sh
 --set=receivers.otlp.protocols.grpc.endpoint=0.0.0.0:4317
 ```
 
@@ -110,7 +111,7 @@ Sometimes these adjustments themselves make the trace hard to understand. For ex
 
 The `jaeger_query` extension supports a configuration property that controls how much clock skew adjustment should be allowed.
 
-```
+```yaml
 extensions:
   jaeger_query:
     max_clock_skew_adjust: 30s
@@ -122,7 +123,7 @@ extensions:
 
 The base path for all `jaeger_query` extension HTTP routes can be set to a non-root value, e.g. `/jaeger` would cause all UI URLs to start with `/jaeger`. This can be useful when running Jaeger behind a reverse proxy. Here is example code to set the base path.
 
-```
+```yaml
 extensions:
   jaeger_query:
     base_path: /

--- a/content/docs/v2/_dev/deployment/frontend-ui.md
+++ b/content/docs/v2/_dev/deployment/frontend-ui.md
@@ -213,7 +213,7 @@ The embedded mode is induced and configured via URL query parameters.
 
 To enter embedded mode, the `uiEmbed=v0` query parameter and value must be added to the URL. For example, the following URL will show the trace with ID `abc123` in embedded mode:
 
-```
+```sh
 http://localhost:16686/trace/abc123?uiEmbed=v0
 ```
 
@@ -232,7 +232,7 @@ To integrate the Search Trace Page to our application we have to indicate to the
 
 For example:
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -252,7 +252,7 @@ The following query parameter can be used to configure the layout of the search 
 
 * `uiSearchHideGraph=1` - disables the display of the scatter plot above the search results
 
-```
+```text
 http://localhost:16686/search?
     service=my-service&
     start=1543917759557000&
@@ -277,6 +277,7 @@ For example:
 ```sh
 http://localhost:16686/trace/{trace-id}?uiEmbed=v0
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view.png)](/img/frontend-ui/embed-trace-view.png)
 
 If we have navigated to this view from the search traces page we'll have a button to go back to the results page.
@@ -289,36 +290,40 @@ The following query parameters can be used to configure the layout of the trace 
 
 * `uiTimelineCollapseTitle=1` causes the trace header to start out collapsed, which hides the summary and the minimap.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineCollapseTitle=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-collapse.png)](/img/frontend-ui/embed-trace-view-with-collapse.png)
 
 * `uiTimelineHideMinimap=1` removes the minimap, entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-minimap.png)
 
 * `uiTimelineHideSummary=1` - removes the trace summary information (number of services, etc.) entirely, regardless of whether the trace header is expanded or not.
 
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-summary.png)](/img/frontend-ui/embed-trace-view-with-hide-summary.png)
 
 We can also combine the options:
-```
+```text
 http://localhost:16686/trace/{trace-id}?
     uiEmbed=v0&
     uiTimelineHideMinimap=1&
     uiTimelineHideSummary=1
 ```
+
 [![Embed Trace view](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)](/img/frontend-ui/embed-trace-view-with-hide-details-and-hide-minimap.png)

--- a/content/docs/v2/_dev/getting-started.md
+++ b/content/docs/v2/_dev/getting-started.md
@@ -10,7 +10,7 @@ If you are new to distributed tracing, please check the [Introduction](../) page
 
 The easiest way to run Jaeger is by starting it in a container:
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \
@@ -24,7 +24,7 @@ This runs the **all-in-one** configuration of Jaeger ([see Architecture](../arch
 
 In order to run Jaeger in other roles ([see Architecture](../architecture/)), an explicit configuration file ([see Configuration](../deployment/configuration/)) must be provided via the `--config` command line argument. When running in a container, the path to the config file must be mapped into the container file system (the `-v ...` mapping below):
 
-```
+```sh
 docker run --rm --name jaeger \
   -p 16686:16686 \
   -p 4317:4317 \

--- a/content/docs/v2/_dev/operations/monitoring.md
+++ b/content/docs/v2/_dev/operations/monitoring.md
@@ -13,13 +13,13 @@ Please refer to [OpenTelemetry Collector documentation](https://opentelemetry.io
 
 Here's a sample `curl` call to obtain the metrics:
 
-```
+```sh
 curl -s http://jaeger-collector:8888/metrics
 ```
 
 The following metrics are of special interest:
 
-```
+```ini
 otelcol_receiver_accepted_spans
 otelcol_receiver_refused_spans
 
@@ -31,7 +31,7 @@ The first two metrics describe how many spans are being received by Jaeger. The 
 
 The labels on the metrics allow to separate different receivers and exporters. For example, the first metric with all labels might look like this (formatted for readability):
 
-```
+```ini
 otelcol_receiver_accepted_spans{
     receiver="otlp",
     service_instance_id="f91d66c2-0445-42bf-a062-32aaed09facf",

--- a/content/docs/v2/_dev/operations/troubleshooting.md
+++ b/content/docs/v2/_dev/operations/troubleshooting.md
@@ -29,9 +29,9 @@ If you suspect the remote sampling is not working correctly, try these steps:
 
 1. Make sure that the SDK is actually configured to use remote sampling, points to the correct sampling service address (see [APIs](../../architecture/apis/#remote-sampling-configuration)), and that address is reachable from your application's [networking namespace](#network-connectivity).
 1. Verify that the server is returning the appropriate sampling strategy for your service:
-```
-    $ curl "jaeger-collector:14268/api/sampling?service=foobar"
-    {"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
+```console
+$ curl "jaeger-collector:14268/api/sampling?service=foobar"
+{"strategyType":"PROBABILISTIC","probabilisticSampling":{"samplingRate":0.001}}
 ```
 
 ## Bypass intermediate collectors
@@ -54,7 +54,7 @@ Jaeger provides useful debugging information when the log level is set to `debug
 
 For the cases where it's not possible or desirable to increase the logging verbosity, the `/metrics` endpoint can be used to check how trace data is being received and processed by Jaeger. See [Monitoring](../monitoring/#logging) for more details on configuring metrics production. Here's a sample `curl` call to obtain the metrics:
 
-```
+```sh
 curl -s http://jaeger-collector:8888/metrics
 ```
 

--- a/content/docs/v2/_dev/storage/cassandra.md
+++ b/content/docs/v2/_dev/storage/cassandra.md
@@ -72,7 +72,7 @@ your Cassandra cluster correctly. You can specify paths to the TLS certificates 
 The schema tool also supports TLS. You need to make a custom cqlshrc file like
 so:
 
-```
+```ini
 # Creating schema in a cassandra cluster requiring client TLS certificates.
 #
 # Create a volume for the schema docker container containing four files:

--- a/content/docs/v2/_dev/storage/elasticsearch.md
+++ b/content/docs/v2/_dev/storage/elasticsearch.md
@@ -143,6 +143,7 @@ To enable ILM support:
   }
   EOF
   ```
+
 * Run elasticsearch initializer with `ES_USE_ILM=true`:
 
   ```shell
@@ -151,6 +152,7 @@ To enable ILM support:
     jaegertracing/jaeger-es-rollover:latest \
     init http://localhost:9200 # <1>
   ```
+
   <1> If you need to initialize archive storage, add `-e ARCHIVE=true`.
 
   {{< info >}}

--- a/content/download.md
+++ b/content/download.md
@@ -63,7 +63,7 @@ The signatures can be verified using the public key below.
 
 ### Import the key
 
-```
+```console
 $ gpg --import <<EOF
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 
@@ -94,7 +94,7 @@ From the release page (TODO: provide link and fix versions):
 
 Use `gpg --verify {signature-file} file`, e.g.:
 
-```
+```console
 $ gpg --verify jaeger-1.39.4-darwin-amd64.tar.gz.asc jaeger-1.39.4-darwin-amd64.tar.gz
 gpg: Signature made Wed Nov  9 13:34:17 2022 EST
 gpg:                using EDDSA key BD0B026014C725261C947887B42D1DB0F079690F

--- a/content/report-security-issue.md
+++ b/content/report-security-issue.md
@@ -38,7 +38,7 @@ gpg -ea -r C043A4D2B3F2AC31 message.txt
 
 ### Our public key
 
-```
+```text
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 mQINBFn7N4QBEAC4Vl68Fdcom/U1kb/6zlUeSLh4Vwyr2wvaLd610AUwmrfQC0eh
 e6vRtt//bYr48gHg1wwnbaQgyg+ZvIfjUa6Olhqi3J1itkagy50pQDWk8nfDdbHO

--- a/content/sdk-migration.md
+++ b/content/sdk-migration.md
@@ -31,7 +31,7 @@ If you find inaccuracies or have information that can be added, please open an i
 
 We encourage OpenTelemetry SDK authors to copy relevant pieces of the Jaeger clients instead of depending on Jaeger modules directly. This is why we use a liberal APL2 license. When copying code, the correct way to respect the license requirements is to keep the copyright notices. For example, Jaeger authors did the same with the code originally written at Uber:
 
-```
+```go
 // Copyright (c) 2019 The Jaeger Authors.
 // Copyright (c) 2017 Uber Technologies, Inc.
 // ... <rest of Apache notice> ...
@@ -137,14 +137,14 @@ e.g. `my-baggage-key-1`.
 
 Example: the following code sequence:
 
-```
+```go
 span.SetBaggageItem("key1", "value1")
 span.SetBaggageItem("key2", "value2")
 ```
 
 will result in the following HTTP headers:
 
-```
+```properties
 uberctx-key1: value1
 uberctx-key2: value2
 ```
@@ -155,13 +155,13 @@ OpenTracing defines two formats for plain text headers: `HTTP_HEADERS` and `TEXT
 
 Example: when using the `HTTP_HEADERS` propagation format, the following code sequence:
 
-```
+```go
 span.SetBaggageItem("key1", "value 1 / blah")
 ```
 
 will result in the following HTTP header:
 
-```
+```properties
 uberctx-key1: value%201%20%2F%20blah
 ```
 

--- a/themes/docsy-overrides/layouts/_partials/admonition.html
+++ b/themes/docsy-overrides/layouts/_partials/admonition.html
@@ -1,0 +1,19 @@
+{{/* TODO: consider making this a .md partial and drop the markdownify. */ -}}
+
+<div class="alert alert-{{ .type }}" role="alert">
+<div class="d-flex align-items-start">
+  <span class="me-3">
+    <i class="fa-solid fa-{{ .icon }} fa-lg"></i>
+  </span>
+  <div>
+    {{ if ne .title nil -}}
+    <div class="h4 alert-heading">
+      {{- .title | markdownify -}}
+    </div>
+    {{ end -}}
+    <div>
+      {{ .content | markdownify }}
+    </div>
+  </div>
+</div>
+</div>


### PR DESCRIPTION
- Contributes to #746
- Adds a new admonition partial for use under Docsy + Bootstrap
- Cleans up code-block markdown by adding language ID. The ensure, under Docsy, that the code block will have a copy button. I haven't done all code blocks but addressed most. I only did 1.74 and 1.dev of the v1 series.