### PR TITLE
Upgrade Docsy to 0.14.0-dev+33-gf81406a

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "autoprefixer": "^10.4.23",
     "cspell": "^9.6.0",
-    "docsy": "github:google/docsy#semver:0.13.0",
+    "docsy": "github:google/docsy#a600e534909f5fc09b1a48cef649d1e554af4bd2",
     "postcss-cli": "^11.0.1",
     "prettier": "^3.8.0"
   },


### PR DESCRIPTION
- Contributes to #1024
- Upgrades Docsy to 0.14.0-dev+33-gf81406a

```console
$ head -3 node_modules/docsy/package.json
{
  "name": "docsy",
  "version": "0.14.0-dev+33-gf81406a",
```

### Site diff

```console
$ (cd public && git diff -bw --ignore-blank-lines -- ':(exclude)*.xml') | grep ^diff 
diff --git a/index.html b/index.html
diff --git a/scss/main.css b/scss/main.css
diff --git a/scss/main.css.map b/scss/main.css.map
```