### PR TITLE
fix(docs): update obsolete Helm chart link and stale jaeger-ui branch…

### DIFF
--- a/content/docs/v2/2.19/deployment/frontend-ui.md
+++ b/content/docs/v2/2.19/deployment/frontend-ui.md
@@ -152,7 +152,7 @@ Users can toggle between light and dark themes using a button in the top navigat
 
 `tracking.trackErrors` enables (`true`) or disables (`false`) error tracking. Errors can only be tracked if a valid analytics tracker is configured. Default: `true`.
 
-For additional details on app analytics see the [tracking README](https://github.com/jaegertracing/jaeger-ui/blob/master/packages/jaeger-ui/src/utils/tracking/README.md) in the UI repo.
+For additional details on app analytics see the [tracking README](https://github.com/jaegertracing/jaeger-ui/blob/main/packages/jaeger-ui/src/utils/tracking/README.md) in the UI repo.
 
 ### Custom Menu Items
 

--- a/content/docs/v2/2.19/features.md
+++ b/content/docs/v2/2.19/features.md
@@ -10,7 +10,7 @@ Jaeger backend is designed to have no single points of failure and to scale with
 
 ## Cloud Native
 
-Jaeger backend is distributed as a container image or a raw binary, available for multiple platforms. The behavior of the binary can be customized via YAML configuration file. Deployment to Kubernetes clusters is assisted by a [Kubernetes operator](https://github.com/jaegertracing/jaeger-operator) and a [Helm chart](https://github.com/kubernetes/charts/tree/master/incubator/jaeger).
+Jaeger backend is distributed as a container image or a raw binary, available for multiple platforms. The behavior of the binary can be customized via YAML configuration file. Deployment to Kubernetes clusters is assisted by a [Kubernetes operator](https://github.com/jaegertracing/jaeger-operator) and a [Helm chart](https://github.com/jaegertracing/helm-charts).
 
 ##  OpenTelemetry
 

--- a/content/docs/v2/2.19/features.md
+++ b/content/docs/v2/2.19/features.md
@@ -10,7 +10,7 @@ Jaeger backend is designed to have no single points of failure and to scale with
 
 ## Cloud Native
 
-Jaeger backend is distributed as a container image or a raw binary, available for multiple platforms. The behavior of the binary can be customized via YAML configuration file. Deployment to Kubernetes clusters is assisted by a [Kubernetes operator](https://github.com/jaegertracing/jaeger-operator) and a [Helm chart](https://github.com/jaegertracing/helm-charts).
+Jaeger backend is distributed as a container image or a raw binary, available for multiple platforms. The behavior of the binary can be customized via YAML configuration file. Deployment to Kubernetes clusters is assisted by a [Kubernetes operator](https://github.com/jaegertracing/jaeger-operator) and a [Helm chart](https://github.com/jaegertracing/helm-charts/tree/main/charts/jaeger).
 
 ##  OpenTelemetry
 

--- a/content/docs/v2/_dev/deployment/frontend-ui.md
+++ b/content/docs/v2/_dev/deployment/frontend-ui.md
@@ -152,7 +152,7 @@ Users can toggle between light and dark themes using a button in the top navigat
 
 `tracking.trackErrors` enables (`true`) or disables (`false`) error tracking. Errors can only be tracked if a valid analytics tracker is configured. Default: `true`.
 
-For additional details on app analytics see the [tracking README](https://github.com/jaegertracing/jaeger-ui/blob/master/packages/jaeger-ui/src/utils/tracking/README.md) in the UI repo.
+For additional details on app analytics see the [tracking README](https://github.com/jaegertracing/jaeger-ui/blob/main/packages/jaeger-ui/src/utils/tracking/README.md) in the UI repo.
 
 ### Custom Menu Items
 

--- a/content/docs/v2/_dev/features.md
+++ b/content/docs/v2/_dev/features.md
@@ -10,7 +10,7 @@ Jaeger backend is designed to have no single points of failure and to scale with
 
 ## Cloud Native
 
-Jaeger backend is distributed as a container image or a raw binary, available for multiple platforms. The behavior of the binary can be customized via YAML configuration file. Deployment to Kubernetes clusters is assisted by a [Kubernetes operator](https://github.com/jaegertracing/jaeger-operator) and a [Helm chart](https://github.com/kubernetes/charts/tree/master/incubator/jaeger).
+Jaeger backend is distributed as a container image or a raw binary, available for multiple platforms. The behavior of the binary can be customized via YAML configuration file. Deployment to Kubernetes clusters is assisted by a [Kubernetes operator](https://github.com/jaegertracing/jaeger-operator) and a [Helm chart](https://github.com/jaegertracing/helm-charts).
 
 ##  OpenTelemetry
 

--- a/content/docs/v2/_dev/features.md
+++ b/content/docs/v2/_dev/features.md
@@ -10,7 +10,7 @@ Jaeger backend is designed to have no single points of failure and to scale with
 
 ## Cloud Native
 
-Jaeger backend is distributed as a container image or a raw binary, available for multiple platforms. The behavior of the binary can be customized via YAML configuration file. Deployment to Kubernetes clusters is assisted by a [Kubernetes operator](https://github.com/jaegertracing/jaeger-operator) and a [Helm chart](https://github.com/jaegertracing/helm-charts).
+Jaeger backend is distributed as a container image or a raw binary, available for multiple platforms. The behavior of the binary can be customized via YAML configuration file. Deployment to Kubernetes clusters is assisted by a [Kubernetes operator](https://github.com/jaegertracing/jaeger-operator) and a [Helm chart](https://github.com/jaegertracing/helm-charts/tree/main/charts/jaeger).
 
 ##  OpenTelemetry
 


### PR DESCRIPTION
### Which problem is this PR solving?

Fixes #1121.

Two stale link patterns had been propagated across nearly every versioned documentation release:

* The Helm chart link referenced the archived `kubernetes/charts` repository, which has been marked **OBSOLETE** for over four years.
* The `jaeger-ui` tracking README link referenced the `master` branch, even though the repository's default branch was renamed to `main`.

### Description of the changes

* Updated the Helm chart link in:

  * `content/docs/v2/_dev/features.md`
  * `content/docs/v2/2.19/features.md`

  The link now points to `jaegertracing/helm-charts`, the current official Helm chart repository.

* Updated the tracking README link in:

  * `content/docs/v2/_dev/deployment/frontend-ui.md`
  * `content/docs/v2/2.19/deployment/frontend-ui.md`

  The link now references the `main` branch instead of `master`, matching the current default branch of the `jaeger-ui` repository.

### Scope

This PR intentionally updates only the `_dev` (next release) and `v2.19` (latest stable) documentation.

The same stale links also exist in historical documentation versions (`v1.76`–`v2.18`). Before making changes across approximately 40 additional files, I opened issue #1121 to confirm the project's preferred policy for versioned documentation. If maintainers would like historical snapshots updated as well, I'm happy to submit a follow-up PR.

### How was this change tested?

* Verified with `grep` that the obsolete `kubernetes/charts` and `jaeger-ui/blob/master` references no longer exist in the four modified files.
* Confirmed that the updated links resolve to the expected destinations.

This is a documentation-only change and has no code, build, or runtime impact.

### Checklist

* [x] I have read `CONTRIBUTING_GUIDELINES.md`.
* [x] I have signed all commits.
* [ ] I have added unit tests for the new functionality *(N/A – documentation-only change).*
