### PR TITLE
docs: fix prioirity typo in CLI flag references

### DIFF
--- a/data/cli/1.52/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.52/jaeger-all-in-one-elasticsearch.yaml
@@ -306,13 +306,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -443,13 +443,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.52/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.52/jaeger-collector-elasticsearch.yaml
@@ -305,13 +305,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -442,13 +442,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.52/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.52/jaeger-ingester-elasticsearch.yaml
@@ -95,13 +95,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -232,13 +232,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.52/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.52/jaeger-query-elasticsearch.yaml
@@ -90,13 +90,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -227,13 +227,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.53/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.53/jaeger-all-in-one-elasticsearch.yaml
@@ -306,13 +306,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -443,13 +443,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.53/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.53/jaeger-collector-elasticsearch.yaml
@@ -305,13 +305,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -442,13 +442,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.53/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.53/jaeger-ingester-elasticsearch.yaml
@@ -95,13 +95,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -232,13 +232,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.53/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.53/jaeger-query-elasticsearch.yaml
@@ -90,13 +90,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -227,13 +227,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.54/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.54/jaeger-all-in-one-elasticsearch.yaml
@@ -306,13 +306,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -443,13 +443,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.54/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.54/jaeger-collector-elasticsearch.yaml
@@ -305,13 +305,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -442,13 +442,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.54/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.54/jaeger-ingester-elasticsearch.yaml
@@ -95,13 +95,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -232,13 +232,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.54/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.54/jaeger-query-elasticsearch.yaml
@@ -90,13 +90,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -227,13 +227,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.55/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.55/jaeger-all-in-one-elasticsearch.yaml
@@ -314,13 +314,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -459,13 +459,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.55/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.55/jaeger-collector-elasticsearch.yaml
@@ -313,13 +313,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -458,13 +458,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.55/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.55/jaeger-ingester-elasticsearch.yaml
@@ -103,13 +103,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -248,13 +248,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.55/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.55/jaeger-query-elasticsearch.yaml
@@ -98,13 +98,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -243,13 +243,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.56/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.56/jaeger-all-in-one-elasticsearch.yaml
@@ -314,13 +314,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -459,13 +459,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.56/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.56/jaeger-collector-elasticsearch.yaml
@@ -313,13 +313,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -458,13 +458,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.56/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.56/jaeger-ingester-elasticsearch.yaml
@@ -103,13 +103,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -248,13 +248,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.56/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.56/jaeger-query-elasticsearch.yaml
@@ -98,13 +98,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -243,13 +243,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.57/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.57/jaeger-all-in-one-elasticsearch.yaml
@@ -314,13 +314,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -459,13 +459,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.57/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.57/jaeger-collector-elasticsearch.yaml
@@ -313,13 +313,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -458,13 +458,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.57/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.57/jaeger-ingester-elasticsearch.yaml
@@ -103,13 +103,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -248,13 +248,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.57/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.57/jaeger-query-elasticsearch.yaml
@@ -98,13 +98,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -243,13 +243,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.58/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.58/jaeger-all-in-one-elasticsearch.yaml
@@ -314,13 +314,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -462,13 +462,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.58/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.58/jaeger-collector-elasticsearch.yaml
@@ -313,13 +313,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -461,13 +461,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.58/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.58/jaeger-ingester-elasticsearch.yaml
@@ -103,13 +103,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -251,13 +251,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.58/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.58/jaeger-query-elasticsearch.yaml
@@ -98,13 +98,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -246,13 +246,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.59/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.59/jaeger-all-in-one-elasticsearch.yaml
@@ -314,13 +314,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -462,13 +462,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.59/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.59/jaeger-collector-elasticsearch.yaml
@@ -313,13 +313,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -461,13 +461,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.59/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.59/jaeger-ingester-elasticsearch.yaml
@@ -103,13 +103,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -251,13 +251,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.59/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.59/jaeger-query-elasticsearch.yaml
@@ -98,13 +98,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -246,13 +246,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.60/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.60/jaeger-all-in-one-elasticsearch.yaml
@@ -316,13 +316,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -464,13 +464,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.60/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.60/jaeger-collector-elasticsearch.yaml
@@ -315,13 +315,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -463,13 +463,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.60/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.60/jaeger-ingester-elasticsearch.yaml
@@ -103,13 +103,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -251,13 +251,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.60/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.60/jaeger-query-elasticsearch.yaml
@@ -98,13 +98,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -246,13 +246,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.61/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.61/jaeger-all-in-one-elasticsearch.yaml
@@ -316,13 +316,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -464,13 +464,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.61/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.61/jaeger-collector-elasticsearch.yaml
@@ -315,13 +315,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -463,13 +463,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.61/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.61/jaeger-ingester-elasticsearch.yaml
@@ -103,13 +103,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -251,13 +251,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.61/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.61/jaeger-query-elasticsearch.yaml
@@ -98,13 +98,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -246,13 +246,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.62/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.62/jaeger-all-in-one-elasticsearch.yaml
@@ -316,13 +316,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -464,13 +464,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.62/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.62/jaeger-collector-elasticsearch.yaml
@@ -315,13 +315,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -463,13 +463,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.62/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.62/jaeger-ingester-elasticsearch.yaml
@@ -103,13 +103,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -251,13 +251,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.62/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.62/jaeger-query-elasticsearch.yaml
@@ -98,13 +98,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -246,13 +246,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.63/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.63/jaeger-all-in-one-elasticsearch.yaml
@@ -316,13 +316,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -464,13 +464,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.63/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.63/jaeger-collector-elasticsearch.yaml
@@ -314,13 +314,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -462,13 +462,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.63/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.63/jaeger-ingester-elasticsearch.yaml
@@ -103,13 +103,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -251,13 +251,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.63/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.63/jaeger-query-elasticsearch.yaml
@@ -98,13 +98,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -246,13 +246,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.64/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.64/jaeger-all-in-one-elasticsearch.yaml
@@ -316,13 +316,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -464,13 +464,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.64/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.64/jaeger-collector-elasticsearch.yaml
@@ -314,13 +314,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -462,13 +462,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.64/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.64/jaeger-ingester-elasticsearch.yaml
@@ -103,13 +103,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -251,13 +251,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.64/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.64/jaeger-query-elasticsearch.yaml
@@ -98,13 +98,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -246,13 +246,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.65/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.65/jaeger-all-in-one-elasticsearch.yaml
@@ -316,13 +316,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -464,13 +464,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.65/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.65/jaeger-collector-elasticsearch.yaml
@@ -314,13 +314,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -462,13 +462,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.65/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.65/jaeger-ingester-elasticsearch.yaml
@@ -103,13 +103,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -251,13 +251,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.65/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.65/jaeger-query-elasticsearch.yaml
@@ -98,13 +98,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -246,13 +246,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.66/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.66/jaeger-all-in-one-elasticsearch.yaml
@@ -332,13 +332,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -480,13 +480,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.66/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.66/jaeger-collector-elasticsearch.yaml
@@ -330,13 +330,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -478,13 +478,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.66/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.66/jaeger-ingester-elasticsearch.yaml
@@ -107,13 +107,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -255,13 +255,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.66/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.66/jaeger-query-elasticsearch.yaml
@@ -102,13 +102,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -250,13 +250,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.67/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.67/jaeger-all-in-one-elasticsearch.yaml
@@ -332,13 +332,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -480,13 +480,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.67/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.67/jaeger-collector-elasticsearch.yaml
@@ -330,13 +330,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -478,13 +478,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.67/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.67/jaeger-ingester-elasticsearch.yaml
@@ -107,13 +107,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -255,13 +255,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.67/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.67/jaeger-query-elasticsearch.yaml
@@ -102,13 +102,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -250,13 +250,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.68/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.68/jaeger-all-in-one-elasticsearch.yaml
@@ -332,13 +332,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -480,13 +480,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.68/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.68/jaeger-collector-elasticsearch.yaml
@@ -330,13 +330,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -478,13 +478,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.68/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.68/jaeger-ingester-elasticsearch.yaml
@@ -107,13 +107,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -255,13 +255,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.68/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.68/jaeger-query-elasticsearch.yaml
@@ -102,13 +102,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -250,13 +250,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.69/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.69/jaeger-all-in-one-elasticsearch.yaml
@@ -335,13 +335,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -486,13 +486,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.69/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.69/jaeger-collector-elasticsearch.yaml
@@ -333,13 +333,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -484,13 +484,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.69/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.69/jaeger-ingester-elasticsearch.yaml
@@ -110,13 +110,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -261,13 +261,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.69/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.69/jaeger-query-elasticsearch.yaml
@@ -105,13 +105,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -256,13 +256,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.70/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.70/jaeger-all-in-one-elasticsearch.yaml
@@ -338,13 +338,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -492,13 +492,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.70/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.70/jaeger-collector-elasticsearch.yaml
@@ -336,13 +336,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -490,13 +490,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.70/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.70/jaeger-ingester-elasticsearch.yaml
@@ -113,13 +113,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -267,13 +267,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.70/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.70/jaeger-query-elasticsearch.yaml
@@ -108,13 +108,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -262,13 +262,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.71/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.71/jaeger-all-in-one-elasticsearch.yaml
@@ -338,13 +338,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -492,13 +492,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.71/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.71/jaeger-collector-elasticsearch.yaml
@@ -336,13 +336,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -490,13 +490,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.71/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.71/jaeger-ingester-elasticsearch.yaml
@@ -113,13 +113,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -267,13 +267,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.71/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.71/jaeger-query-elasticsearch.yaml
@@ -108,13 +108,13 @@ options:
     - name: es-archive.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -262,13 +262,13 @@ options:
     - name: es.password-file
       usage: |
         Path to a file containing password. This file is watched for changes.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.72/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.72/jaeger-all-in-one-elasticsearch.yaml
