### PR TITLE
Remove ClickHouse from roadmap page

### DIFF
--- a/content/roadmap.md
+++ b/content/roadmap.md
@@ -15,18 +15,6 @@ As part of #5079, Jaeger has introduced the more efficient **[v2 Storage API](ht
 
 For more information see the [issue description](https://github.com/jaegertracing/jaeger/issues/6458).
 
-## Support ClickHouse as a core storage backend
-
-Build first-class support for [ClickHouse ](https://github.com/ClickHouse/ClickHouse) as an official Jaeger backend. ClickHouse is an open-source column-oriented database for OLAP use cases. It is highly efficient and performant for high volumes of ingestion and search making it a good database for tracing and logging data specifically. It can also do aggregates very quickly which will come in handy for several features in Jaeger.
-
-Benefits to the users:
-
-* Efficient backend
-* Powerful search
-* Analytics capability, e.g. the possibility to support the APM function (Monitoring tab in Jaeger) directly from ClickHouse
-
-For more information see the [issue description](https://github.com/jaegertracing/jaeger/issues/5058).
-
 ## GenAI integration with Jaeger
 
 GenAI can provide powerful capabilities for automatic analysis of tracing data.
@@ -76,4 +64,3 @@ We need a dynamic configuration solution that comes in handy in various scenario
   * etc.
 
 For more information see the [issue description](https://github.com/jaegertracing/jaeger/issues/355).
-


### PR DESCRIPTION

  ## Which problem is this PR solving?
  - Resolves jaegertracing/jaeger#8312

  ## Description of the changes
  - Removed the completed `Support ClickHouse as a core storage backend` item from the website roadmap page at `content/roadmap.md`
  - Left other ClickHouse documentation references unchanged, since this issue only targets the roadmap page

  ## How was this change tested?
  - Reviewed the diff for `content/roadmap.md` to confirm only the roadmap entry was removed
  - Verified the surrounding roadmap sections still flow correctly after the removal

  ## Checklist
  - [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
  - [ ] I have signed all commits
  - [ ] I have added unit tests for the new functionality
  - [ ] I have run lint and test steps successfully: `make lint test`

  ## AI Usage in this PR (choose one)
  See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
  - [ ] **None**: No AI tools were used in creating this PR
  - [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
  - [ ] **Moderate**: AI helped with code generation or debugging specific parts
  - [ ] **Heavy**: AI generated most or all of the code changes