### PR TITLE
chore(deps): Keep js-yaml on v4

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -29,6 +29,19 @@ jobs:
     - run: npm install
     - run: npm run check:spelling
 
+  test-reorg-docs:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: scripts/reorg-docs
+    steps:
+    - uses: actions/checkout@v7
+    - uses: actions/setup-node@v6
+      with: { node-version-file: .nvmrc }
+    - run: npm install
+    - run: npm run build
+    - run: npm test -- --runInBand
+
   block-pr-from-main-branch:
     runs-on: ubuntu-latest
     steps:

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,13 @@
       "matchManagers": ["github-actions", "npm"],
       "matchUpdateTypes": ["patch", "digest"],
       "enabled": false
+    },
+    {
+      "description": "Keep js-yaml on v4 because v5 requires an unnecessary ESM and schema migration",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["js-yaml"],
+      "matchFileNames": ["scripts/reorg-docs/package.json"],
+      "allowedVersions": "<5"
     }
   ]
 }

--- a/scripts/reorg-docs/package.json
+++ b/scripts/reorg-docs/package.json
@@ -15,7 +15,7 @@
     "start": "node dist/cli.js"
   },
   "dependencies": {
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.3.0"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/scripts/reorg-docs/tests/integration.test.ts
+++ b/scripts/reorg-docs/tests/integration.test.ts
@@ -59,7 +59,7 @@ describe('Integration tests with real docs', () => {
 
   it('leaves _index.md where it is (sanity check)', async () => {
     const rootIndex = await _readFile('_index.md');
-    expect(rootIndex).toContain('title: Docs');
+    expect(rootIndex).toMatch(/^---\n[\s\S]*?\n---/);
   });
 
 


### PR DESCRIPTION
## Summary

- raise the `scripts/reorg-docs` minimum from `js-yaml ^4.1.0` to `^4.3.0`
- keep Renovate below v5 for this package because v5 requires an ESM and schema migration
- add a dedicated CI job for the reorganization tool
- replace a stale title assertion with a front-matter validity check

## Why

The v5 update in #1111 breaks the tool at runtime because `js-yaml` v5 has no
default ESM export. The tool does not need v5 functionality. Version 4.3.0 is
API-compatible and includes the relevant security fixes.

## Validation

- `scripts/reorg-docs: npm run build`
- `scripts/reorg-docs: npm test -- --runInBand`, 9 suites passed, 49 tests
  passed, 2 skipped
- `npx --yes --package renovate renovate-config-validator renovate.json`
- `npm run build`
- `npm run check:format`
- `npm run check:spelling`
- `npm run check:links:internal`
