### PR TITLE
Update docsy to version 0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "autoprefixer": "^10.4.23",
     "cspell": "^9.6.0",
-    "docsy": "github:google/docsy#0e2ad1805410641c8c6200ded66af5d7b69bc847",
+    "docsy": "github:google/docsy#semver:0.13.0",
     "postcss-cli": "^11.0.1",
     "prettier": "^3.8.0"
   },


### PR DESCRIPTION
- Contributes to #1024
- Update docsy to version 0.13.0
- Was previously `v0.13.0-dev+38-g53cfee7`

### Site diff

Mainly changes due to the new way the in-page toc attributes:

```console
$ (cd public && git diff -bw --ignore-blank-lines -I 'class="no-js"' -I '#TableOfContents|td-toc' -I '^</div>$' -I 'Hugo 0.15' -- ':(exclude)*.xml') | grep ^diff
diff --git a/index.html b/index.html
diff --git a/js/main.js b/js/main.js
diff --git a/scss/main.css b/scss/main.css
diff --git a/scss/main.css.map b/scss/main.css.map
```