### PR TITLE
Add LFX Mentorship Term 1 2026 mentees

### DIFF
--- a/.cspell/project-names-src.txt
+++ b/.cspell/project-names-src.txt
@@ -7,6 +7,10 @@ Juraci Paixão Kröhling
 # Other names (sometimes from github links)
 robbert
 
+## LFX Mentorship March-May 2026 (Term 1)
+Nabil Salah
+Parship Chowdhury
+
 ## LFX Mentorship Sep-Dec 2025 (Term 3)
 Saiddiqui
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@ https://jaegertracing.io, built with [Hugo](https://gohugo.io/) and hosted on
 [Netlify](https://www.netlify.com/). For general information about the
 repository, see [README.md](README.md).
 
+## Commit Requirements
+
+All commits must include a sign-off (`git commit -s`).
+
 ## Contributing Guidelines
 
 Before making changes, familiarize yourself with:

--- a/content/mentorship/_index.md
+++ b/content/mentorship/_index.md
@@ -11,6 +11,11 @@ See also:
   * [For mentees](for-mentees/)
   * [For mentors](for-mentors/)
 
+## LFX Mentorship March-May 2026 (Term 1)
+
+* [Nabil Salah](https://github.com/Nabil-Salah) -- [AI-Powered Trace Analysis with Bring-Your-Own-Agent](https://github.com/jaegertracing/jaeger/issues/7832)
+* [Parship Chowdhury](https://github.com/Parship12) -- [Modernizing Jaeger-UI routing and state management](https://github.com/jaegertracing/jaeger-ui/issues/3313)
+
 ## LFX Mentorship September-November 2025 (Term 3)
 
 * [Danish Saiddiqui](https://github.com/danish9039) -- [Next-Generation Jaeger Demo with OpenTelemetry and OpenSearch](https://github.com/jaegertracing/jaeger/issues/7326)

--- a/content/mentorship/_index.md
+++ b/content/mentorship/_index.md
@@ -14,7 +14,7 @@ See also:
 ## LFX Mentorship March-May 2026 (Term 1)
 
 * [Nabil Salah](https://github.com/Nabil-Salah) -- [AI-Powered Trace Analysis with Bring-Your-Own-Agent](https://github.com/jaegertracing/jaeger/issues/7832)
-* [Parship Chowdhury](https://github.com/Parship12) -- [Modernizing Jaeger-UI routing and state management](https://github.com/jaegertracing/jaeger-ui/issues/3313)
+* [Parship Chowdhury](https://github.com/parshipcy) -- [Modernizing Jaeger-UI routing and state management](https://github.com/jaegertracing/jaeger-ui/issues/3313)
 
 ## LFX Mentorship September-November 2025 (Term 3)
 


### PR DESCRIPTION
Add Nabil Salah and Parship Chowdhury as mentees for LFX Mentorship Term 1 2026 (March–May 2026).

🤖 Generated with [Claude Code](https://claude.com/claude-code)