@@ -358,13 +358,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -532,13 +532,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.72/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.72/jaeger-collector-elasticsearch.yaml
@@ -356,13 +356,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -530,13 +530,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.72/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.72/jaeger-ingester-elasticsearch.yaml
@@ -133,13 +133,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -307,13 +307,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.72/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.72/jaeger-query-elasticsearch.yaml
@@ -128,13 +128,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -302,13 +302,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.73/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.73/jaeger-all-in-one-elasticsearch.yaml
@@ -358,13 +358,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -532,13 +532,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.73/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.73/jaeger-collector-elasticsearch.yaml
@@ -356,13 +356,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -530,13 +530,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.73/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.73/jaeger-ingester-elasticsearch.yaml
@@ -133,13 +133,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -307,13 +307,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.73/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.73/jaeger-query-elasticsearch.yaml
@@ -128,13 +128,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -302,13 +302,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.74/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.74/jaeger-all-in-one-elasticsearch.yaml
@@ -358,13 +358,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -532,13 +532,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.74/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.74/jaeger-collector-elasticsearch.yaml
@@ -356,13 +356,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -530,13 +530,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.74/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.74/jaeger-ingester-elasticsearch.yaml
@@ -133,13 +133,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -307,13 +307,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.74/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.74/jaeger-query-elasticsearch.yaml
@@ -128,13 +128,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -302,13 +302,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.75/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.75/jaeger-all-in-one-elasticsearch.yaml
@@ -358,13 +358,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -532,13 +532,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.75/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.75/jaeger-collector-elasticsearch.yaml
@@ -356,13 +356,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -530,13 +530,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.75/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.75/jaeger-ingester-elasticsearch.yaml
@@ -133,13 +133,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -307,13 +307,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.75/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.75/jaeger-query-elasticsearch.yaml
@@ -128,13 +128,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -302,13 +302,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.76/jaeger-all-in-one-elasticsearch.yaml
+++ b/data/cli/1.76/jaeger-all-in-one-elasticsearch.yaml
@@ -358,13 +358,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -532,13 +532,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.76/jaeger-collector-elasticsearch.yaml
+++ b/data/cli/1.76/jaeger-collector-elasticsearch.yaml
@@ -356,13 +356,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -530,13 +530,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.76/jaeger-ingester-elasticsearch.yaml
+++ b/data/cli/1.76/jaeger-ingester-elasticsearch.yaml
@@ -133,13 +133,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -307,13 +307,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters

