### PR TITLE
Add LFX 2026 Term 2 mentees to mentorship page

### DIFF
--- a/.cspell/project-names-src.txt
+++ b/.cspell/project-names-src.txt
@@ -7,6 +7,10 @@ Juraci Paixão Kröhling
 # Other names (sometimes from github links)
 robbert
 
+## LFX Mentorship June-August 2026 (Term 2)
+Soumya Raikwar
+Swetalin Rout
+
 ## LFX Mentorship March-May 2026 (Term 1)
 Nabil Salah
 Parship Chowdhury

--- a/content/mentorship/_index.md
+++ b/content/mentorship/_index.md
@@ -12,6 +12,11 @@ See also:
   * [For mentees](for-mentees/)
   * [For mentors](for-mentors/)
 
+## LFX Mentorship June-August 2026 (Term 2)
+
+* [Soumya Raikwar](https://github.com/SoumyaRaikwar) -- [AI-Powered Trace Analysis Phase 2 - Skills Framework](https://github.com/jaegertracing/jaeger/issues/8440)
+* [Swetalin Rout](https://github.com/swetalin-10) -- [Jaeger for GenAI Observability: Specialized Trace Visualization](https://github.com/jaegertracing/jaeger/issues/8401)
+
 ## LFX Mentorship March-May 2026 (Term 1)
 
 * [Nabil Salah](https://github.com/Nabil-Salah) -- [AI-Powered Trace Analysis with Bring-Your-Own-Agent](https://github.com/jaegertracing/jaeger/issues/7832)


### PR DESCRIPTION
## Summary
- Add Soumya Raikwar and Swetalin Rout as LFX 2026 Term 2 mentees
- Update spellcheck dictionary with new names

## Test plan
- [x] Spellcheck passes
- [x] Content renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)