### PR TITLE
Illustrate use of new Markdown alert syntax

### DIFF
--- a/content/download.md
+++ b/content/download.md
@@ -6,11 +6,15 @@ type: docs
 body_class: td-no-left-sidebar
 ---
 
-{{< warning >}}
-🎉 **Jaeger v2** is a new major release based on the OpenTelemetry Collector framework. Read [the blog post](https://medium.com/jaegertracing/jaeger-v2-released-09a6033d1b10) for more details.
-
-🌆 **Jaeger v1** has reached [end-of-life](https://github.com/jaegertracing/jaeger/issues/6321) on **December 31, 2025** and will no longer receive updates.
-{{< /warning >}}
+> [!WARNING]
+>
+> 🎉 **Jaeger v2** is a new major release based on the OpenTelemetry Collector
+> framework. For details, read [the blog
+> post](https://medium.com/jaegertracing/jaeger-v2-released-09a6033d1b10).
+>
+> 🌆 **Jaeger v1** reached
+> [end-of-life](https://github.com/jaegertracing/jaeger/issues/6321) on
+> **December 31, 2025** and will no longer receive updates.
 
 Jaeger v2 components can be downloaded in two ways:
 


### PR DESCRIPTION
- Contributes to #1024
- Illustrates Hugo and Docsy's new Markdown alert syntax, by replacing a `warning` shortcode call in the download page
- Copyedits the v1/v2 download warning
- I'd suggest we adopt this new syntax for all admonition since it is plain Markdown. This allows better tooling and AI support.
- I'll migrate others if you agree with the use of this new syntax
- **Preview**: https://deploy-preview-1063--jaegertracing.netlify.app/download/

### Screenshot

<img width="725" height="400" alt="image" src="https://github.com/user-attachments/assets/b3beb927-7d15-4200-aada-27ba9fa2bc4e" />

