### PR TITLE
[docsy] Show at most X versions in vers menu + link full list

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -8,7 +8,7 @@ cascade:
   params:
     version_menu: Versions
   target:
-    path: '/docs/**'
+    path: '/docs**'
 ---
 
 {{% doc_versions %}}

--- a/content/docs/v1/_dev/_index.md
+++ b/content/docs/v1/_dev/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-linkTitle: 1.dev
+linkTitle: 1.dev (preview)
 weight: -100 # == -100 - MINOR
 children:
 - title: Features

--- a/content/docs/v2/_dev/_index.md
+++ b/content/docs/v2/_dev/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-linkTitle: 2.dev
+linkTitle: 2.dev (preview)
 weight: -200 # == -200 - MINOR
 children:
 - title: Getting Started

--- a/hugo.dev.yaml
+++ b/hugo.dev.yaml
@@ -1,8 +1,8 @@
 # Development config - build only next and latest versions
 
 ignoreFiles:
-  # Ignore all v1 versions except 1.74, 1.73, and _dev
-  - 'content/docs/v1/1\.([6-9]|[1-6]\d|7[0-2])/'
+  # Ignore all v1 versions except 1.74, 1.73, 1.72, and _dev
+  - 'content/docs/v1/1\.([6-9]|[1-6]\d|7[0-1])/'
 
-  # Ignore all v2 versions except for 2.10, 2.11, and _dev
-  - 'content/docs/v2/2\.(\d)/'
+  # Ignore all v2 versions except for 2.9, 2.10, 2.11, and _dev
+  - 'content/docs/v2/2\.[0-8]/'

--- a/hugo.docsy.yaml
+++ b/hugo.docsy.yaml
@@ -43,10 +43,10 @@ params:
     to_year: present
 
   github_repo: https://github.com/jaegertracing/documentation
-  # github_branch: main
-  # version_menu: Versions
-  version_menu_pagelinks: true
   # TODO: Lunr config
+  # Version menu: note some param are set via cascade
+  version_menu_pagelinks: true
+  version_menu_max_versions: 5
 
   privacy_policy: https://www.linuxfoundation.org/legal/privacy-policy
 

--- a/scripts/set-docsy-wksp.sh
+++ b/scripts/set-docsy-wksp.sh
@@ -46,7 +46,13 @@ __docsy_wksp_helper() {
 
   echo "  > branch: $branch"
 
-  WKSP_FOR_DOCSY="dev.yaml,hugo.docsy"
+  WKSP_FOR_DOCSY_ONLY="docsy"
+  WKSP_FOR_DOCSY_DEV="dev.yaml,hugo.docsy"
+
+  WKSP_FOR_DOCSY="${WKSP_FOR_DOCSY_ONLY}"
+  if [ -z "${NETLIFY:-}" ]; then
+    WKSP_FOR_DOCSY="${WKSP_FOR_DOCSY_DEV}"
+  fi
 
   case "$branch" in
     docsy*)

--- a/themes/docsy-overrides/layouts/_partials/navbar-version-selector.html
+++ b/themes/docsy-overrides/layouts/_partials/navbar-version-selector.html
@@ -33,9 +33,10 @@
     {{ end -}}
 
     {{ $dot := . -}}
+    {{ $maxVersPerMajorVers := sub (.Site.Params.version_menu_max_versions | default 99999) 1 -}}
     {{ range $versions := (slice
-        (.Site.Params.versionsV2 | append "2.dev")
-        (.Site.Params.versions | append "1.dev")
+        ((first $maxVersPerMajorVers .Site.Params.versionsV2) | append "2.dev")
+        ((first $maxVersPerMajorVers .Site.Params.versions) | append "1.dev")
       ) -}}
       {{ template "navbar-version-list" (dict
             "dot" $dot
@@ -43,7 +44,13 @@
             "path" $path
             "relPermalink" $relPermalink)
       -}}
-    {{ end -}}
+      <li><hr class="dropdown-divider"></li>
+      {{ end -}}
+    <li>
+      <a class="dropdown-item" href="/docs/">
+        All versions
+      </a>
+    </li>
   </ul>
 </div>
 
@@ -55,6 +62,10 @@
   {{ $isLatest := eq $i 0 -}}
   {{ $_href := printf "/docs/%s/%s" $version $path -}}
   {{ $href := partial "docs/lookup-page" (slice $dot $_href) -}}
+  {{ $title := "" -}}
+  {{ with site.GetPage $href -}}
+    {{ $title = .Params.linkTitle -}}
+  {{ end -}}
   <li> {{- /**/ -}}
     <a class="dropdown-item
         {{- if eq $href $relPermalink }} active{{ end -}}
@@ -62,7 +73,7 @@
         "
       {{ with $href }} href="{{ . }}" {{- end -}}
       >
-      {{- $version -}}{{ if $isLatest }} (latest){{ end -}}
+      {{- $title | default $version -}}
     </a>
     {{- /**/ -}}
   </li>


### PR DESCRIPTION
- Contributes to #746
- Docsy adjustments
  - Versions menu to show max versions (per major version), including the preview (x.dev) release
  - Shows versions menu in /docs landing page
  - Builds all doc versions under Netlify
  - Gets version link title from page title

### Screenshot

> <img width="444" height="490" alt="image" src="https://github.com/user-attachments/assets/3271f186-b9ec-40ed-94b9-29ccde770f1c" />
