### PR TITLE
[docsy] Don't redirect docs path for Docsy site

### DIFF
--- a/content/_index-pre-docsy.md
+++ b/content/_index-pre-docsy.md
@@ -2,5 +2,8 @@
 title: 'Jaeger: open source, distributed tracing platform'
 linkTitle: Jaeger
 description: Monitor and troubleshoot workflows in complex distributed systems
-show_banner: true
+cascade:
+  redirect: /docs/latest 302!
+  target:
+    path: /docs
 ---

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Documentation
 linkTitle: Docs
-params:
-  redirect: /docs/latest 302!
 no_list: true
 toc_hide: true
 layout: default

--- a/hugo.pre-docsy.yaml
+++ b/hugo.pre-docsy.yaml
@@ -1,10 +1,14 @@
-# Pre-Docsy config
+# cSpell:ignore docsy
 
 module:
   mounts:
+    - source: content/_index-pre-docsy.md
+      target: content/_index.md
+
     - excludeFiles:
-        - docs/v?
         - _index.md
+        - _index-pre-docsy.md
+        - docs/v?
       source: content
       target: content
 
@@ -19,6 +23,3 @@ module:
       target: content/docs
     - source: content/docs/v2/_dev
       target: content/docs/next-release-v2
-
-    - source: pre-docsy-content/_index.md
-      target: content/_index.md


### PR DESCRIPTION
- Contributes to #746
- Docsy version of site:
  - Drops redirect of `/docs`
- Simplifies the config and file path of the pre-docsy index page
- No changes to generated (non-Docsy) site files
- **Preview**: https://deploy-preview-1013--jaegertracing.netlify.app/
- **Redirect test**, to show that it still works for the base site: https://deploy-preview-1013--jaegertracing.netlify.app/docs