### PR TITLE
[docsy] Add search page using GCS engine

### DIFF
--- a/content/search.md
+++ b/content/search.md
@@ -1,0 +1,4 @@
+---
+title: Search results
+layout: search
+---

--- a/hugo.docsy.yaml
+++ b/hugo.docsy.yaml
@@ -43,6 +43,8 @@ params:
     to_year: present
 
   github_repo: https://github.com/jaegertracing/documentation
+  gcs_engine_id: c196bdeb585f04a00
+
   # TODO: Lunr config
   # Version menu: note some param are set via cascade
   version_menu_pagelinks: true


### PR DESCRIPTION
- Contributes to #985
- Adds Search results page
- Enables GCS engine search

**Preview**: https://deploy-preview-1017--jaegertracing.netlify.app/search/?q=Kubernetes#gsc.tab=1&gsc.q=Kubernetes&gsc.page=1