### PR TITLE
Separate Applying, add post-selection

### DIFF
--- a/content/mentorship/_index.md
+++ b/content/mentorship/_index.md
@@ -8,6 +8,7 @@ weight: 30
 The Jaeger project regularly participates in mentorship programs via CNCF, such as [Outreachy](https://www.outreachy.org/), [Google Summer of Code](https://summerofcode.withgoogle.com/), and [LFX Mentorship](https://mentorship.lfx.linuxfoundation.org/). As a mentee, you will have the opportunity to contribute to an open-source project while working under the guidance of an experienced mentor who is an active contributor to the project and open-source community. The mentees receive an internship stipend.
 
 See also:
+  * [Applying](applying/)
   * [For mentees](for-mentees/)
   * [For mentors](for-mentors/)
 

--- a/content/mentorship/applying.md
+++ b/content/mentorship/applying.md
@@ -28,7 +28,7 @@ It does not mean that the longer the proposal the better. It's about the quality
 
 #### Level playing field
 
-To ensure a fair and consistent evaluation process for all applicants, we cannot provide individual feedback on proposals before the submission deadline.  Providing feedback to some applicants and not others would create an unequal opportunity.  All proposals will receive thorough consideration by the selection committee after the deadline.  We encourage all interested individuals to submit their best work.
+To ensure a fair and consistent evaluation process for all applicants, we cannot provide individual feedback on proposals before the submission deadline. Providing feedback to some applicants and not others would create an unequal opportunity. All proposals will receive thorough consideration by the selection committee after the deadline. We encourage all interested individuals to submit their best work.
 
 If you need to ask specific questions / clarifications about the project, please ask them in the comments on the tracking issue, where they will be visible to all applicants.
 

--- a/content/mentorship/applying.md
+++ b/content/mentorship/applying.md
@@ -1,0 +1,66 @@
+---
+title: Mentorship Application Guidelines
+linkTitle: Applying
+aliases: [/mentorship-for-mentees]
+---
+
+## Application process
+
+Applications are submitted via respective program websites, such as [Google Summer of Code][gsoc] and [LFX Mentorship][lfxm].
+
+### Proposal
+
+Jaeger mentorship projects are getting a lot of applications (up to 150 per project), therefore we require applicants to submit a **proposal** for the project, which allows us to find most suitable candidates. Even if a specific program's guidelines do not require submitting a proposal, please include it in the other application documents, such as a **cover letter** (PDF documents are preferred over hyperlinks).
+
+We are looking for the following topics to be covered by the proposal:
+
+* About you
+  * Why are you interested in this specific project?
+  * What kind of relevant experience or skills do you have that will help you be successful?
+  * (optional) What kind of open source experience you have? Please link to some notable pull requests.
+  * What are your time commitments during the mentorship term?
+* About the project
+  * How do you understand what needs to be done in this project?
+  * What kind of technical challenges do you foresee and how do you suggest to address them?
+  * How do you plan to approach the project (roadmap, milestones, schedule)?
+
+It does not mean that the longer the proposal the better. It's about the quality and demonstrating which candidate better understands the problem and has a handle on how to solve it. You do not need to explain what Jaeger does and how. Instead, focus on the specific problem of the project, and think about the challenges and the solutions.
+
+#### Level playing field
+
+To ensure a fair and consistent evaluation process for all applicants, we cannot provide individual feedback on proposals before the submission deadline.  Providing feedback to some applicants and not others would create an unequal opportunity.  All proposals will receive thorough consideration by the selection committee after the deadline.  We encourage all interested individuals to submit their best work.
+
+If you need to ask specific questions / clarifications about the project, please ask them in the comments on the tracking issue, where they will be visible to all applicants.
+
+### Bootcamp
+
+In order to understand the project better and come up with reasonable solutions, it's always helpful to become familiar with Jaeger and its code base. We strongly recommend going through the [Bootcamp](../../get-involved/#bootcamp).
+
+### Evaluation criteria
+
+We do not have an exact checklist that we use for evaluation, but the following criteria have a high impact:
+
+* Candidates have several PRs merged into Jaeger, which demonstrate:
+  * their understanding of the code base,
+  * their understanding of our development workflow,
+  * their coding and problem solving skills.
+* High quality proposal that demonstrates:
+  * good understanding of the problem,
+  * technical due diligence conducted,
+  * viable approach to solving the problem.
+* Evidence of previous high quality development tasks completed, e.g., in other open source projects.
+
+### Selection Decisions and Post-Selection Inquiries
+
+Given the high volume of applications (often exceeding 100 per project), the selection process is highly competitive. The maintainers evaluate candidates holistically, balancing both community contributions (PRs) and the technical depth and research demonstrated in the written proposal.
+
+If you are not selected, please keep the following guidelines in mind:
+
+*   **Decisions are final:** Once the chosen mentees are announced for a term, the selection is final.
+*   **No candidate comparisons:** To respect the privacy of all applicants and maintain a supportive community environment, maintainers will not discuss, debate, or compare candidates against one another under any circumstances. Public or private harassment regarding selection decisions violates the CNCF Code of Conduct.
+*   **Limited feedback:** While we deeply appreciate the hard work and enthusiasm of all applicants, the sheer volume of submissions means we generally cannot provide individualized, post-selection feedback on why a specific application was not chosen.
+
+Not being selected is rarely a reflection of your coding abilities; it is simply a reality of the limited mentorship slots available. We highly encourage you to remain active in the Jaeger community and apply again in future cohorts.
+
+[gsoc]: https://summerofcode.withgoogle.com/
+[lfxm]: https://mentorship.lfx.linuxfoundation.org/

--- a/content/mentorship/for-mentees.md
+++ b/content/mentorship/for-mentees.md
@@ -1,60 +1,11 @@
 ---
 title: Mentorship - For Mentees
 linkTitle: For Mentees
-aliases: [/mentorship-for-mentees]
 ---
-
-## Application process
-
-Applications are submitted via respective program websites, such as [Google Summer of Code][gsoc] and [LFX Mentorship][lfxm].
-
-### Proposal
-
-Jaeger mentorship projects are getting a lot of applications (up to 150 per project), therefore we require applicants to submit a **proposal** for the project, which allows us to find most suitable candidates. Even if a specific program's guidelines do not require submitting a proposal, please include it in the other application documents, such as a **cover letter** (PDF documents are preferred over hyperlinks).
-
-We are looking for the following topics to be covered by the proposal:
-
-* About you
-  * Why are you interested in this specific project?
-  * What kind of relevant experience or skills do you have that will help you be successful?
-  * (optional) What kind of open source experience you have? Please link to some notable pull requests.
-  * What are your time commitments during the mentorship term?
-* About the project
-  * How do you understand what needs to be done in this project?
-  * What kind of technical challenges do you foresee and how do you suggest to address them?
-  * How do you plan to approach the project (roadmap, milestones, schedule)?
-
-It does not mean that the longer the proposal the better. It's about the quality and demonstrating which candidate better understands the problem and has a handle on how to solve it. You do not need to explain what Jaeger does and how. Instead, focus on the specific problem of the project, and think about the challenges and the solutions.
-
-#### Level playing field
-
-To ensure a fair and consistent evaluation process for all applicants, we cannot provide individual feedback on proposals before the submission deadline.  Providing feedback to some applicants and not others would create an unequal opportunity.  All proposals will receive thorough consideration by the selection committee after the deadline.  We encourage all interested individuals to submit their best work.
-
-If you need to ask specific questions / clarifications about the project, please ask them in the comments on the tracking issue, where they will be visible to all applicants.
-
-### Bootcamp
-
-In order to understand the project better and come up with reasonable solutions, it's always helpful to become familiar with Jaeger and its code base. We strongly recommend going through the [Bootcamp](../../get-involved/#bootcamp).
-
-### Evaluation criteria
-
-We do not have an exact checklist that we use for evaluation, but the following criteria have a high impact:
-
-* Candidates have several PRs merged into Jaeger, which demonstrate:
-  * their understanding of the code base,
-  * their understanding of our development workflow,
-  * their coding and problem solving skills.
-* High quality proposal that demonstrates:
-  * good understanding of the problem,
-  * technical due diligence conducted,
-  * viable approach to solving the problem.
-* Evidence of previous high quality development tasks completed, e.g., in other open source projects.
-
-## Mentorship
 
 Congratulations on being selected as a Jaeger Mentee! It can be daunting when starting off on your project, so here are some guidelines to help you get started.
 
-### Onboarding Checklist
+## Onboarding Checklist
 
 - Please review the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
   It offers a guideline that both mentors and mentees should follow to ensure a
@@ -66,8 +17,8 @@ Congratulations on being selected as a Jaeger Mentee! It can be daunting when st
   with all past and new mentees and mentors together.
 - Join the [#jaeger](https://cloud-native.slack.com/archives/CGG7NFUJ3) public channel.
   This is where you can get help from the Jaeger community.
-- Say “hello” to your mentors, fellow mentees, and jaeger community; and if
-  you’re comfortable with it, introduce yourself with a few sentences.
+- Say "hello" to your mentors, fellow mentees, and jaeger community; and if
+  you're comfortable with it, introduce yourself with a few sentences.
 - Read our contributing guides ([#1](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md),
   [#2](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md)),
   containing instructions on the development workflow.
@@ -78,7 +29,7 @@ Congratulations on being selected as a Jaeger Mentee! It can be daunting when st
   Post any clarifying questions on that issue, ensuring a persistent record for
   later reference by yourself, mentors and the community.
 
-### Keep a Progress Log
+## Keep a Progress Log
 
 Since the mentorships are remote, the best way to ensure you are making steady progress and to keep your mentor informed is to keep a regular progress log.
 
@@ -96,10 +47,10 @@ Why the log is important:
 - Clear writing is one of the most important skills for software engineers. You may think it's coding skills, but as you become more senior, writing is how you communicate your ideas and get alignment with the team / community. Use this mentorship to hone your writing skills.
 - Treat the mentorship project as a job, with responsibility to make progress and meet the goals.
 
-### Tips
+## Tips
 
 - Ask questions! A good rule of thumb is if you spend more than an hour not able to find an answer
-  in the documentation or the code, then don’t hesitate to ask your mentor for pointers. You can also ask in
+  in the documentation or the code, then don't hesitate to ask your mentor for pointers. You can also ask in
   [#jaeger](https://cloud-native.slack.com/archives/CGG7NFUJ3) and #jaeger-mentorships Slack channels.
 - Before embarking on a relatively substantial change, write up a plan on what you plan to do,
   why and potential challenges or unknowns. Consider documenting this as a
@@ -113,15 +64,13 @@ Why the log is important:
   to explore the various alternative solutions and identify the best option.
 - You are welcome to join the [monthly Jaeger video calls](../../get-in-touch/).
 - Write unit tests and, if applicable, run live integration tests locally. Tests give assurance
-  to yourself that what you’ve written works, documents the expected behavior to readers of the code,
+  to yourself that what you've written works, documents the expected behavior to readers of the code,
   and prevents regressions from future contributions.
-- You’re encouraged to review others’ PRs (e.g. from your fellow mentees)
-  with kind and constructive feedback. It’s a great way to learn about good coding
+- You're encouraged to review others' PRs (e.g. from your fellow mentees)
+  with kind and constructive feedback. It's a great way to learn about good coding
   practices, while also helping familiarize yourself with the codebase.
-- Feel free to suggest improvements! For example, if you’re experiencing a
+- Feel free to suggest improvements! For example, if you're experiencing a
   lot of friction in the development workflow, is there anything we can do to
   improve the developer experience through better documentation or automation?
 
-[gsoc]: https://summerofcode.withgoogle.com/
-[lfxm]: https://mentorship.lfx.linuxfoundation.org/
 [template]: https://docs.google.com/document/d/1lAL0iHHozXZoIL4W0qiOWyXVPo9a6lUTeH9cz95O6Kg/edit#

--- a/content/mentorship/for-mentees.md
+++ b/content/mentorship/for-mentees.md
@@ -17,7 +17,7 @@ Congratulations on being selected as a Jaeger Mentee! It can be daunting when st
   with all past and new mentees and mentors together.
 - Join the [#jaeger](https://cloud-native.slack.com/archives/CGG7NFUJ3) public channel.
   This is where you can get help from the Jaeger community.
-- Say "hello" to your mentors, fellow mentees, and jaeger community; and if
+- Say "hello" to your mentors, fellow mentees, and Jaeger community; and if
   you're comfortable with it, introduce yourself with a few sentences.
 - Read our contributing guides ([#1](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md),
   [#2](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md)),


### PR DESCRIPTION
## Summary

- Extracts the application-related content (proposal guidelines, evaluation criteria, level playing field policy) from `for-mentees.md` into a new dedicated `applying.md` page
- Adds a new "Selection Decisions and Post-Selection Inquiries" section to `applying.md`, clarifying that decisions are final and individual feedback is limited
- Moves the `/mentorship-for-mentees` URL alias to `applying.md` (since that page previously hosted the application content)
- Refocuses `for-mentees.md` on post-selection content: onboarding checklist, progress log, and tips for accepted mentees
- Links the new `applying.md` page from the mentorship index

## Motivation

The `for-mentees.md` page was serving two distinct audiences: prospective applicants and accepted mentees. Splitting these into separate pages makes it easier for each audience to find relevant information and allows the application guidelines to grow independently.