### PR TITLE
Add docs for building custom Jaeger distributions via ocb

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -33,6 +33,7 @@ flink
 fluentd
 glvs
 gobin
+gomod
 gopath
 goroutines
 Hashicorp

--- a/assets/scss/_links.scss
+++ b/assets/scss/_links.scss
@@ -45,6 +45,8 @@ $nbsp: \00A0;
 .td-sidebar-nav a[target='_blank']:after,
 a.external-link:after {
   @include external-link-icon();
+  display: inline-block;
+  text-decoration: none;
 }
 
 .td-footer a.external-link:after {

--- a/content/docs/v2/_dev/architecture/_index.md
+++ b/content/docs/v2/_dev/architecture/_index.md
@@ -76,7 +76,7 @@ Downsides:
 The Jaeger binary is built on top of the OpenTelemetry Collector framework and includes:
   * Official upstream components, such as OTLP Receiver, Batch and Attribute Processor, etc.
   * Upstream components from `opentelemetry-collector-contrib`, such as Kafka Exporter and Receiver, Tail Sampling Processor, etc.
-  * Jaeger own components, such as Jaeger Storage Exporter, Jaeger Query Extension, etc.
+  * Jaeger's own components, such as Jaeger Storage Exporter, Jaeger Query Extension, etc.
 
 You can build a [custom Jaeger distribution](../deployment/custom-distribution/) with additional or fewer components using the [OpenTelemetry Collector Builder (`ocb`)](https://opentelemetry.io/docs/collector/extend/ocb/).
 

--- a/content/docs/v2/_dev/architecture/_index.md
+++ b/content/docs/v2/_dev/architecture/_index.md
@@ -78,7 +78,7 @@ The Jaeger binary is built on top of the OpenTelemetry Collector framework and i
   * Upstream components from `opentelemetry-collector-contrib`, such as Kafka Exporter and Receiver, Tail Sampling Processor, etc.
   * Jaeger own components, such as Jaeger Storage Exporter, Jaeger Query Extension, etc.
 
-You can build a [custom Jaeger distribution](../deployment/custom-distribution/) with additional or fewer components using the [OpenTelemetry Collector Builder (`ocb`)](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder).
+You can build a [custom Jaeger distribution](../deployment/custom-distribution/) with additional or fewer components using the [OpenTelemetry Collector Builder (`ocb`)](https://opentelemetry.io/docs/collector/extend/ocb/).
 
 [![Architecture](/img/architecture-v2-binary.png)](/img/architecture-v2-binary.png)
 

--- a/content/docs/v2/_dev/architecture/_index.md
+++ b/content/docs/v2/_dev/architecture/_index.md
@@ -73,10 +73,12 @@ Downsides:
 
 ## Jaeger Binary
 
-The Jaeger binary is build on top of the OpenTelemetry Collector framework and includes:
+The Jaeger binary is built on top of the OpenTelemetry Collector framework and includes:
   * Official upstream components, such as OTLP Receiver, Batch and Attribute Processor, etc.
   * Upstream components from `opentelemetry-collector-contrib`, such as Kafka Exporter and Receiver, Tail Sampling Processor, etc.
   * Jaeger own components, such as Jaeger Storage Exporter, Jaeger Query Extension, etc.
+
+You can build a [custom Jaeger distribution](../deployment/custom-distribution/) with additional or fewer components using the [OpenTelemetry Collector Builder (`ocb`)](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder).
 
 [![Architecture](/img/architecture-v2-binary.png)](/img/architecture-v2-binary.png)
 

--- a/content/docs/v2/_dev/deployment/_index.md
+++ b/content/docs/v2/_dev/deployment/_index.md
@@ -12,6 +12,8 @@ children:
   url: windows
 - title: Security
   url: security
+- title: Custom Distribution
+  url: custom-distribution
 ---
 
 Jaeger backend is released as a single binary or container image (see [Downloads](../../../download/)). Despite that, it can be configured to operate in different **roles**, such as **all-in-one**, **collector**, **query**, and **ingester** (see [Architecture](../architecture/)).

--- a/content/docs/v2/_dev/deployment/custom-distribution.md
+++ b/content/docs/v2/_dev/deployment/custom-distribution.md
@@ -1,0 +1,105 @@
+---
+title: Custom Distribution
+---
+
+Since Jaeger v2 is built on the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) framework, you can use the [OpenTelemetry Collector Builder (`ocb`)](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder) to create custom Jaeger distributions with additional or fewer components than the default binary ships with.
+
+This is useful when you want to:
+  * Add third-party OpenTelemetry Collector components (receivers, processors, exporters, connectors, extensions) to Jaeger.
+  * Remove unused components to reduce binary size and attack surface.
+  * Pin specific versions of dependencies for compliance or reproducibility.
+
+## Prerequisites
+
+Install the OpenTelemetry Collector Builder:
+
+```sh
+go install go.opentelemetry.io/collector/cmd/builder@latest
+```
+
+The installed binary will be named `builder`. Rename or alias it to `ocb` if you prefer:
+
+```sh
+mv $(go env GOPATH)/bin/builder $(go env GOPATH)/bin/ocb
+```
+
+## Builder Manifest
+
+The `ocb` tool takes a YAML manifest file (commonly named `builder.yaml`) that declares which components to include in the binary. Jaeger provides a [reference manifest](https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/builder.yaml) that reproduces the default distribution.
+
+Here is a minimal example that builds a Jaeger binary with just the core components:
+
+```yaml
+dist:
+  module: github.com/example/my-jaeger
+  name: jaeger
+  description: My custom Jaeger distribution
+  output_path: ./build
+
+telemetry:
+  gomod: github.com/jaegertracing/jaeger v2.19.0
+  import: github.com/jaegertracing/jaeger/components/telemetry
+
+extensions:
+  - gomod: github.com/jaegertracing/jaeger v2.19.0
+    import: github.com/jaegertracing/jaeger/components/extension/jaegerstorage
+  - gomod: github.com/jaegertracing/jaeger v2.19.0
+    import: github.com/jaegertracing/jaeger/components/extension/jaegerquery
+  - gomod: github.com/jaegertracing/jaeger v2.19.0
+    import: github.com/jaegertracing/jaeger/components/ext/extension/healthcheckv2extension
+
+receivers:
+  - gomod: github.com/jaegertracing/jaeger v2.19.0
+    import: github.com/jaegertracing/jaeger/components/ext/receiver/otlpreceiver
+
+exporters:
+  - gomod: github.com/jaegertracing/jaeger v2.19.0
+    import: github.com/jaegertracing/jaeger/components/exporter/storageexporter
+
+processors:
+  - gomod: github.com/jaegertracing/jaeger v2.19.0
+    import: github.com/jaegertracing/jaeger/components/ext/processor/batchprocessor
+```
+
+## Available Components
+
+Jaeger exposes its components as public Go packages under [`components/`](https://github.com/jaegertracing/jaeger/tree/main/components) in the Jaeger repository:
+
+  * **Jaeger-specific components** (`components/extension/`, `components/exporter/`, `components/processor/`) — these are Jaeger's own implementations such as the storage exporter, query extension, adaptive sampling processor, etc.
+  * **Third-party OTel components** (`components/ext/`) — these are upstream OpenTelemetry Collector components (from core and contrib) re-exported through Jaeger's module. Using these ensures version consistency with the rest of the Jaeger distribution, as their actual versions are resolved transitively through Jaeger's `go.mod`.
+
+All components use a single `gomod` entry (`github.com/jaegertracing/jaeger`) which simplifies dependency management in the manifest.
+
+## Adding Custom Components
+
+To add a component that is not part of the default Jaeger distribution, append it to the relevant section in your manifest. For example, to add the [resource detection processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor):
+
+```yaml
+processors:
+  # ... existing processors ...
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.123.0
+```
+
+## Building
+
+Run the builder:
+
+```sh
+ocb --config builder.yaml
+```
+
+The resulting binary will be placed in the `output_path` directory specified in the manifest. You can then run it with a standard Jaeger configuration file:
+
+```sh
+./build/jaeger --config config.yaml
+```
+
+Cross-compilation is supported via environment variables:
+
+```sh
+GOOS=linux GOARCH=arm64 ocb --config builder.yaml
+```
+
+## Version Compatibility
+
+Replace the version placeholder (`v2.19.0` in the examples above) with the Jaeger release version you want to base your distribution on. All Jaeger component packages within a given release are versioned together, so you only need to track a single version number.

--- a/content/docs/v2/_dev/deployment/custom-distribution.md
+++ b/content/docs/v2/_dev/deployment/custom-distribution.md
@@ -9,6 +9,10 @@ This is useful when you want to:
   * Remove unused components to reduce binary size and attack surface.
   * Pin specific versions of dependencies for compliance or reproducibility.
 
+## Prerequisites
+
+Follow the [official instructions](https://opentelemetry.io/docs/collector/extend/ocb/) to install the OpenTelemetry Collector Builder (`ocb`).
+
 ## Builder Manifest
 
 The `ocb` tool takes a YAML manifest file (commonly named `builder.yaml`) that declares which components to include in the binary. Jaeger provides a [reference manifest](https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/builder.yaml) that reproduces the default distribution.

--- a/content/docs/v2/_dev/deployment/custom-distribution.md
+++ b/content/docs/v2/_dev/deployment/custom-distribution.md
@@ -85,8 +85,10 @@ processors:
 Run the builder:
 
 ```sh
-ocb --config builder.yaml
+ocb --config builder.yaml --skip-strict-versioning
 ```
+
+The `--skip-strict-versioning` flag is recommended because Jaeger's component packages use the same module version as the main Jaeger module, which may not match the versions of upstream OpenTelemetry dependencies. Without this flag, `ocb` would reject the build due to version mismatches between the declared `gomod` versions and the transitively resolved ones.
 
 The resulting binary will be placed in the `output_path` directory specified in the manifest. You can then run it with a standard Jaeger configuration file:
 

--- a/content/docs/v2/_dev/deployment/custom-distribution.md
+++ b/content/docs/v2/_dev/deployment/custom-distribution.md
@@ -80,6 +80,10 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.123.0
 ```
 
+{{< warning >}}
+When adding components from `opentelemetry-collector-contrib` or other OTel modules, use the same version of OpenTelemetry that Jaeger is built with. Mixing different OTel versions may cause API incompatibilities and build failures. Check Jaeger's [`go.mod`](https://github.com/jaegertracing/jaeger/blob/main/go.mod) for the exact versions used in each release.
+{{< /warning >}}
+
 ## Building
 
 Run the builder:

--- a/content/docs/v2/_dev/deployment/custom-distribution.md
+++ b/content/docs/v2/_dev/deployment/custom-distribution.md
@@ -9,20 +9,6 @@ This is useful when you want to:
   * Remove unused components to reduce binary size and attack surface.
   * Pin specific versions of dependencies for compliance or reproducibility.
 
-## Prerequisites
-
-Install the OpenTelemetry Collector Builder:
-
-```sh
-go install go.opentelemetry.io/collector/cmd/builder@latest
-```
-
-The installed binary will be named `builder`. Rename or alias it to `ocb` if you prefer:
-
-```sh
-mv $(go env GOPATH)/bin/builder $(go env GOPATH)/bin/ocb
-```
-
 ## Builder Manifest
 
 The `ocb` tool takes a YAML manifest file (commonly named `builder.yaml`) that declares which components to include in the binary. Jaeger provides a [reference manifest](https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/builder.yaml) that reproduces the default distribution.

--- a/content/docs/v2/_dev/deployment/custom-distribution.md
+++ b/content/docs/v2/_dev/deployment/custom-distribution.md
@@ -2,7 +2,7 @@
 title: Custom Distribution
 ---
 
-Since Jaeger v2 is built on the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) framework, you can use the [OpenTelemetry Collector Builder (`ocb`)](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder) to create custom Jaeger distributions with additional or fewer components than the default binary ships with.
+Since Jaeger v2 is built on the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) framework, you can use the [OpenTelemetry Collector Builder (`ocb`)](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder) to create custom Jaeger distributions that include additional components or exclude unused ones.
 
 This is useful when you want to:
   * Add third-party OpenTelemetry Collector components (receivers, processors, exporters, connectors, extensions) to Jaeger.

--- a/content/docs/v2/_dev/deployment/custom-distribution.md
+++ b/content/docs/v2/_dev/deployment/custom-distribution.md
@@ -2,7 +2,7 @@
 title: Custom Distribution
 ---
 
-Since Jaeger v2 is built on the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) framework, you can use the [OpenTelemetry Collector Builder (`ocb`)](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder) to create custom Jaeger distributions that include additional components or exclude unused ones.
+Since Jaeger v2 is built on the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) framework, you can use the [OpenTelemetry Collector Builder (`ocb`)](https://opentelemetry.io/docs/collector/extend/ocb/) to create custom Jaeger distributions that include additional components or exclude unused ones.
 
 This is useful when you want to:
   * Add third-party OpenTelemetry Collector components (receivers, processors, exporters, connectors, extensions) to Jaeger.

--- a/content/docs/v2/_dev/deployment/custom-distribution.md
+++ b/content/docs/v2/_dev/deployment/custom-distribution.md
@@ -15,7 +15,7 @@ Follow the [official instructions](https://opentelemetry.io/docs/collector/exten
 
 ## Builder Manifest
 
-The `ocb` tool takes a YAML manifest file (commonly named `builder.yaml`) that declares which components to include in the binary. Jaeger provides a [reference manifest](https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/builder.yaml) that reproduces the default distribution.
+The `ocb` tool takes a YAML manifest file (commonly named `builder.yaml`) that declares which components to include in the binary. Jaeger provides a [reference manifest](https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/builder.yaml) that reproduces the default distribution. Note that the reference manifest uses `v0.0.0` with a `replaces` directive for in-repo builds — when building outside the Jaeger repository, use a real release version as shown in the example below.
 
 Here is a minimal example that builds a Jaeger binary with just the core components:
 
@@ -68,6 +68,7 @@ To add a component that is not part of the default Jaeger distribution, append i
 processors:
   # ... existing processors ...
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.123.0
+    import: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
 ```
 
 {{< warning >}}

--- a/content/docs/v2/_dev/deployment/custom-distribution.md
+++ b/content/docs/v2/_dev/deployment/custom-distribution.md
@@ -90,7 +90,7 @@ ocb --config builder.yaml --skip-strict-versioning
 
 The `--skip-strict-versioning` flag is recommended because Jaeger's component packages use the same module version as the main Jaeger module, which may not match the versions of upstream OpenTelemetry dependencies. Without this flag, `ocb` would reject the build due to version mismatches between the declared `gomod` versions and the transitively resolved ones.
 
-The resulting binary will be placed in the `output_path` directory specified in the manifest. You can then run it with a standard Jaeger configuration file:
+The resulting binary will be placed in the `output_path` directory specified in the manifest. You will need to provide a configuration file that references the components included in your custom build:
 
 ```sh
 ./build/jaeger --config config.yaml


### PR DESCRIPTION
## Summary

- Adds a new "Custom Distribution" page under Deployment explaining how to use the OpenTelemetry Collector Builder (`ocb`) to build custom Jaeger binaries
- Adds a cross-reference from the Architecture page's "Jaeger Binary" section
- Documents the public `components/` packages added in https://github.com/jaegertracing/jaeger/pull/8800

## Test plan

- [x] Verify the page renders correctly on the site
- [x] Verify links to the Jaeger repo and OTel Collector Builder are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)