### PR TITLE
fix(netlify): Add hardened website headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,7 +9,6 @@ command = "npm run build:production"
   for = "/*"
 
   [headers.values]
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://code.jquery.com https://cdn.jsdelivr.net https://unpkg.com https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: https://scarf.jaegertracing.io https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.googletagmanager.com https://*.google-analytics.com https://analytics.google.com https://stats.g.doubleclick.net; font-src 'self' data:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; upgrade-insecure-requests"
     Strict-Transport-Security = "max-age=31536000"
     X-Content-Type-Options = "nosniff"
     X-Frame-Options = "DENY"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,17 @@ command = "npm run build:preview"
 [context.production]
 command = "npm run build:production"
 
+[[headers]]
+  for = "/*"
+
+  [headers.values]
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://code.jquery.com https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://scarf.jaegertracing.io https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.googletagmanager.com https://*.google-analytics.com https://analytics.google.com https://stats.g.doubleclick.net; font-src 'self' data:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; upgrade-insecure-requests"
+    Strict-Transport-Security = "max-age=31536000; includeSubDomains"
+    X-Content-Type-Options = "nosniff"
+    X-Frame-Options = "DENY"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "camera=(), geolocation=(), microphone=()"
+
 # Edge function to redirect all /docs/1.X/* to /docs/1.76/*
 [[edge_functions]]
   path = "/docs/1.(.*)"

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,8 +9,8 @@ command = "npm run build:production"
   for = "/*"
 
   [headers.values]
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://code.jquery.com https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://scarf.jaegertracing.io https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.googletagmanager.com https://*.google-analytics.com https://analytics.google.com https://stats.g.doubleclick.net; font-src 'self' data:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; upgrade-insecure-requests"
-    Strict-Transport-Security = "max-age=31536000; includeSubDomains"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://code.jquery.com https://cdn.jsdelivr.net https://unpkg.com https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: https://scarf.jaegertracing.io https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.googletagmanager.com https://*.google-analytics.com https://analytics.google.com https://stats.g.doubleclick.net; font-src 'self' data:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; upgrade-insecure-requests"
+    Strict-Transport-Security = "max-age=31536000"
     X-Content-Type-Options = "nosniff"
     X-Frame-Options = "DENY"
     Referrer-Policy = "strict-origin-when-cross-origin"


### PR DESCRIPTION
## Summary

- Add a global Netlify header rule for the Jaeger website.
- Configure HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, and Permissions-Policy for all paths.
- Leave CSP out of this PR after maintainer feedback; a stricter CSP can be tracked separately once it can avoid unsafe-inline and be validated against the site assets.

## OpenSSF

Refs jaegertracing/jaeger#8600
Refs jaegertracing/jaeger#8484
Parent tracker: jaegertracing/jaeger#8481

## Validation

- `node` TOML parse check for required header fields and no blocking CSP
- `git diff --check`
- `npm run check:format`
- `npm run check:filenames`

Note: local `npm run build` currently fails before rendering pages because Hugo cannot find the Docsy partial `dark-mode-config.html` in this checkout dependency state. The failure is unrelated to the `netlify.toml` header change.