### PR TITLE
[docsy] Explicitly set type:docs for all Project pages

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -4,10 +4,7 @@ linkTitle: Jaeger
 description: Monitor and troubleshoot workflows in complex distributed systems
 show_banner: true
 cascade:
-  type: docs # Only when using Docsy theme
-  params:
-    versions: false
-type: home
+  versions: false
 cSpell:ignore: Dosu
 ---
 

--- a/content/demo.md
+++ b/content/demo.md
@@ -2,6 +2,7 @@
 title: Live Demo
 linkTitle: Demo
 menu: {main: { weight: 20 }}
+type: docs
 ---
 
 Jaeger Live Demo consists of:

--- a/content/download.md
+++ b/content/download.md
@@ -2,6 +2,7 @@
 title: Download
 aliases: [/docs/download]
 menu: {main: { weight: 30 }}
+type: docs
 body_class: td-no-left-sidebar
 ---
 

--- a/content/get-in-touch.md
+++ b/content/get-in-touch.md
@@ -1,5 +1,6 @@
 ---
 title: Getting in touch
+type: docs
 weight: 20
 ---
 

--- a/content/get-involved.md
+++ b/content/get-involved.md
@@ -1,5 +1,6 @@
 ---
 title: Get Involved
+type: docs
 weight: 10
 ---
 

--- a/content/mentorship/_index.md
+++ b/content/mentorship/_index.md
@@ -1,5 +1,7 @@
 ---
 title: Mentorships
+cascade:
+  type: docs
 weight: 30
 ---
 

--- a/content/news.md
+++ b/content/news.md
@@ -1,5 +1,6 @@
 ---
 title: News
+type: docs
 weight: 60
 ---
 

--- a/content/project.md
+++ b/content/project.md
@@ -2,6 +2,7 @@
 title: Project
 toc_hide: true
 menu: {main: { weight: 50 }}
+type: docs
 ---
 
 Welcome to the Jaeger project! Below you will find information about the project

--- a/content/report-security-issue.md
+++ b/content/report-security-issue.md
@@ -1,5 +1,6 @@
 ---
 title: Report a security issue
+type: docs
 weight: 80
 ---
 

--- a/content/roadmap.md
+++ b/content/roadmap.md
@@ -1,5 +1,6 @@
 ---
 title: Roadmap
+type: docs
 weight: 70
 ---
 

--- a/content/sdk-migration.md
+++ b/content/sdk-migration.md
@@ -1,6 +1,7 @@
 ---
 title: Migration to OpenTelemetry SDK
 linkTitle: Migration to OTel SDK
+type: docs
 ---
 
 ## Jaeger clients/SDKs are no longer supported

--- a/content/search.md
+++ b/content/search.md
@@ -1,6 +1,5 @@
 ---
 title: Search results
 layout: search
-type: default
 toc_hide: true
 ---


### PR DESCRIPTION
- Contributes to #746
- Explicitly sets `type:docs` for all Project pages instead of using a cascade with target.path ... which bleeds into other pages like the 404 page (something that we don't want).
