### PR TITLE
[docsy] Add custom 404 page

### DIFF
--- a/assets/scss/_404.scss
+++ b/assets/scss/_404.scss
@@ -1,0 +1,26 @@
+.jaeger-404-logo {
+  display: inline-block;
+  max-width: 14rem;
+
+  .logo-dark {
+    display: none;
+  }
+
+  img {
+    width: 100%;
+  }
+
+  @include media-breakpoint-up(md) {
+    max-width: 16rem;
+  }
+
+  @at-root [data-bs-theme='dark'] & {
+    .logo-light {
+      display: none;
+    }
+
+    .logo-dark {
+      display: initial;
+    }
+  }
+}

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -7,6 +7,7 @@
 @import 'home';
 @import 'navbar';
 @import 'page_no_left_sidebar';
+@import '404';
 @import 'td/code-dark';
 @import 'gcs_search';
 

--- a/themes/docsy-overrides/layouts/404.html
+++ b/themes/docsy-overrides/layouts/404.html
@@ -1,0 +1,22 @@
+{{ define "main" -}}
+<div class="td-content py-5">
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-lg-8 text-center">
+        <div class="jaeger-404-logo mb-4">
+          <img src="{{ "img/jaeger-icon-color.png" | relURL }}" class="img-fluid logo-light" alt="Jaeger logo">
+          <img src="{{ "img/jaeger-icon-reverse-color.svg" | relURL }}" class="img-fluid logo-dark" alt="Jaeger logo">
+        </div>
+        <h1 class="display-5 mb-3">We couldn’t <span class="fst-italic">trace</span> that page!</h1>
+        <p class="lead mb-4">
+          Get it? The URL you followed doesn’t exist. Try the following instead.
+        </p>
+        <div class="d-flex flex-column flex-md-row justify-content-center gap-3">
+          <a class="btn btn-primary btn-lg px-4" href="{{ "/" | relURL }}">Home</a>
+          <a class="btn btn-outline-primary btn-lg px-4" href="{{ "/docs/" | relURL }}">Docs</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{{- end }}


### PR DESCRIPTION
- Contributes to #746
- Adds a custom 404 page similar to the non-Docsy version
- The page works in dark and light mode

Once we fix page types, it'll look like this:

> <img width="888" alt="image" src="https://github.com/user-attachments/assets/bd6c3fd8-9792-4d37-bc95-72a572c91531" />

> <img width="888" alt="image" src="https://github.com/user-attachments/assets/725566e5-50c2-4920-ba1b-c688db93b36e" />
