### PR TITLE
Fix Kubernetes deployment links

### DIFF
--- a/content/docs/v2/2.17/deployment/kubernetes.md
+++ b/content/docs/v2/2.17/deployment/kubernetes.md
@@ -6,8 +6,8 @@ hasparent: true
 
 ## Kubernetes Operator
 
-The [OpenTelemetry Collector Operator](https://github.com/open-telemetry/opentelemetry-operator) can be used to manage Jaeger v2.
+The [OpenTelemetry Operator](https://github.com/open-telemetry/opentelemetry-operator) can be used to manage Jaeger v2.
 
 ## Helm Chart
 
-The [Helm Chart for Jaeger v2](https://github.com/jaegertracing/helm-charts/tree/v2) is available in the `v2` branch.
+The [Helm Chart for Jaeger v2](https://github.com/jaegertracing/helm-charts/tree/main/charts/jaeger) is available from the helm-charts main branch.

--- a/content/docs/v2/2.17/deployment/kubernetes.md
+++ b/content/docs/v2/2.17/deployment/kubernetes.md
@@ -6,8 +6,8 @@ hasparent: true
 
 ## Kubernetes Operator
 
-The [OpenTelemetry Collector Operator](https://github.com/jaegertracing/jaeger-operator#jager-v2-operator) can be used to manage Jaeger v2.
+The [OpenTelemetry Collector Operator](https://github.com/open-telemetry/opentelemetry-operator) can be used to manage Jaeger v2.
 
 ## Helm Chart
 
-The Helm Chart for Jaeger v2 is available in the `v2` branch: https://github.com/jaegertracing/helm-charts/tree/v2.
+The [Helm Chart for Jaeger v2](https://github.com/jaegertracing/helm-charts/tree/v2) is available in the `v2` branch.

--- a/content/docs/v2/_dev/deployment/kubernetes.md
+++ b/content/docs/v2/_dev/deployment/kubernetes.md
@@ -6,8 +6,8 @@ hasparent: true
 
 ## Kubernetes Operator
 
-The [OpenTelemetry Collector Operator](https://github.com/open-telemetry/opentelemetry-operator) can be used to manage Jaeger v2.
+The [OpenTelemetry Operator](https://github.com/open-telemetry/opentelemetry-operator) can be used to manage Jaeger v2.
 
 ## Helm Chart
 
-The [Helm Chart for Jaeger v2](https://github.com/jaegertracing/helm-charts/tree/v2) is available in the `v2` branch.
+The [Helm Chart for Jaeger v2](https://github.com/jaegertracing/helm-charts/tree/main/charts/jaeger) is available from the helm-charts main branch.

--- a/content/docs/v2/_dev/deployment/kubernetes.md
+++ b/content/docs/v2/_dev/deployment/kubernetes.md
@@ -6,8 +6,8 @@ hasparent: true
 
 ## Kubernetes Operator
 
-The [OpenTelemetry Collector Operator](https://github.com/jaegertracing/jaeger-operator#jager-v2-operator) can be used to manage Jaeger v2.
+The [OpenTelemetry Collector Operator](https://github.com/open-telemetry/opentelemetry-operator) can be used to manage Jaeger v2.
 
 ## Helm Chart
 
-The Helm Chart for Jaeger v2 is available in the `v2` branch: https://github.com/jaegertracing/helm-charts/tree/v2.
+The [Helm Chart for Jaeger v2](https://github.com/jaegertracing/helm-charts/tree/v2) is available in the `v2` branch.


### PR DESCRIPTION
Fixes #1088.

This updates the Kubernetes deployment docs for the current live v2 docs and the next-release docs:

- Point the OpenTelemetry Collector Operator link at the OpenTelemetry Operator repository instead of the deprecated Jaeger operator page.
- Convert the Jaeger v2 Helm chart URL into a proper Markdown link.

Validation:

- `npx --yes prettier@3.8.0 --check content/docs/v2/_dev/deployment/kubernetes.md content/docs/v2/2.17/deployment/kubernetes.md`
- Verified both updated GitHub URLs return `200 OK` locally.