### PR TITLE
chore: normalize the jaeger-tracing Google Group URL

### DIFF
--- a/content/news.md
+++ b/content/news.md
@@ -61,4 +61,4 @@ a public beta. Try it out by running the complete backend along with a sample
 application, to generate interesting traces.
 
 We hope that other organizations find Jaeger to be a useful tool, and we welcome contributions.
-Keep up to date by subscribing to our [mailing list](https://groups.google.com/forum/#!forum/jaeger-tracing).
+Keep up to date by subscribing to our [mailing list](https://groups.google.com/g/jaeger-tracing).

--- a/content/report-security-issue.md
+++ b/content/report-security-issue.md
@@ -93,5 +93,5 @@ oF+qZY4uEvqFvYo8
 -----END PGP PUBLIC KEY BLOCK-----
 ```
 
-[mailing-list]: https://groups.google.com/forum/#!forum/jaeger-tracing
+[mailing-list]: https://groups.google.com/g/jaeger-tracing
 [slack-room]: https://cloud-native.slack.com/archives/CGG7NFUJ3

--- a/data/refcache.json
+++ b/data/refcache.json
@@ -2771,9 +2771,9 @@
     "StatusCode": 200,
     "LastSeen": "2025-05-31T11:49:35.026101-04:00"
   },
-  "https://groups.google.com/forum/#!forum/jaeger-tracing": {
+  "https://groups.google.com/g/jaeger-tracing": {
     "StatusCode": 200,
-    "LastSeen": "2025-05-31T11:48:43.856238-04:00"
+    "LastSeen": "2025-11-16T11:41:08.105959-05:00"
   },
   "https://hotrod.demo.jaegertracing.io": {
     "StatusCode": 206,


### PR DESCRIPTION
- Housekeeping / cleanup
- Switch to new recommended URL format for Google Groups
- Now using https://groups.google.com/g/jaeger-tracing