### PR TITLE
Add icons to Project navbar menu and footer links

### DIFF
--- a/assets/scss/_navbar.scss
+++ b/assets/scss/_navbar.scss
@@ -22,4 +22,15 @@ $navbar-margin-top: -($navbar-brand-size - $navbar-brand-base) / 2;
       $decoration: $link-decoration
     );
   }
+
+  // Font Awesome's own .fa-fw assumes a ~1.25em glyph width, but some free
+  // icons (e.g. fa-handshake, fa-comments) use a wider viewBox and overflow
+  // it, eating into the following text's spacing. Use a wider box and clip
+  // it so every icon lines up regardless of its native aspect ratio.
+  .nav-icon {
+    display: inline-block;
+    overflow: hidden;
+    width: 1.75em;
+    text-align: center;
+  }
 }

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -133,17 +133,20 @@ menu:
     - name: Get Involved
       url: /get-involved/
       parent: project
-      params: {icon: fa-solid fa-handshake}
+      params:
+        icon: fa-solid fa-handshake
       weight: 1
     - name: Getting in Touch
       url: /get-in-touch/
       parent: project
-      params: {icon: fa-solid fa-comments}
+      params:
+        icon: fa-solid fa-comments
       weight: 2
     - name: Mentorships
       url: /mentorship/
       parent: project
-      params: {icon: fa-solid fa-user-graduate}
+      params:
+        icon: fa-solid fa-user-graduate
       weight: 3
     - name: For Mentees
       url: /mentorship/for-mentees/
@@ -158,32 +161,39 @@ menu:
     - name: News
       url: /news/
       parent: project
-      params: {icon: fa-solid fa-newspaper}
+      params:
+        icon: fa-solid fa-newspaper
       weight: 6
     - name: Roadmap
       url: /roadmap/
       parent: project
-      params: {icon: fa-solid fa-route}
+      params:
+        icon: fa-solid fa-route
       weight: 7
     - name: Report a Security Issue
       url: /report-security-issue/
       parent: project
-      params: {icon: fa-solid fa-shield-halved, divider_before: true}
+      params:
+        icon: fa-solid fa-shield-halved
+        divider_before: true
       weight: 8
     - name: Branding
       url: https://github.com/cncf/artwork/tree/master/projects/jaeger
       parent: project
-      params: {icon: fa-solid fa-palette}
+      params:
+        icon: fa-solid fa-palette
       weight: 9
     - name: Main GitHub repo
       url: https://github.com/jaegertracing/jaeger
       parent: project
-      params: {icon: fa-brands fa-github}
+      params:
+        icon: fa-brands fa-github
       weight: 10
     - name: Docs GitHub repo
       url: https://github.com/jaegertracing/documentation
       parent: project
-      params: {icon: fa-brands fa-github}
+      params:
+        icon: fa-brands fa-github
       weight: 11
 
 module:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -129,49 +129,58 @@ menu:
     - name: Get Involved
       url: /get-involved/
       parent: project
+      pre: '<i class="fa-solid fa-handshake pe-1" aria-hidden="true"></i>'
       weight: 1
     - name: Getting in Touch
       url: /get-in-touch/
       parent: project
+      pre: '<i class="fa-solid fa-comments pe-1" aria-hidden="true"></i>'
       weight: 2
     - name: Mentorships
       url: /mentorship/
       parent: project
+      pre: '<i class="fa-solid fa-user-graduate pe-1" aria-hidden="true"></i>'
       weight: 3
     - name: For Mentees
       url: /mentorship/for-mentees/
       parent: project
-      pre: '&nbsp;&nbsp;&nbsp;&nbsp;⏺&nbsp;'
+      pre: '&nbsp;&nbsp;&nbsp;&nbsp;•&nbsp;'
       weight: 4
     - name: For Mentors
       url: /mentorship/for-mentors/
       parent: project
-      pre: '&nbsp;&nbsp;&nbsp;&nbsp;⏺&nbsp;'
+      pre: '&nbsp;&nbsp;&nbsp;&nbsp;•&nbsp;'
       weight: 5
     - name: News
       url: /news/
       parent: project
+      pre: '<i class="fa-solid fa-newspaper pe-1" aria-hidden="true"></i>'
       weight: 6
     - name: Roadmap
       url: /roadmap/
       parent: project
+      pre: '<i class="fa-solid fa-route pe-1" aria-hidden="true"></i>'
       weight: 7
     - name: Report a Security Issue
       url: /report-security-issue/
       parent: project
+      pre: '<i class="fa-solid fa-shield-halved pe-1" aria-hidden="true"></i>'
       params: {divider_before: true}
       weight: 8
     - name: Branding
       url: https://github.com/cncf/artwork/tree/master/projects/jaeger
       parent: project
+      pre: '<i class="fa-solid fa-palette pe-1" aria-hidden="true"></i>'
       weight: 9
     - name: Main GitHub repo
       url: https://github.com/jaegertracing/jaeger
       parent: project
