### PR TITLE
[docsy] Support pages without left sidebar

### DIFF
--- a/assets/scss/_page_no_left_sidebar.scss
+++ b/assets/scss/_page_no_left_sidebar.scss
@@ -1,0 +1,59 @@
+// This is an improved version of
+// https://github.com/open-telemetry/opentelemetry.io/commit/1f83b9ffa3ecdd5e2b507379cc259e5678596c7f
+
+// Styles for docs-like pages without left sidebar, but with a ToC.
+
+.td-no-left-sidebar .td-main {
+  // Hide left sidebar
+  .td-sidebar {
+    display: none !important;
+  }
+
+  // Adjust ToC sidebar, e.g., to fill Bootstrap columns that the left sidebar
+  // would have taken was using.
+  .td-sidebar-toc {
+    @include media-breakpoint-up(md) {
+      display: block !important;
+    }
+
+    // Always 2 col wide (unless hidden)
+    @extend .col-md-2;
+
+    // Don't scroll with the page (otherwise, for short pages, the ToC hides
+    // behind the top navbar).
+    position: fixed;
+    right: 0;
+
+    @at-root {
+      .td-footer {
+        z-index: 0;
+      }
+    }
+  }
+
+  // The <main> element sibling of the ToC sidebar
+  > div > main {
+    // Always 10 col wide (unless the ToC sidebar is hidden)
+    @extend .col-md-10;
+    @extend .col-xl-10;
+
+    @include media-breakpoint-up(md) {
+      padding-right: 3rem;
+    }
+
+    @include media-breakpoint-up(lg) {
+      // Center content on larger screens
+
+      .td-content {
+        max-width: 90%;
+        margin-left: auto;
+        margin-right: auto;
+
+        // Cancel .td-max-width-on-larger-screens
+        > * {
+          max-width: 100%;
+        }
+      }
+    }
+  }
+}

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -6,6 +6,7 @@
 @import 'footer';
 @import 'home';
 @import 'navbar';
+@import 'page_no_left_sidebar';
 @import 'td/code-dark';
 
 .td-content {

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -9,6 +9,7 @@ cascade:
     version_menu: Versions
   target:
     path: '/docs**'
+body_class: td-no-left-sidebar
 ---
 
 {{% doc_versions %}}

--- a/content/download.md
+++ b/content/download.md
@@ -2,6 +2,7 @@
 title: Download
 aliases: [/docs/download]
 menu: {main: { weight: 30 }}
+body_class: td-no-left-sidebar
 ---
 
 Jaeger components can be downloaded in two ways:

--- a/themes/docsy-overrides/layouts/_partials/navbar-version-selector.html
+++ b/themes/docsy-overrides/layouts/_partials/navbar-version-selector.html
@@ -63,7 +63,7 @@
   {{ $_href := printf "/docs/%s/%s" $version $path -}}
   {{ $href := partial "docs/lookup-page" (slice $dot $_href) -}}
   {{ $title := "" -}}
-  {{ with site.GetPage $href -}}
+  {{ with and $href (site.GetPage $href) -}}
     {{ $title = .Params.linkTitle -}}
   {{ end -}}
   <li> {{- /**/ -}}

--- a/themes/docsy-overrides/layouts/shortcodes/dockerImages.html
+++ b/themes/docsy-overrides/layouts/shortcodes/dockerImages.html
@@ -27,8 +27,8 @@
         </a>
       </td>
       <td>
-        {{ $bg_kind := cond (eq $major "v2") "primary" "secondary" -}}
-        <span class="badge bg-{{ $bg_kind }}">{{ $major }}</span>
+        {{ $bg_kind := cond (eq $major "v2") "success" "secondary" -}}
+        <span class="badge fs-6 bg-{{ $bg_kind }} text-bg-{{ $bg_kind }}">{{ $major }}</span>
       </td>
       <td>
         {{ if .until }}


### PR DESCRIPTION
- Contributes to #746
- Adds support for pages w/o left sidebars
- Uses this for the docs landing page and downloads
- Fixes vers menu entry titles (when versions dne)
- Adjusts docker-image version badge colors