### PR TITLE
fix: ensure Docs appears in top nav, drop page-build constraints

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,11 +2,12 @@
 /CONTRIBUTING.md
 /README.md
 /RELEASE.md
-/content
+/content/**/*.*
 !/content/_index.md
+!/content/docs/latest.md
 /data
 /hugo.yaml
 /layouts
-# TODO: tempoary, remove /scripts
+# TODO: temporary, remove /scripts
 /scripts
 /themes

--- a/content/docs/latest.md
+++ b/content/docs/latest.md
@@ -1,6 +1,6 @@
 ---
 title: Latest docs
-menu: {main: { name: Docs,weight: 10 }}
+menu: { main: { name: Docs, weight: 10 } }
 
 # NOTE: This page is a convenience page for contributors serving locally using
 # Hugo, so that the browser will refresh/redirect this page to the latest
@@ -11,21 +11,10 @@ metaRefreshToLatest: true
 # Set type to default to avoid seeing a flash of this page with stub content.
 # The default type renders a blank page, so the flash is less bothersome.
 type: default
-
 # This page is ignored when serving from Netlify, whether locally or in
 # production.
 #
 # For the `latest`Netlify redirect rule, see
 # [redirects.txt](../../layouts/_partials/redirects.txt).
 #
-cascade:
-  - build:
-      list: never
-      render: never
-    target:
-      environment: production
-  - build:
-      list: never
-    target:
-      environment: development
 ---


### PR DESCRIPTION
- Followup to #1030
- Drops the page-specific `build` directive that were conditional to the env type. Just always render the page as usual. Besides we nave a `302!` (force) Netlify rule, so we're ok.

**Preview**: https://deploy-preview-1031--jaegertracing.netlify.app/
**Redirect test**: https://deploy-preview-1031--jaegertracing.netlify.app/docs/latest - same as before