+      pre: '<i class="fa-brands fa-github pe-1" aria-hidden="true"></i>'
       weight: 10
     - name: Docs GitHub repo
       url: https://github.com/jaegertracing/documentation
       parent: project
+      pre: '<i class="fa-brands fa-github pe-1" aria-hidden="true"></i>'
       weight: 11
 
 module:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -133,58 +133,57 @@ menu:
     - name: Get Involved
       url: /get-involved/
       parent: project
-      pre: '<i class="fa-solid fa-handshake pe-1" aria-hidden="true"></i>'
+      params: {icon: fa-solid fa-handshake}
       weight: 1
     - name: Getting in Touch
       url: /get-in-touch/
       parent: project
-      pre: '<i class="fa-solid fa-comments pe-1" aria-hidden="true"></i>'
+      params: {icon: fa-solid fa-comments}
       weight: 2
     - name: Mentorships
       url: /mentorship/
       parent: project
-      pre: '<i class="fa-solid fa-user-graduate pe-1" aria-hidden="true"></i>'
+      params: {icon: fa-solid fa-user-graduate}
       weight: 3
     - name: For Mentees
       url: /mentorship/for-mentees/
       parent: project
-      pre: '&nbsp;&nbsp;&nbsp;&nbsp;•&nbsp;'
+      pre: '&nbsp;&nbsp;&nbsp;&nbsp;<span class="opacity-50">—</span>&nbsp;'
       weight: 4
     - name: For Mentors
       url: /mentorship/for-mentors/
       parent: project
-      pre: '&nbsp;&nbsp;&nbsp;&nbsp;•&nbsp;'
+      pre: '&nbsp;&nbsp;&nbsp;&nbsp;<span class="opacity-50">—</span>&nbsp;'
       weight: 5
     - name: News
       url: /news/
       parent: project
-      pre: '<i class="fa-solid fa-newspaper pe-1" aria-hidden="true"></i>'
+      params: {icon: fa-solid fa-newspaper}
       weight: 6
     - name: Roadmap
       url: /roadmap/
       parent: project
-      pre: '<i class="fa-solid fa-route pe-1" aria-hidden="true"></i>'
+      params: {icon: fa-solid fa-route}
       weight: 7
     - name: Report a Security Issue
       url: /report-security-issue/
       parent: project
-      pre: '<i class="fa-solid fa-shield-halved pe-1" aria-hidden="true"></i>'
-      params: {divider_before: true}
+      params: {icon: fa-solid fa-shield-halved, divider_before: true}
       weight: 8
     - name: Branding
       url: https://github.com/cncf/artwork/tree/master/projects/jaeger
       parent: project
-      pre: '<i class="fa-solid fa-palette pe-1" aria-hidden="true"></i>'
+      params: {icon: fa-solid fa-palette}
       weight: 9
     - name: Main GitHub repo
       url: https://github.com/jaegertracing/jaeger
       parent: project
-      pre: '<i class="fa-brands fa-github pe-1" aria-hidden="true"></i>'
+      params: {icon: fa-brands fa-github}
       weight: 10
     - name: Docs GitHub repo
       url: https://github.com/jaegertracing/documentation
       parent: project
-      pre: '<i class="fa-brands fa-github pe-1" aria-hidden="true"></i>'
+      params: {icon: fa-brands fa-github}
       weight: 11
 
 module:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -108,12 +108,16 @@ params:
     developer:
       - name: Via chat
         url: /get-in-touch/#via-chat
+        icon: fa-solid fa-comments
       - name: Project video meetings
         url: /get-in-touch/#project-video-meetings
+        icon: fa-solid fa-video
       - name: Report issues on GitHub
         url: /get-in-touch/#open-issue-or-discussion-on-github
+        icon: fa-brands fa-github
       - name: Report a security issue
         url: /report-security-issue/
+        icon: fa-solid fa-shield-halved
 
 menu:
   main:

--- a/themes/docsy-overrides/layouts/_partials/footer/list.html
+++ b/themes/docsy-overrides/layouts/_partials/footer/list.html
@@ -1,7 +1,7 @@
 <ul class="td-footer__list">
   {{ range . }}
   <li class="td-footer__list-item">
-    <a href="{{ .url }}">{{ .name }}</a>
+    <a href="{{ .url }}">{{ .name }}{{ with .icon }} <i class="{{ . }} ps-1" aria-hidden="true"></i>{{ end }}</a>
   </li>
   {{ end -}}
 </ul>

--- a/themes/docsy-overrides/layouts/_partials/footer/list.html
+++ b/themes/docsy-overrides/layouts/_partials/footer/list.html
@@ -1,7 +1,7 @@
 <ul class="td-footer__list">
   {{ range . }}
   <li class="td-footer__list-item">
-    <a href="{{ .url }}">{{ .name }}{{ with .icon }} <i class="{{ . }} ps-1" aria-hidden="true"></i>{{ end }}</a>
+    <a href="{{ .url }}">{{ .name }}{{ with .icon }}<i class="{{ . }} ps-1" aria-hidden="true"></i>{{ end }}</a>
   </li>
   {{ end -}}
 </ul>