--- a/data/cli/1.76/jaeger-query-elasticsearch.yaml
+++ b/data/cli/1.76/jaeger-query-elasticsearch.yaml
@@ -128,13 +128,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es-archive.prioirity-dependencies-template
+    - name: es-archive.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es-archive.prioirity-service-template
+    - name: es-archive.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es-archive.prioirity-span-template
+    - name: es-archive.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es-archive.remote-read-clusters
@@ -302,13 +302,13 @@ options:
       default_value: 10s
       usage: |
         Interval for reloading password from file. Set to 0 to disable automatic reloading.
-    - name: es.prioirity-dependencies-template
+    - name: es.priority-dependencies-template
       default_value: "0"
       usage: Priority of jaeger-dependecies index template (ESv8 only)
-    - name: es.prioirity-service-template
+    - name: es.priority-service-template
       default_value: "0"
       usage: Priority of jaeger-service index template (ESv8 only)
-    - name: es.prioirity-span-template
+    - name: es.priority-span-template
       default_value: "0"
       usage: Priority of jaeger-span index template (ESv8 only)
     - name: es.remote-read-clusters


### PR DESCRIPTION
## Summary

Fixes #1080

CLI flag documentation references contain the typo 'prioirity' instead of 'priority'.

## Root Cause

The misspelling 'prioirity' appears in CLI flag documentation across 100 YAML files (600 occurrences), likely a typo from initial authoring that propagated through all versioned CLI data files.

## Fix

Correct all instances of 'prioirity' to 'priority' across the codebase.

## Changes

- Updated 100 files containing 'prioirity' to use correct spelling 'priority'
- All 6 flag patterns corrected:
  - `es.priority-dependencies-template`
  - `es.priority-service-template`
  - `es.priority-span-template`
  - `es-archive.priority-dependencies-template`
  - `es-archive.priority-service-template`
  - `es-archive.priority-span-template`

## Testing

- `grep -r 'prioirity' .` returns no results after fix ✅
- `grep -r 'priority' .` shows correct flag names ✅
- Documentation still reads correctly ✅