### PR TITLE
Update NPM package versions, Hugo to 0.154.5

### DIFF
--- a/data/refcache.json
+++ b/data/refcache.json
@@ -2467,6 +2467,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-05-31T11:50:23.871931-04:00"
   },
+  "https://github.com/jaegertracing/jaeger-ui/blob/main/packages/jaeger-ui/src/types/config.ts": {
+    "StatusCode": 206,
+    "LastSeen": "2026-01-18T03:31:32.568128-05:00"
+  },
   "https://github.com/jaegertracing/jaeger-ui/blob/main/packages/jaeger-ui/src/types/config.tsx": {
     "StatusCode": 206,
     "LastSeen": "2025-05-31T11:49:23.040133-04:00"

--- a/netlify/tests/docs-1x-redirect.test.ts
+++ b/netlify/tests/docs-1x-redirect.test.ts
@@ -19,8 +19,14 @@ const tests = [
   { input: '/docs/1.57', expectedRedirect: '/docs/1.76' },
   { input: '/docs/1.65/', expectedRedirect: '/docs/1.76/' },
   { input: '/docs/1.13/faq/', expectedRedirect: '/docs/1.76/faq/' },
-  { input: '/docs/1.50/deployment/cli/', expectedRedirect: '/docs/1.76/deployment/cli/' },
-  { input: '/docs/1.18/client-libraries/', expectedRedirect: '/docs/1.76/client-libraries/' },
+  {
+    input: '/docs/1.50/deployment/cli/',
+    expectedRedirect: '/docs/1.76/deployment/cli/',
+  },
+  {
+    input: '/docs/1.18/client-libraries/',
+    expectedRedirect: '/docs/1.76/client-libraries/',
+  },
   // Last v1, no redirect
   { input: '/docs/1.76/', expectedRedirect: null },
   { input: '/docs/1.76/faq/', expectedRedirect: null },

--- a/netlify/tests/redirects.test.ts
+++ b/netlify/tests/redirects.test.ts
@@ -5,8 +5,12 @@
 const baseUrl = Deno.args[0];
 
 if (!baseUrl) {
-  console.error('Usage: deno run --allow-net tests/redirects.test.ts <base-url>');
-  console.error('Example: deno run --allow-net tests/redirects.test.ts https://jaegertracing.io');
+  console.error(
+    'Usage: deno run --allow-net tests/redirects.test.ts <base-url>',
+  );
+  console.error(
+    'Example: deno run --allow-net tests/redirects.test.ts https://jaegertracing.io',
+  );
   Deno.exit(1);
 }
 
@@ -18,13 +22,22 @@ const tests = [
   { input: '/docs/1.57', expectedRedirect: '/docs/1.76' },
   { input: '/docs/1.65/', expectedRedirect: '/docs/1.76/' },
   { input: '/docs/1.13/faq/', expectedRedirect: '/docs/1.76/faq/' },
-  { input: '/docs/1.50/deployment/cli/', expectedRedirect: '/docs/1.76/deployment/cli/' },
-  { input: '/docs/1.18/client-libraries/', expectedRedirect: '/docs/1.76/client-libraries/' },
+  {
+    input: '/docs/1.50/deployment/cli/',
+    expectedRedirect: '/docs/1.76/deployment/cli/',
+  },
+  {
+    input: '/docs/1.18/client-libraries/',
+    expectedRedirect: '/docs/1.76/client-libraries/',
+  },
   // Last v1, no redirect
   { input: '/docs/1.76/', expectedRedirect: null },
   { input: '/docs/1.76/faq/', expectedRedirect: null },
   // Last v2, no redirect
-  { input: '/docs/2.1/apis/', expectedRedirect: '/docs/2.1/architecture/apis/' },
+  {
+    input: '/docs/2.1/apis/',
+    expectedRedirect: '/docs/2.1/architecture/apis/',
+  },
   { input: '/docs/2.14/architecture/', expectedRedirect: null },
 ];
 
@@ -48,13 +61,19 @@ for (const { input, expectedRedirect } of tests) {
     if (expectedRedirect === null) {
       // Expect no redirect
       ok = !isRedirect;
-      result = ok ? `${response.status} (no redirect)` : `${response.status} → ${location}`;
+      result = ok
+        ? `${response.status} (no redirect)`
+        : `${response.status} → ${location}`;
     } else {
       // Expect redirect to specific path
       const expectedLocation = `${base}${expectedRedirect}`;
       // Also check for relative redirects
-      ok = isRedirect && (location === expectedLocation || location === expectedRedirect);
-      result = isRedirect ? `${response.status} → ${location}` : `${response.status} (no redirect)`;
+      ok =
+        isRedirect &&
+        (location === expectedLocation || location === expectedRedirect);
+      result = isRedirect
+        ? `${response.status} → ${location}`
+        : `${response.status} (no redirect)`;
     }
 
     const status = ok ? '✓' : '✗';

--- a/package.json
+++ b/package.json
@@ -41,16 +41,16 @@
     "update:packages": "npx npm-check-updates -u"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.22",
-    "cspell": "^9.3.1",
+    "autoprefixer": "^10.4.23",
+    "cspell": "^9.6.0",
     "docsy": "github:google/docsy#0e2ad1805410641c8c6200ded66af5d7b69bc847",
     "postcss-cli": "^11.0.1",
-    "prettier": "^3.6.2"
+    "prettier": "^3.8.0"
   },
   "peerDependencies": {
-    "hugo-extended": "0.152.2",
-    "netlify-cli": "^23.13.3",
-    "npm-check-updates": "^19.1.2"
+    "hugo-extended": "0.154.5",
+    "netlify-cli": "^23.13.4",
+    "npm-check-updates": "^19.3.1"
   },
   "enginesComment": "Ensure that engines.node value stays consistent with the project's .nvmrc",
   "engines": {


### PR DESCRIPTION
- Updates NPM package versions, Hugo to 0.154.5
- Commits two other files updated when the Prettier is run (file updates from a previous commit)

---

The changes to the generated site files seem to be due to:

- Chroma upgrade: empty spans have been removed, and the light style tweaked
- Image fingerprinting

```console
$ (cd public && git diff -bw --ignore-blank-lines -I 'class="(cl|cp|gi|k|nn|nt)"' -I '_hu_' -I 'Hugo 0.15' -- ':(exclude)*.xml') | grep ^diff | grep -v \.jpg
diff --git a/index.html b/index.html
```

Reference:

- #2431