--- a/themes/docsy-overrides/layouts/_partials/navbar.html
+++ b/themes/docsy-overrides/layouts/_partials/navbar.html
@@ -47,7 +47,7 @@ page/section relative version lists. */ -}}
           data-bs-toggle="dropdown"
           aria-expanded="false"
         >
-            {{- with .Params.icon }}<i class="{{ . }} pe-1 opacity-50" aria-hidden="true"></i>{{ end -}}
+            {{- with .Params.icon }}<i class="{{ . }} nav-icon pe-1 opacity-50" aria-hidden="true"></i>{{ end -}}
             {{- .Pre -}}
             <span>{{ .Name }}</span>
             {{- .Post -}}
@@ -65,7 +65,7 @@ page/section relative version lists. */ -}}
               href="{{ $childHref }}"
               {{- if $childIsExternal }} target="_blank" rel="noopener" {{- end -}}
             >
-              {{- with .Params.icon }}<i class="{{ . }} pe-1 opacity-50" aria-hidden="true"></i>{{ end -}}
+              {{- with .Params.icon }}<i class="{{ . }} nav-icon pe-1 opacity-50" aria-hidden="true"></i>{{ end -}}
               {{- .Pre -}}
               <span>{{ .Name }}</span>
               {{- .Post -}}
@@ -79,7 +79,7 @@ page/section relative version lists. */ -}}
           href="{{ $href }}"
           {{- if $isExternal }} target="_blank" rel="noopener" {{- end -}}
         >
-            {{- with .Params.icon }}<i class="{{ . }} pe-1 opacity-50" aria-hidden="true"></i>{{ end -}}
+            {{- with .Params.icon }}<i class="{{ . }} nav-icon pe-1 opacity-50" aria-hidden="true"></i>{{ end -}}
             {{- .Pre -}}
             <span>{{ .Name }}</span>
             {{- .Post -}}

--- a/themes/docsy-overrides/layouts/_partials/navbar.html
+++ b/themes/docsy-overrides/layouts/_partials/navbar.html
@@ -47,6 +47,7 @@ page/section relative version lists. */ -}}
           data-bs-toggle="dropdown"
           aria-expanded="false"
         >
+            {{- with .Params.icon }}<i class="{{ . }} pe-1 opacity-50" aria-hidden="true"></i>{{ end -}}
             {{- .Pre -}}
             <span>{{ .Name }}</span>
             {{- .Post -}}
@@ -64,6 +65,7 @@ page/section relative version lists. */ -}}
               href="{{ $childHref }}"
               {{- if $childIsExternal }} target="_blank" rel="noopener" {{- end -}}
             >
+              {{- with .Params.icon }}<i class="{{ . }} pe-1 opacity-50" aria-hidden="true"></i>{{ end -}}
               {{- .Pre -}}
               <span>{{ .Name }}</span>
               {{- .Post -}}
@@ -77,6 +79,7 @@ page/section relative version lists. */ -}}
           href="{{ $href }}"
           {{- if $isExternal }} target="_blank" rel="noopener" {{- end -}}
         >
+            {{- with .Params.icon }}<i class="{{ . }} pe-1 opacity-50" aria-hidden="true"></i>{{ end -}}
             {{- .Pre -}}
             <span>{{ .Name }}</span>
             {{- .Post -}}


### PR DESCRIPTION
## Summary
- Add monochrome Font Awesome icons to each entry in the "Project" navbar dropdown, using a `params.icon` menu param (consistent with the `icon` field already used for footer links) instead of raw markup in `pre`.
- Swap the boxed bullet glyph (⏺) on the "For Mentees" / "For Mentors" sub-items, which was rendering oddly on some platforms, for a muted em dash (—).
- Mute the navbar icons and the mentorship sub-item dash with Bootstrap's `opacity-50`, matching the light/dark theme toggler's icon style.
- Fix icon-to-text spacing: some Font Awesome free icons (e.g. `fa-handshake`, `fa-comments`) use a wider viewBox than most others and overflowed Font Awesome's own `.fa-fw` fixed-width box, leaving no visible gap before the label. Added a custom, wider, clipped icon box so alignment is consistent regardless of a given icon's native aspect ratio.
- Add trailing icons to the footer's "Get in touch" list (Via chat, Project video meetings, Report issues on GitHub, Report a security issue).

## Test plan
- [x] Ran `hugo server` locally and confirmed each icon renders correctly in the Project dropdown
- [x] Confirmed the mentorship sub-item dash is muted and no longer shows the boxed glyph
- [x] Confirmed the footer "Get in touch" links render their trailing icons

<img width="237" height="461" alt="image" src="https://github.com/user-attachments/assets/59c09b0c-8cf2-4ee5-8ef5-3d301c018423" />
<img width="305" height="199" alt="image" src="https://github.com/user-attachments/assets/01769cb9-734e-4a6d-8a89-12d9926cbd49" />

